### PR TITLE
Make local identifiers respect naming policies

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -162,7 +162,8 @@ struct
           ("pglobal_ident: expected to be handled somewhere else: "
          ^ show_global_ident id)
 
-  let rec plocal_ident (e : LocalIdent.t) = F.id @@ String.lowercase e.name
+  let rec plocal_ident (e : LocalIdent.t) =
+    F.id @@ U.Concrete_ident_view.local_name e.name
 
   let pgeneric_param_name (name : string) : string =
     String.lowercase

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -211,7 +211,9 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
     | Value | Impl ->
         if start_uppercase name || is_reserved_word name then "v_" ^ name
         else escape name
-    | Constructor _ -> if start_lowercase name then "C_" ^ name else escape name
+    | Constructor _ ->
+        if start_lowercase name || is_reserved_word name then "C_" ^ name
+        else escape name
     | Field -> (
         match Caml.int_of_string_opt name with
         | Some _ -> NP.index_field_transform name
@@ -253,6 +255,17 @@ module MakeViewAPI (NP : NAME_POLICY) : VIEW_API = struct
     |> (fun View.{ crate; path; definition } ->
          crate :: (path @ [ definition ]))
     |> String.concat ~sep:"::"
+
+  let local_name name =
+    to_definition_name
+      {
+        def_id =
+          {
+            krate = "dummy_for_local_name";
+            path = [ { data = ValueNs name; disambiguator = 0 } ];
+          };
+        kind = Value;
+      }
 end
 
 let to_debug_string = T.show

--- a/engine/lib/concrete_ident/concrete_ident_sig.ml
+++ b/engine/lib/concrete_ident/concrete_ident_sig.ml
@@ -23,5 +23,6 @@ struct
     val to_definition_name : t_ -> string
     val to_crate_name : t_ -> string
     val to_namespace : t_ -> string * string list
+    val local_name : string -> string
   end
 end


### PR DESCRIPTION
Only global identifiers were subject to naming policies. This commit adds a `local_name` function in `Concrete_ident` that applies the naming policy to a simple name (a `string`).

This commit also changes the F* backend to use `local_name` on local names.

(this is kind of a fix for #177, which was actually partially broken)