### PR TITLE
Support patterns on arrays and opaque types.

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1697,6 +1697,7 @@ module TransformToInputLanguage =
   |> Phases.Direct_and_mut
   |> Phases.Reject.Arbitrary_lhs
   |> Phases.Drop_blocks
+  |> Phases.Rewrite_patterns
   |> Phases.Drop_match_guards
   |> Phases.Drop_references
   |> Phases.Trivialize_assign_lhs

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -203,7 +203,7 @@ functor
       (* An or-pattern, e.g. `p | q`.
          Invariant: `List.length subpats >= 2`. *)
       | POr of { subpats : pat list }
-      | PArray of { args : pat list }
+      | PArray of { args : pat list; slice : bool; suffix : pat list }
       | PDeref of { subpat : pat; witness : F.reference }
       | PConstant of { lit : literal }
       | PBinding of {

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -53,6 +53,7 @@ module Phase = struct
     | DropNeedlessReturns
     | TransformHaxLibInline
     | NewtypeAsRefinement
+    | RewritePatterns
     | DummyA
     | DummyB
     | DummyC

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -358,10 +358,14 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
                     ^^ print#pat_at Pat_PBinding_subpat subpat
                     |> wrap_parens
                 | None -> p)
-            | PArray { args } ->
-                separate_map (break 0)
-                  (print#pat_at Pat_PArray >> terminate comma >> group)
-                  args
+            | PArray { args; slice; suffix } ->
+                let args = List.map ~f:(print#pat_at Pat_PArray) args in
+                let pats =
+                  if slice then
+                    args @ List.map ~f:(print#pat_at Pat_PArray) suffix
+                  else args
+                in
+                separate_map (break 0) (terminate comma >> group) pats
                 |> iblock brackets
             | PDeref { subpat; _ } ->
                 ampersand ^^ print#pat_at Pat_PDeref subpat

--- a/engine/lib/phases/phase_hoist_disjunctive_patterns.ml
+++ b/engine/lib/phases/phase_hoist_disjunctive_patterns.ml
@@ -3,10 +3,7 @@
 
 open! Prelude
 
-module Make (F : Features.T) =
-  Phase_utils.MakeMonomorphicPhase
-    (F)
-    (struct
+(* (struct
       let phase_id = Diagnostics.Phase.HoistDisjunctions
 
       open Ast.Make (F)
@@ -15,100 +12,118 @@ module Make (F : Features.T) =
 
       module Error = Phase_utils.MakeError (struct
         let ctx = Diagnostics.Context.Phase phase_id
-      end)
+      end) *)
+module Make (F : Features.T) = struct
+  module FA = F
+  module FB = F
+  module A = Ast.Make (F)
+  module B = Ast.Make (FB)
+  module ImplemT = Phase_utils.MakePhaseImplemT (A) (B)
+  module Visitors = Ast_visitors.Make (F)
+  open Ast.Make (F)
 
-      let hoist_disjunctions =
-        object (self)
-          inherit [_] Visitors.map
+  module Implem = struct
+    let metadata = Phase_utils.Metadata.make Diagnostics.Phase.HoistDisjunctions
+    let subtype (l : A.item list) : B.item list = Stdlib.Obj.magic l
 
-          method! visit_pat () p =
-            let return_pat p' = { p = p'; span = p.span; typ = p.typ } in
+    let hoist_disjunctions =
+      object (self)
+        inherit [ < visit_F__block : unit -> _ -> _ ; .. > ] Visitors.map
 
-            (* When there is a list of subpaterns, we use the distributivity of nested
-               disjunctions: (a | b, c | d) gives (a, c) | (a, d) | (b, c) | (b,d) *)
-            let rec treat_args cases = function
-              | { p = POr { subpats }; _ } :: tail ->
-                  treat_args
-                    (List.concat_map
-                       ~f:(fun subpat ->
-                         List.map ~f:(fun args -> subpat :: args) cases)
-                       subpats)
-                    tail
-              | pat :: tail ->
-                  let pat = self#visit_pat () pat in
-                  treat_args (List.map ~f:(fun args -> pat :: args) cases) tail
-              | [] -> cases
-            in
-            let subpats_to_disj subpats =
-              match subpats with
-              | [ pat ] -> pat
-              | _ -> POr { subpats } |> return_pat
-            in
+        method! visit_pat _ p =
+          let return_pat p' = { p = p'; span = p.span; typ = p.typ } in
 
-            (* When there is one subpattern, we check if it is a disjunction,
-               and if it is, we hoist it. *)
-            let treat_subpat pat to_pattern =
-              let subpat = self#visit_pat () pat in
-              match subpat with
-              | { p = POr { subpats }; span; _ } ->
-                  return_pat
-                    (POr
-                       {
-                         subpats =
-                           List.map
-                             ~f:(fun pat ->
-                               { p = to_pattern pat; span; typ = p.typ })
-                             subpats;
-                       })
-              | _ -> p
-            in
+          (* When there is a list of subpaterns, we use the distributivity of nested
+             disjunctions: (a | b, c | d) gives (a, c) | (a, d) | (b, c) | (b,d) *)
+          let rec treat_args cases = function
+            | { p = POr { subpats }; _ } :: tail ->
+                treat_args
+                  (List.concat_map
+                     ~f:(fun subpat ->
+                       List.map ~f:(fun args -> subpat :: args) cases)
+                     subpats)
+                  tail
+            | pat :: tail ->
+                let pat = self#visit_pat () pat in
+                treat_args (List.map ~f:(fun args -> pat :: args) cases) tail
+            | [] -> cases
+          in
+          let subpats_to_disj subpats =
+            match subpats with
+            | [ pat ] -> pat
+            | _ -> POr { subpats } |> return_pat
+          in
 
-            match p.p with
-            | PConstruct { name; args; is_record; is_struct } ->
-                let args_as_pat =
-                  List.rev_map args ~f:(fun arg -> self#visit_pat () arg.pat)
-                in
-                let subpats =
-                  List.map (treat_args [ [] ] args_as_pat)
-                    ~f:(fun args_as_pat ->
-                      let args =
-                        List.map2_exn args_as_pat args
-                          ~f:(fun pat { field; _ } -> { field; pat })
-                      in
-                      PConstruct { name; args; is_record; is_struct }
-                      |> return_pat)
-                in
+          (* When there is one subpattern, we check if it is a disjunction,
+             and if it is, we hoist it. *)
+          let treat_subpat pat to_pattern =
+            let subpat = self#visit_pat () pat in
+            match subpat with
+            | { p = POr { subpats }; span; _ } ->
+                return_pat
+                  (POr
+                     {
+                       subpats =
+                         List.map
+                           ~f:(fun pat ->
+                             { p = to_pattern pat; span; typ = p.typ })
+                           subpats;
+                     })
+            | _ -> p
+          in
 
-                subpats_to_disj subpats
-            | PArray { args } ->
-                let subpats =
-                  List.map
-                    ~f:(fun args -> PArray { args } |> return_pat)
-                    (treat_args [ [] ]
-                       (List.rev_map args ~f:(fun arg -> self#visit_pat () arg)))
-                in
-                subpats_to_disj subpats
-            | POr { subpats } ->
-                let subpats = List.map ~f:(self#visit_pat ()) subpats in
-                POr
-                  {
-                    subpats =
-                      List.concat_map
-                        ~f:(function
-                          | { p = POr { subpats }; _ } -> subpats | p -> [ p ])
-                        subpats;
-                  }
-                |> return_pat
-            | PAscription { typ; typ_span; pat } ->
-                treat_subpat pat (fun pat -> PAscription { typ; typ_span; pat })
-            | PBinding { subpat = Some (pat, as_pat); mut; mode; typ; var } ->
-                treat_subpat pat (fun pat ->
-                    PBinding
-                      { subpat = Some (pat, as_pat); mut; mode; typ; var })
-            | PDeref { subpat; witness } ->
-                treat_subpat subpat (fun subpat -> PDeref { subpat; witness })
-            | PWild | PConstant _ | PBinding { subpat = None; _ } -> p
-        end
+          match p.p with
+          | PConstruct { name; args; is_record; is_struct } ->
+              let args_as_pat =
+                List.rev_map args ~f:(fun arg -> self#visit_pat () arg.pat)
+              in
+              let subpats =
+                List.map (treat_args [ [] ] args_as_pat) ~f:(fun args_as_pat ->
+                    let args =
+                      List.map2_exn args_as_pat args ~f:(fun pat { field; _ } ->
+                          { field; pat })
+                    in
+                    PConstruct { name; args; is_record; is_struct }
+                    |> return_pat)
+              in
 
-      let ditems = List.map ~f:(hoist_disjunctions#visit_item ())
-    end)
+              subpats_to_disj subpats
+          | PArray { args; slice; suffix } ->
+              let subpats =
+                List.map
+                  ~f:(fun args_and_suffix ->
+                    let args, suffix =
+                      List.split_n args_and_suffix (List.length args)
+                    in
+                    PArray { args; slice; suffix } |> return_pat)
+                  (treat_args [ [] ]
+                     (List.rev_map (args @ suffix) ~f:(fun arg ->
+                          self#visit_pat () arg)))
+              in
+              subpats_to_disj subpats
+          | POr { subpats } ->
+              let subpats = List.map ~f:(self#visit_pat ()) subpats in
+              POr
+                {
+                  subpats =
+                    List.concat_map
+                      ~f:(function
+                        | { p = POr { subpats }; _ } -> subpats | p -> [ p ])
+                      subpats;
+                }
+              |> return_pat
+          | PAscription { typ; typ_span; pat } ->
+              treat_subpat pat (fun pat -> PAscription { typ; typ_span; pat })
+          | PBinding { subpat = Some (pat, as_pat); mut; mode; typ; var } ->
+              treat_subpat pat (fun pat ->
+                  PBinding { subpat = Some (pat, as_pat); mut; mode; typ; var })
+          | PDeref { subpat; witness } ->
+              treat_subpat subpat (fun subpat -> PDeref { subpat; witness })
+          | PWild | PConstant _ | PBinding { subpat = None; _ } -> p
+      end
+
+    let ditems = List.map ~f:(hoist_disjunctions#visit_item ()) >> subtype
+  end
+
+  include Implem
+end

--- a/engine/lib/phases/phase_hoist_disjunctive_patterns.mli
+++ b/engine/lib/phases/phase_hoist_disjunctive_patterns.mli
@@ -2,4 +2,17 @@
     only shallow disjunctions). It moves the disjunctions up 
     to the top-level pattern. *)
 
-module Make : Phase_utils.UNCONSTRAINTED_MONOMORPHIC_PHASE
+module Make : functor (F : Features.T) -> sig
+  include module type of struct
+    module FB = F
+    module A = Ast.Make (F)
+    module B = Ast.Make (FB)
+    module ImplemT = Phase_utils.MakePhaseImplemT (A) (B)
+    module FA = F
+  end
+
+  include ImplemT.T
+
+  val hoist_disjunctions :
+    < visit_F__block : unit -> _ -> _ ; .. > Ast_visitors.Make(F).map
+end

--- a/engine/lib/phases/phase_rewrite_patterns.ml
+++ b/engine/lib/phases/phase_rewrite_patterns.ml
@@ -1,0 +1,542 @@
+(** This phase rewrites patterns that don't need a guard in Rust 
+    but need one in a backend. Currently it rewrites array/slice 
+    patterns and usize/isize, u128/i128 patterns. *)
+
+open! Prelude
+
+module Make
+    (F : Features.T
+           with type match_guard = Features.On.match_guard
+            and type slice = Features.On.slice
+            and type reference = Features.On.reference) =
+  Phase_utils.MakeMonomorphicPhase
+    (F)
+    (struct
+      let phase_id = Diagnostics.Phase.RewritePatterns
+
+      open Ast.Make (F)
+      open Ast
+      module U = Ast_utils.Make (F)
+      module Visitors = Ast_visitors.Make (F)
+      module HoistDisj = Phase_hoist_disjunctive_patterns.Make (F)
+
+      module Error = Phase_utils.MakeError (struct
+        let ctx = Diagnostics.Context.Phase phase_id
+      end)
+
+      module HoistDisjunctions = Phase_hoist_disjunctive_patterns.Make (F)
+
+      exception IncompatibleDisjunction
+
+      let rewrite_patterns =
+        object (_self)
+          inherit [_] Visitors.map as super
+
+          method! visit_arm' () a =
+            (* These booleans could allow to make this phase configurable. *)
+            let rewrite_u_i_size = true in
+            let rewrite_u_i_128 = true in
+            let rewrite_slice_array = true in
+            let pat_span = a.arm_pat.span in
+            let combine_guards guards =
+              match guards with
+              | [] -> None
+              | [ g1 ] -> Some { guard = g1; span = pat_span }
+              | IfLet { witness; _ } :: _ ->
+                  let lhss, rhss =
+                    List.map guards ~f:(fun (IfLet { lhs; rhs; _ }) ->
+                        (lhs, rhs))
+                    |> List.unzip
+                  in
+                  Some
+                    {
+                      guard =
+                        IfLet
+                          {
+                            lhs = U.make_tuple_pat lhss;
+                            rhs = U.make_tuple_expr ~span:pat_span rhss;
+                            witness;
+                          };
+                      span = pat_span;
+                    }
+            in
+
+            let combine_option_guards (guards : guard option list) :
+                guard option =
+              List.filter_map
+                ~f:(Option.map ~f:(fun (g : guard) -> g.guard))
+                guards
+              |> combine_guards
+            in
+
+            let rec pats_and_guards ?(forced_span : span option = None)
+                (l : pat list) : pat list * guard option list =
+              let pats, guards =
+                List.fold_left
+                  ~f:(fun (pats_left, guards_left) p ->
+                    let new_p, g =
+                      pat_and_guard ~forced_span p
+                        ~unfresh_exprs:
+                          (List.filter_map guards_left
+                             ~f:
+                               (Option.map ~f:(fun (g : guard) ->
+                                    match g.guard with IfLet { rhs; _ } -> rhs)))
+                    in
+                    (new_p :: pats_left, g :: guards_left))
+                  ~init:([], []) l
+              in
+              (List.rev pats, List.rev guards)
+            and pats_and_guard ?(forced_span : span option = None)
+                (l : pat list) : pat list * guard option =
+              let pats, guards = pats_and_guards ~forced_span l in
+              let guard = combine_option_guards guards in
+              (pats, guard)
+            and pat_and_guard ?(unfresh_exprs : expr list = [])
+                ?(forced_span : span option = None) (p : pat) :
+                pat * guard option =
+              let p_span = Option.value ~default:p.span forced_span in
+              match p.p with
+              | PArray { args; slice; suffix } ->
+                  (* [pat1, pat2] should be rewritten as:
+                     | array_var if let (pat1, pat2) = (array_var[0], array_var[1]) *)
+                  (* In the case of slice patterns:
+                     [pat1,.., pat2] should be rewritten as:
+                     | array_var if let Some(pat1, pat2) =
+                        if array_var.len() >= 2
+                          then Some (array_var[0], array_var[array_var.len() - 1])
+                          else None *)
+                  (* In the case where subpatterns also have guards we need to
+                        insert another pattern matching (see under). *)
+                  let args_len = List.length args in
+                  let suffix_len = List.length suffix in
+                  let total_len = args_len + suffix_len in
+                  let args_suffix, args_suffix_guards =
+                    pats_and_guards ~forced_span (args @ suffix)
+                  in
+                  let args, suffix = List.split_n args_suffix args_len in
+                  let combined_guard =
+                    args_suffix_guards
+                    |> List.filter_map
+                         ~f:(Option.map ~f:(fun (g : guard) -> g.guard))
+                    |> combine_guards
+                  in
+
+                  if not rewrite_slice_array then
+                    ( {
+                        p = PArray { args; slice; suffix };
+                        span = p_span;
+                        typ = p.typ;
+                      },
+                      combined_guard )
+                  else
+                    let unfresh = a.body :: unfresh_exprs in
+                    let unfresh =
+                      match combined_guard with
+                      | Some { guard = IfLet { rhs; _ }; _ } -> rhs :: unfresh
+                      | _ -> unfresh
+                    in
+                    let var = U.fresh_local_ident_in_expr unfresh "array_var" in
+                    let array_var_expr =
+                      { e = LocalVar var; span = p_span; typ = p.typ }
+                    in
+                    let elem_type, is_slice =
+                      match p.typ with
+                      | TArray { typ; _ } -> (typ, false)
+                      | TSlice { ty; _ } -> (ty, true)
+                      | _ ->
+                          failwith
+                            ("Unexpected type in array pattern: "
+                            ^ [%show: ty] p.typ)
+                    in
+                    let usize_size = { size = SSize; signedness = Signed } in
+                    let usize_typ = TInt usize_size in
+                    let length =
+                      let ref_var =
+                        {
+                          e =
+                            Borrow
+                              {
+                                kind = Shared;
+                                e = array_var_expr;
+                                witness = Features.On.reference;
+                              };
+                          span = p_span;
+                          typ =
+                            TRef
+                              {
+                                witness = Features.On.reference;
+                                region = "";
+                                typ = p.typ;
+                                mut = Immutable;
+                              };
+                        }
+                      in
+
+                      U.call Core__slice__Impl__len
+                        [
+                          (if is_slice then ref_var
+                          else
+                            U.call Rust_primitives__unsize [ ref_var ] p_span
+                              (TSlice
+                                 {
+                                   witness = Features.On.slice;
+                                   ty = ref_var.typ;
+                                 }));
+                        ]
+                        p_span usize_typ
+                    in
+                    let int_literal value =
+                      {
+                        e =
+                          Literal
+                            (Int
+                               {
+                                 value = Int.to_string value;
+                                 negative = false;
+                                 kind = usize_size;
+                               });
+                        span = p_span;
+                        typ = usize_typ;
+                      }
+                    in
+                    let table_at i =
+                      let index_expr =
+                        if i < args_len then int_literal i
+                        else
+                          U.call Core__ops__arith__Sub__sub
+                            [ length; int_literal (total_len - i) ]
+                            p_span usize_typ
+                      in
+                      U.call Core__ops__index__Index__index
+                        [ array_var_expr; index_expr ]
+                        p_span elem_type
+                    in
+                    let args_suffix_indexed =
+                      List.mapi ~f:Core.Tuple.T2.create args_suffix
+                    in
+                    let guard_lhs, guard_rhs_inner =
+                      List.map2_exn args_suffix_indexed args_suffix_guards
+                        ~f:(fun (i, p) g ->
+                          match g with
+                          | Some { guard = IfLet { lhs; rhs; _ }; _ } ->
+                              (lhs, rhs)
+                          | None -> (p, table_at i))
+                      |> List.unzip
+                    in
+                    let length_test =
+                      U.call Core__cmp__PartialOrd__ge
+                        [ length; int_literal total_len ]
+                        p_span usize_typ
+                    in
+                    let tuple_pat = U.make_tuple_pat guard_lhs in
+                    let make_if_length_test then_ =
+                      {
+                        e =
+                          If
+                            {
+                              cond = length_test;
+                              then_;
+                              else_ =
+                                Some (U.make_opt_expr None p_span tuple_pat.typ);
+                            };
+                        span = p_span;
+                        typ = then_.typ;
+                      }
+                    in
+                    let witness = Features.On.match_guard in
+                    let opt_tuple_pat =
+                      U.make_opt_pattern (Some tuple_pat) p_span tuple_pat.typ
+                    in
+                    let tuple_rhs =
+                      U.make_tuple_expr ~span:p_span guard_rhs_inner
+                    in
+                    let some_tuple_rhs =
+                      U.make_opt_expr (Some tuple_rhs) p_span tuple_pat.typ
+                    in
+                    let pat_guard' : guard' =
+                      match combined_guard with
+                      | Some _ ->
+                          (* Case with guards in the subpatterns: *)
+                          (* We rewrite to the following (where pat0, ... patk)
+                             correspond to the subpatterns with guards: *)
+                          (* var if let Some(guard_lhs_0, pat_1, ... guard_lhs_n) =
+                             if var.len() >= l then
+                               match (var[0], ..., var[k]) with
+                               | pat0, ... patk -> Some(guard_rhs0, var[1], ... guard_rhsn)
+                               | _ -> None
+                             else None*)
+                          let scrutinee_list, pat_list =
+                            List.map2_exn args_suffix_indexed args_suffix_guards
+                              ~f:(fun (i, p) g ->
+                                Option.map g ~f:(fun _ -> (table_at i, p)))
+                            |> List.filter_map ~f:(Option.map ~f:(fun x -> x))
+                            |> List.unzip
+                          in
+                          let scrutinee =
+                            U.make_tuple_expr ~span:p_span scrutinee_list
+                          in
+                          let first_pat = U.make_tuple_pat pat_list in
+                          let arms =
+                            [
+                              U.make_arm first_pat some_tuple_rhs p_span;
+                              U.make_arm
+                                (U.make_wild_pat first_pat.typ p_span)
+                                (U.make_opt_expr None p_span tuple_rhs.typ)
+                                p_span;
+                            ]
+                          in
+                          let pattern_matching =
+                            {
+                              e = Match { scrutinee; arms };
+                              span = p_span;
+                              typ = opt_tuple_pat.typ;
+                            }
+                          in
+                          let rhs = make_if_length_test pattern_matching in
+                          IfLet { lhs = opt_tuple_pat; rhs; witness }
+                      | None ->
+                          (*
+                          No guards in the subpatterns, we rewrite to:
+                              | var if let Some(pat0, ... patn) =
+                                if var.len() >= l then
+                                  Some(var[0], ... var[n])
+                                else 
+                                  None
+                               *)
+                          (* In case this is an array pattern we can even remove
+                             the length test (and we don't need the option)*)
+                          let lhs =
+                            if is_slice then opt_tuple_pat else tuple_pat
+                          in
+                          let rhs =
+                            if is_slice then make_if_length_test some_tuple_rhs
+                            else tuple_rhs
+                          in
+                          IfLet { lhs; rhs; witness }
+                    in
+                    ( U.make_var_pat var p.typ p_span,
+                      Some { guard = pat_guard'; span = p_span } )
+              | PConstruct { name; args; is_record; is_struct } ->
+                  let pats, g =
+                    args
+                    |> List.map ~f:(fun (fp : field_pat) -> fp.pat)
+                    |> pats_and_guard ~forced_span
+                  in
+                  ( {
+                      p =
+                        PConstruct
+                          {
+                            name;
+                            args =
+                              List.map2_exn args pats
+                                ~f:(fun { field; _ } pat -> { field; pat });
+                            is_record;
+                            is_struct;
+                          };
+                      span = p_span;
+                      typ = p.typ;
+                    },
+                    g )
+              | PConstant
+                  { lit = Int { value; negative; kind = { size; _ } as kind } }
+                when (rewrite_u_i_size && [%eq: Ast.size] size Ast.SSize)
+                     || (rewrite_u_i_128 && [%eq: Ast.size] size Ast.S128) ->
+                  (* We should rewrite to: | x if let true = (x == value)*)
+
+                  (* The variable should be free in the body of the arm,
+                     and in the other already generated guards rhs
+                     (this allows in particular to make sure all the
+                     bindings we generate have different names). *)
+                  let var =
+                    U.fresh_local_ident_in_expr (a.body :: unfresh_exprs)
+                      "size_var"
+                  in
+                  let eq_comp =
+                    {
+                      e =
+                        App
+                          {
+                            f =
+                              {
+                                e =
+                                  GlobalVar
+                                    (Global_ident.of_name Value
+                                       Core__cmp__PartialEq__eq);
+                                span = pat_span;
+                                typ = TArrow ([ TInt kind; TInt kind ], TBool);
+                              };
+                            args =
+                              [
+                                {
+                                  e = Literal (Int { value; negative; kind });
+                                  span = pat_span;
+                                  typ = TInt kind;
+                                };
+                                {
+                                  e = LocalVar var;
+                                  span = pat_span;
+                                  typ = TInt kind;
+                                };
+                              ];
+                            generic_args = [];
+                            bounds_impls = [];
+                            trait = None;
+                          };
+                      span = pat_span;
+                      typ = TBool;
+                    }
+                  in
+                  let guard =
+                    Some
+                      (U.make_if_guard eq_comp pat_span Features.On.match_guard)
+                  in
+                  (U.make_var_pat var p.typ p_span, guard)
+              | POr { subpats } -> (
+                  (* The span is "forced" to make sure that equality comparison on guards lhs
+                     does not fail because of spans. *)
+                  let subpats, guards =
+                    List.map
+                      ~f:(pat_and_guard ~forced_span:(Some p_span))
+                      subpats
+                    |> List.unzip
+                  in
+                  if guards |> combine_option_guards |> Option.is_none then
+                    ({ p = POr { subpats }; span = p_span; typ = p.typ }, None)
+                  else
+                    (* If all guards are boolean we can take their disjunction. *)
+                    let conditions =
+                      List.filter_map guards
+                        ~f:
+                          (Option.map ~f:(fun (g : guard) ->
+                               match g.guard with
+                               | IfLet
+                                   {
+                                     rhs;
+                                     lhs =
+                                       { p = PConstant { lit = Bool true }; _ };
+                                     _;
+                                   } ->
+                                   rhs
+                               | _ -> raise IncompatibleDisjunction))
+                    in
+                    match subpats with
+                    | first_pat :: other_pats
+                      when List.for_all
+                           (* TODO change the equality to ignore span so that we don't need forced_span *)
+                             ~f:(fun p -> [%equal: pat'] p.p first_pat.p)
+                             other_pats ->
+                        let guard =
+                          match conditions with
+                          | [] -> None
+                          | ({ span; _ } as e1) :: remaining_conditions ->
+                              let e =
+                                List.fold_left remaining_conditions ~init:e1
+                                  ~f:(fun acc c ->
+                                    {
+                                      e =
+                                        App
+                                          {
+                                            f =
+                                              {
+                                                e =
+                                                  GlobalVar
+                                                    (`Primitive (LogicalOp Or));
+                                                span;
+                                                typ =
+                                                  TArrow
+                                                    ([ TBool; TBool ], TBool);
+                                              };
+                                            args = [ acc; c ];
+                                            generic_args = [];
+                                            bounds_impls = [];
+                                            trait = None;
+                                          };
+                                      span;
+                                      typ = TBool;
+                                    })
+                              in
+
+                              Some
+                                {
+                                  guard =
+                                    IfLet
+                                      {
+                                        lhs =
+                                          {
+                                            p = PConstant { lit = Bool true };
+                                            span;
+                                            typ = TBool;
+                                          };
+                                        rhs = e;
+                                        witness = Features.On.match_guard;
+                                      };
+                                  span;
+                                }
+                        in
+
+                        (first_pat, guard)
+                    | _ -> raise IncompatibleDisjunction)
+              | PDeref { subpat; witness } ->
+                  let subpat, g = pat_and_guard ~forced_span subpat in
+                  ( {
+                      p = PDeref { subpat; witness };
+                      span = p_span;
+                      typ = p.typ;
+                    },
+                    g )
+              | PBinding { mut; mode; var; typ; subpat = Some (p, as_p) } ->
+                  let subpat, g = pat_and_guard ~forced_span p in
+                  ( {
+                      p =
+                        PBinding
+                          { mut; mode; var; typ; subpat = Some (subpat, as_p) };
+                      span = p_span;
+                      typ = p.typ;
+                    },
+                    g )
+              | PAscription { typ; typ_span; pat } ->
+                  let pat, g = pat_and_guard ~forced_span pat in
+                  ( {
+                      p = PAscription { typ; typ_span; pat };
+                      span = p.span;
+                      typ = p.typ;
+                    },
+                    g )
+              | PConstant _ | PWild | PBinding _ ->
+                  ( { p with span = Option.value ~default:p.span forced_span },
+                    None )
+            in
+            let arm_pat, guard = pat_and_guard a.arm_pat in
+            {
+              arm_pat;
+              body = a.body;
+              guard = combine_option_guards [ guard; a.guard ];
+            }
+
+          method! visit_expr' () e =
+            (* In case a disjunction cannot be rewritten with a single guard,
+               We hoist the disjunction and separate the arms. *)
+            match e with
+            | Match { scrutinee; arms } -> (
+                try super#visit_expr' () e
+                with IncompatibleDisjunction ->
+                  let arms =
+                    List.concat_map arms ~f:(fun arm ->
+                        let arm =
+                          HoistDisj.hoist_disjunctions#visit_arm () arm
+                        in
+                        match arm.arm.arm_pat.p with
+                        | POr { subpats } ->
+                            List.map subpats ~f:(fun subpat ->
+                                {
+                                  arm with
+                                  arm = { arm.arm with arm_pat = subpat };
+                                })
+                        | _ -> [ arm ])
+                  in
+                  super#visit_expr' () (Match { arms; scrutinee }))
+            | _ -> super#visit_expr' () e
+        end
+
+      let ditems = List.map ~f:(rewrite_patterns#visit_item ())
+    end)

--- a/engine/lib/phases/phase_rewrite_patterns.mli
+++ b/engine/lib/phases/phase_rewrite_patterns.mli
@@ -1,0 +1,19 @@
+(** This phase rewrites patterns that don't need a guard in Rust 
+    but need one in a backend. Currently it rewrites array/slice 
+    patterns and usize/isize, u128/i128 patterns. *)
+
+module Make
+    (F : Features.T
+           with type match_guard = Features.On.match_guard
+            and type slice = Features.On.slice
+            and type reference = Features.On.reference) : sig
+  include module type of struct
+    module FB = F
+    module A = Ast.Make (F)
+    module B = Ast.Make (FB)
+    module ImplemT = Phase_utils.MakePhaseImplemT (A) (B)
+    module FA = F
+  end
+
+  include ImplemT.T
+end

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -209,7 +209,14 @@ module Raw = struct
           & concat ~sep:!", " (List.map ~f:(fun { pat; _ } -> ppat pat) args)
           & !")"
     | POr { subpats } -> concat ~sep:!" | " (List.map ~f:ppat subpats)
-    | PArray { args } -> !"[" & concat ~sep:!"," (List.map ~f:ppat args) & !"]"
+    | PArray { args; slice = true; suffix } ->
+        !"["
+        & concat ~sep:!"," (List.map ~f:ppat args)
+        & !",..,"
+        & concat ~sep:!"," (List.map ~f:ppat suffix)
+        & !"]"
+    | PArray { args; _ } ->
+        !"[" & concat ~sep:!"," (List.map ~f:ppat args) & !"]"
     | PDeref { subpat; _ } -> !"&" & ppat subpat
     | PConstant { lit } -> pliteral e.span lit
     | PBinding { mut; mode; var; typ = _; subpat } ->

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -127,7 +127,13 @@ struct
             is_struct;
           }
     | POr { subpats } -> POr { subpats = List.map ~f:dpat subpats }
-    | PArray { args } -> PArray { args = List.map ~f:dpat args }
+    | PArray { args; slice; suffix } ->
+        PArray
+          {
+            args = List.map ~f:dpat args;
+            slice;
+            suffix = List.map ~f:dpat suffix;
+          }
     | PConstant { lit } -> PConstant { lit }
     | PBinding { mut; mode; var : Local_ident.t; typ; subpat } ->
         PBinding

--- a/test-harness/src/snapshots/toolchain__pattern-array into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__pattern-array into-fstar.snap
@@ -1,0 +1,167 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: pattern-array
+    manifest: pattern-array/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: false
+      stdout: true
+    include_flag: ~
+    backend_options: ~
+---
+exit = 0
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Pattern_array.fst" = '''
+module Pattern_array
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let array_pattern (x: t_Array i32 (sz 2)) : i32 =
+  match
+    match x with
+    | array_var ->
+      (match array_var.[ isz 0 ], array_var.[ isz 1 ] <: (i32 & i32) with
+        | 0l, a -> Core.Option.Option_Some a <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 1l
+
+let nested_array_pattern (x: t_Slice (t_Array i32 (sz 2))) : i32 =
+  match
+    match x with
+    | array_var1 ->
+      (match
+          if (Core.Slice.impl__len array_var1 <: isize) >=. isz 2
+          then
+            match array_var1.[ isz 1 ] with
+            | array_var ->
+              Core.Option.Option_Some
+              (array_var1.[ isz 0 ], (array_var.[ isz 0 ], array_var.[ isz 1 ] <: (i32 & i32))
+                <:
+                (t_Array i32 (sz 2) & (i32 & i32)))
+              <:
+              Core.Option.t_Option (t_Array i32 (sz 2) & (i32 & i32))
+            | _ ->
+              Core.Option.Option_None <: Core.Option.t_Option (t_Array i32 (sz 2) & (i32 & i32))
+          else Core.Option.Option_None <: Core.Option.t_Option (t_Array i32 (sz 2) & (i32 & i32))
+        with
+        | Core.Option.Option_Some (_, (y, _)) ->
+          Core.Option.Option_Some y <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 1l
+
+let nested_usize_array_pattern (x: t_Slice (t_Array usize (sz 2))) : usize =
+  match
+    match x with
+    | array_var2 ->
+      (match
+          if (Core.Slice.impl__len array_var2 <: isize) >=. isz 2
+          then
+            match
+              array_var2.[ isz 0 ], array_var2.[ isz 1 ]
+              <:
+              (t_Array usize (sz 2) & t_Array usize (sz 2))
+            with
+            | array_var, array_var1 ->
+              Core.Option.Option_Some
+              ((if
+                    (Core.Slice.impl__len (array_var <: t_Slice (t_Array usize (sz 2))) <: isize) >=.
+                    isz 2
+                  then
+                    match array_var.[ isz 0 ] with
+                    | size_var ->
+                      Core.Option.Option_Some
+                      (sz 1 =. size_var, array_var.[ isz 1 ] <: (bool & usize))
+                      <:
+                      Core.Option.t_Option (bool & usize)
+                    | _ -> Core.Option.Option_None <: Core.Option.t_Option (bool & usize)
+                  else Core.Option.Option_None <: Core.Option.t_Option (bool & usize)),
+                (array_var1.[ isz 0 ], array_var1.[ isz 1 ] <: (usize & usize))
+                <:
+                (Core.Option.t_Option (bool & usize) & (usize & usize)))
+              <:
+              Core.Option.t_Option (Core.Option.t_Option (bool & usize) & (usize & usize))
+            | _ ->
+              Core.Option.Option_None
+              <:
+              Core.Option.t_Option (Core.Option.t_Option (bool & usize) & (usize & usize))
+          else
+            Core.Option.Option_None
+            <:
+            Core.Option.t_Option (Core.Option.t_Option (bool & usize) & (usize & usize))
+        with
+        | Core.Option.Option_Some (Core.Option.Option_Some (true, _), (y, _)) ->
+          Core.Option.Option_Some y <: Core.Option.t_Option usize
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option usize)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option usize
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> sz 1
+
+let slice_pattern (x: t_Slice i32) : i32 =
+  match
+    match x with
+    | array_var ->
+      (match
+          if (Core.Slice.impl__len array_var <: isize) >=. isz 2
+          then
+            Core.Option.Option_Some
+            (array_var.[ isz 0 ],
+              array_var.[ (Core.Slice.impl__len array_var <: isize) -! isz 1 <: isize ]
+              <:
+              (i32 & i32))
+            <:
+            Core.Option.t_Option (i32 & i32)
+          else Core.Option.Option_None <: Core.Option.t_Option (i32 & i32)
+        with
+        | Core.Option.Option_Some (0l, a) -> Core.Option.Option_Some a <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 1l
+
+let usize_array_pattern (x: t_Slice usize) : usize =
+  match
+    match x with
+    | array_var ->
+      (match
+          if (Core.Slice.impl__len array_var <: isize) >=. isz 2
+          then
+            match array_var.[ isz 0 ] with
+            | size_var ->
+              Core.Option.Option_Some (sz 1 =. size_var, array_var.[ isz 1 ] <: (bool & usize))
+              <:
+              Core.Option.t_Option (bool & usize)
+            | _ -> Core.Option.Option_None <: Core.Option.t_Option (bool & usize)
+          else Core.Option.Option_None <: Core.Option.t_Option (bool & usize)
+        with
+        | Core.Option.Option_Some (true, y) ->
+          Core.Option.Option_Some y <: Core.Option.t_Option usize
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option usize)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option usize
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> sz 1
+'''

--- a/test-harness/src/snapshots/toolchain__pattern-opaque into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__pattern-opaque into-fstar.snap
@@ -1,0 +1,160 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: pattern-opaque
+    manifest: pattern-opaque/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: false
+      stdout: true
+    include_flag: ~
+    backend_options: ~
+---
+exit = 0
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Pattern_opaque.fst" = '''
+module Pattern_opaque
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let equivalent (x: usize) : i32 =
+  match
+    match x with
+    | a ->
+      (match a =. sz 1 with
+        | true -> Core.Option.Option_Some 1l <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  ->
+    match
+      match x with
+      | a ->
+        (match a =. sz 2 with
+          | true -> Core.Option.Option_Some 2l <: Core.Option.t_Option i32
+          | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+      | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+    with
+    | Core.Option.Option_Some x -> x
+    | Core.Option.Option_None  -> 0l
+
+let u128_pattern (x: u128) : i32 =
+  match
+    match x with
+    | size_var ->
+      (match pub_u128 1 =. size_var with
+        | true -> Core.Option.Option_Some 1l <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 0l
+
+let u_i_size_nested (x1 x2: usize) (y: isize) : i32 =
+  match
+    match (x1, 1l <: (usize & i32)), y <: ((usize & i32) & isize) with
+    | (size_var, res), size_var1 ->
+      (match sz 1 =. size_var, isz 1 =. size_var1 <: (bool & bool) with
+        | true, true -> Core.Option.Option_Some res <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 0l
+
+let u_i_size_nested_equivalent (x1 x2: usize) (y: isize) : i32 =
+  match
+    match (x1, 1l <: (usize & i32)), y <: ((usize & i32) & isize) with
+    | (a1, res), b ->
+      (match a1 =. sz 1, b =. isz 1 <: (bool & bool) with
+        | true, true -> Core.Option.Option_Some res <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 0l
+
+let usize_complicated_or_pattern (x: usize) : usize =
+  match
+    match x, x <: (usize & usize) with
+    | size_var, a ->
+      (match sz 1 =. size_var with
+        | true -> Core.Option.Option_Some a <: Core.Option.t_Option usize
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option usize)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option usize
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  ->
+    match
+      match x, x <: (usize & usize) with
+      | a, size_var ->
+        (match sz 1 =. size_var with
+          | true -> Core.Option.Option_Some a <: Core.Option.t_Option usize
+          | _ -> Core.Option.Option_None <: Core.Option.t_Option usize)
+      | _ -> Core.Option.Option_None <: Core.Option.t_Option usize
+    with
+    | Core.Option.Option_Some x -> x
+    | Core.Option.Option_None  -> sz 0
+
+let usize_or_equivalent (x: usize) : i32 =
+  match
+    match x, x <: (usize & usize) with
+    | a, b ->
+      (match a =. sz 1 || a =. sz 2 with
+        | true -> Core.Option.Option_Some 1l <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 0l
+
+let usize_or_pattern (x: usize) : i32 =
+  match
+    match x, 1l <: (usize & i32) with
+    | size_var, a ->
+      (match sz 1 =. size_var || sz 2 =. size_var with
+        | true -> Core.Option.Option_Some a <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  -> 0l
+
+let usize_pattern (x: usize) : i32 =
+  match
+    match x with
+    | size_var ->
+      (match sz 1 =. size_var with
+        | true -> Core.Option.Option_Some 1l <: Core.Option.t_Option i32
+        | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+    | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+  with
+  | Core.Option.Option_Some x -> x
+  | Core.Option.Option_None  ->
+    match
+      match x with
+      | size_var ->
+        (match sz 2 =. size_var with
+          | true -> Core.Option.Option_Some 2l <: Core.Option.t_Option i32
+          | _ -> Core.Option.Option_None <: Core.Option.t_Option i32)
+      | _ -> Core.Option.Option_None <: Core.Option.t_Option i32
+    with
+    | Core.Option.Option_Some x -> x
+    | Core.Option.Option_None  -> 0l
+'''

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -652,6 +652,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pattern-array"
+version = "0.1.0"
+
+[[package]]
+name = "pattern-opaque"
+version = "0.1.0"
+
+[[package]]
 name = "pattern-or"
 version = "0.1.0"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,8 @@ members = [
         "let-else",
         "enum-repr",
         "pattern-or",
+        "pattern-array",
+        "pattern-opaque",
         "side-effects",
         "mut-ref-functionalization",
         "generics",

--- a/tests/pattern-array/Cargo.toml
+++ b/tests/pattern-array/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pattern-array"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { broken = false, snapshot = "stdout", issue_id = "804" }

--- a/tests/pattern-array/src/lib.rs
+++ b/tests/pattern-array/src/lib.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+#![feature(if_let_guard)]
+
+pub fn slice_pattern(x: &[i32]) -> i32 {
+    match x {
+        [0, .., a] => *a,
+        _ => 1,
+    }
+}
+
+pub fn array_pattern(x: [i32; 2]) -> i32 {
+    match x {
+        [0, a] => a,
+        _ => 1,
+    }
+}
+
+pub fn nested_array_pattern(x: &[[i32; 2]]) -> i32 {
+    match x {
+        [_, [y, _], ..] => *y,
+        _ => 1,
+    }
+}
+
+pub fn usize_array_pattern(x: &[usize]) -> usize {
+    match x {
+        [1, y] => *y,
+        _ => 1,
+    }
+}
+
+pub fn nested_usize_array_pattern(x: &[[usize; 2]]) -> usize {
+    match x {
+        [[1, _], [y, _], ..] => *y,
+        _ => 1,
+    }
+}

--- a/tests/pattern-opaque/Cargo.toml
+++ b/tests/pattern-opaque/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pattern-opaque"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { broken = false, snapshot = "stdout", issue_id = "464" }

--- a/tests/pattern-opaque/src/lib.rs
+++ b/tests/pattern-opaque/src/lib.rs
@@ -1,0 +1,59 @@
+#![allow(dead_code)]
+#![feature(if_let_guard)]
+
+pub fn usize_pattern(x: usize) -> i32 {
+    match x {
+        1 => 1,
+        2 => 2,
+        _ => 0,
+    }
+}
+
+pub fn u128_pattern(x: u128) -> i32 {
+    match x {
+        1 => 1,
+        _ => 0,
+    }
+}
+
+pub fn equivalent(x: usize) -> i32 {
+    match x {
+        a if let true = a == 1 => 1,
+        a if let true = a == 2 => 2,
+        _ => 0,
+    }
+}
+
+pub fn usize_or_pattern(x: usize) -> i32 {
+    match (x, 1) {
+        (1, a) | (2, a) => a,
+        _ => 0,
+    }
+}
+
+pub fn usize_complicated_or_pattern(x: usize) -> usize {
+    match (x, x) {
+        (1, a) | (a, 1) => a,
+        _ => 0,
+    }
+}
+
+pub fn usize_or_equivalent(x: usize) -> i32 {
+    match (x, x) {
+        (a, b) if let true = (a == 1 || a == 2) => 1,
+        _ => 0,
+    }
+}
+
+pub fn u_i_size_nested(x1: usize, x2: usize, y: isize) -> i32 {
+    match ((x1, 1), y) {
+        ((1, res), 1) => res,
+        _ => 0,
+    }
+}
+pub fn u_i_size_nested_equivalent(x1: usize, x2: usize, y: isize) -> i32 {
+    match ((x1, 1), y) {
+        ((a1, res), b) if let (true, true) = (a1 == 1, b == 1) => res,
+        _ => 0,
+    }
+}


### PR DESCRIPTION
Closes #464 , #804

We add a phase to rewrite array patterns and usize/isize/i128/u128 patterns.

The phase rewrites them with `if let` guards.

For integer types the idea is to rewrite:
```
match x {
  1 => ...
}
```
as 
```
match x {
  x if let true = (x == 1) => ...
}
```

For array/slice patterns, the idea is to rewrite:
```
match x {
  [a, b] => ...
}
```
as 
```
match x {
 t if let (a, b) = (t[0], t[1]) => ...
}
```
In the case of slice patterns we also test the length of the slice in the condition: 
```
match x {
  [a,.., b] => ...
}
```
becomes
```
match x {
 t if let Some(a, b) = if t.len() >= 2 then Some(t[0], t[t.len()-1]) else None => ...
}
```

In case the subpatterns of an array also need a guard to be rewritten, we rewrite using a pattern matching.

In case there is a disjunctive pattern with guards in the subpatterns,  we try to take a boolean disjunction of the guards. When it is not possible we call the phase `hoist_disjunctive_patterns` and separate the arm into one arm for each case of the disjunction.

 