### PR TITLE
Add requires to rust doc

### DIFF
--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -16,12 +16,22 @@ macro_rules! identity_proc_macro_attribute {
     }
 }
 
+#[proc_macro_attribute]
+pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item: ItemFn = parse_macro_input!(item);
+    let phi: syn::Expr = parse_macro_input!(attr);
+
+    quote! {
+        #[doc=concat!("Requires: ",stringify!(#phi))]
+        #item
+    }.into()
+}
+
 identity_proc_macro_attribute!(
     fstar_options,
     fstar_verification_status,
     include,
     exclude,
-    requires,
     ensures,
     pv_handwritten,
     pv_constructor,

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -22,7 +22,7 @@ pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
     let phi: syn::Expr = parse_macro_input!(attr);
 
     quote! {
-        #[doc=concat!("Requires: ",stringify!(#phi))]
+        #[doc=concat!("Requires:\n```\n",stringify!(#phi),"\n```")]
         #item
     }.into()
 }


### PR DESCRIPTION
Start adding rustdoc to hax-lib macros. Will be used by annotated core.