### PR TITLE
Make predicate handling a bit more consistent

### DIFF
--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -241,7 +241,7 @@ pub fn self_clause_for_item<'tcx, S: UnderOwnerState<'tcx>>(
 
     let tr_def_id = tcx.trait_of_item(assoc.def_id)?;
     // The "self" predicate in the context of the trait.
-    let self_pred = self_predicate(tcx, tr_def_id).unwrap();
+    let self_pred = self_predicate(tcx, tr_def_id);
     // Substitute to be in the context of the current item.
     let generics = generics.truncate_to(tcx, tcx.generics_of(tr_def_id));
     let self_pred = EarlyBinder::bind(self_pred).instantiate(tcx, generics);

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -206,13 +206,15 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
 fn solve_item_traits_inner<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     generics: ty::GenericArgsRef<'tcx>,
-    predicates: impl Iterator<Item = ty::Clause<'tcx>>,
+    predicates: ty::GenericPredicates<'tcx>,
 ) -> Vec<ImplExpr> {
     use crate::rustc_middle::ty::ToPolyTraitRef;
     let tcx = s.base().tcx;
     let param_env = s.param_env();
-
     predicates
+        .predicates
+        .iter()
+        .map(|(clause, _span)| *clause)
         .filter_map(|clause| clause.as_trait_clause())
         .map(|clause| clause.to_poly_trait_ref())
         // Substitute the item generics

--- a/frontend/exporter/src/traits/resolution.rs
+++ b/frontend/exporter/src/traits/resolution.rs
@@ -131,7 +131,7 @@ fn initial_search_predicates<'tcx>(
                 acc_predicates(tcx, parent, predicates, pred_id);
             }
             Trait => {
-                let self_pred = self_predicate(tcx, def_id).unwrap().upcast(tcx);
+                let self_pred = self_predicate(tcx, def_id).upcast(tcx);
                 predicates.push(AnnotatedTraitPred {
                     origin: BoundPredicateOrigin::SelfPred,
                     clause: self_pred,

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -98,14 +98,10 @@ pub fn implied_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPred
         // We consider all predicates on traits to be outputs
         Trait => predicates_defined_on(tcx, def_id),
         AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
-            // TODO: `item_bounds` contains parent traits, use `explicit_item_bounds` instead.
-            let clauses = tcx.item_bounds(def_id).instantiate_identity();
-            use crate::rustc_middle::query::Key;
-            let span = clauses.default_span(tcx);
-            let predicates = clauses.iter().map(|c| (c, span));
             GenericPredicates {
                 parent,
-                predicates: tcx.arena.alloc_from_iter(predicates),
+                // `skip_binder` is for an `EarlyBinder`
+                predicates: tcx.explicit_item_bounds(def_id).skip_binder(),
                 ..GenericPredicates::default()
             }
         }

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -79,13 +79,9 @@ pub fn required_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPre
 }
 
 /// The special "self" predicate on a trait.
-pub fn self_predicate<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<PolyTraitRef<'tcx>> {
-    use DefKind::*;
-    match tcx.def_kind(def_id) {
-        // Copied from the code of `tcx.predicates_of()`.
-        Trait => Some(Binder::dummy(TraitRef::identity(tcx, def_id))),
-        _ => None,
-    }
+pub fn self_predicate<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> PolyTraitRef<'tcx> {
+    // Copied from the code of `tcx.predicates_of()`.
+    Binder::dummy(TraitRef::identity(tcx, def_id))
 }
 
 /// The predicates that can be deduced from the presence of this item in a signature. We only

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -97,7 +97,7 @@ pub enum FullDefKind<Body> {
     Struct {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.adt_def(s.owner_id()).sinto(s))]
         def: AdtDef,
@@ -105,7 +105,7 @@ pub enum FullDefKind<Body> {
     Union {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.adt_def(s.owner_id()).sinto(s))]
         def: AdtDef,
@@ -113,7 +113,7 @@ pub enum FullDefKind<Body> {
     Enum {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.adt_def(s.owner_id()).sinto(s))]
         def: AdtDef,
@@ -122,7 +122,7 @@ pub enum FullDefKind<Body> {
     TyAlias {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         /// `Some` if the item is in the local crate.
         #[value(s.base().tcx.hir().get_if_local(s.owner_id()).map(|node| {
@@ -142,7 +142,7 @@ pub enum FullDefKind<Body> {
         parent: DefId,
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_item_predicates(s, s.owner_id()))]
+        #[value(normalized_implied_predicates(s, s.owner_id()))]
         // FIXME: clarify implied vs required predicates
         predicates: GenericPredicates,
         #[value(s.base().tcx.associated_item(s.owner_id()).sinto(s))]
@@ -164,7 +164,7 @@ pub enum FullDefKind<Body> {
     Trait {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_implied_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         /// The special `Self: Trait` clause.
         #[value({
@@ -226,7 +226,7 @@ pub enum FullDefKind<Body> {
     Fn {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.codegen_fn_attrs(s.owner_id()).inline.sinto(s))]
         inline: InlineAttr,
@@ -246,7 +246,7 @@ pub enum FullDefKind<Body> {
         associated_item: AssocItem,
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.codegen_fn_attrs(s.owner_id()).inline.sinto(s))]
         inline: InlineAttr,
@@ -281,7 +281,7 @@ pub enum FullDefKind<Body> {
     Const {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.type_of(s.owner_id()).instantiate_identity().sinto(s))]
         ty: Ty,
@@ -296,7 +296,7 @@ pub enum FullDefKind<Body> {
         associated_item: AssocItem,
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.type_of(s.owner_id()).instantiate_identity().sinto(s))]
         ty: Ty,
@@ -316,7 +316,7 @@ pub enum FullDefKind<Body> {
         nested: bool,
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
-        #[value(get_generic_predicates(s, s.owner_id()))]
+        #[value(normalized_required_predicates(s, s.owner_id()))]
         predicates: GenericPredicates,
         #[value(s.base().tcx.type_of(s.owner_id()).instantiate_identity().sinto(s))]
         ty: Ty,
@@ -662,7 +662,7 @@ where
     let tcx = s.base().tcx;
     let impl_def_id = s.owner_id();
     let generics = tcx.generics_of(impl_def_id).sinto(s);
-    let predicates = get_generic_predicates(s, impl_def_id);
+    let predicates = normalized_required_predicates(s, impl_def_id);
     match tcx.impl_subject(impl_def_id).instantiate_identity() {
         ty::ImplSubject::Inherent(ty) => {
             let items = tcx
@@ -866,9 +866,10 @@ where
 #[cfg(feature = "rustc")]
 fn normalize_trait_clauses<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
-    predicates: &[(ty::Clause<'tcx>, rustc_span::Span)],
-) -> Vec<(Predicate, Span)> {
-    let predicates: Vec<_> = predicates
+    predicates: ty::GenericPredicates<'tcx>,
+) -> GenericPredicates {
+    let clauses: Vec<_> = predicates
+        .predicates
         .iter()
         .map(|(clause, span)| {
             let mut clause = *clause;
@@ -882,46 +883,30 @@ fn normalize_trait_clauses<'tcx, S: UnderOwnerState<'tcx>>(
             (clause.as_predicate(), *span)
         })
         .collect();
-    predicates.sinto(s)
+    GenericPredicates {
+        parent: predicates.parent.sinto(s),
+        predicates: clauses.sinto(s),
+    }
 }
 
-/// Gets the `predicates_defined_on` the given `DefId` and processes them with
+/// Get the `required_predicates` for the given `def_id` and process them with
 /// `normalize_trait_clauses`.
 #[cfg(feature = "rustc")]
-fn get_generic_predicates<'tcx, S: UnderOwnerState<'tcx>>(
+fn normalized_required_predicates<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     def_id: RDefId,
 ) -> GenericPredicates {
-    let predicates = predicates_defined_on(s.base().tcx, def_id);
-    let pred_list = normalize_trait_clauses(s, predicates.predicates);
-    GenericPredicates {
-        parent: predicates.parent.sinto(s),
-        predicates: pred_list,
-    }
+    let tcx = s.base().tcx;
+    normalize_trait_clauses(s, required_predicates(tcx, def_id))
 }
 
-/// Gets the predicates defined on the given associated type and processes them with
+/// Get the `implied_predicates` for the given `def_id` and process them with
 /// `normalize_trait_clauses`.
 #[cfg(feature = "rustc")]
-fn get_item_predicates<'tcx, S: UnderOwnerState<'tcx>>(s: &S, def_id: RDefId) -> GenericPredicates {
+fn normalized_implied_predicates<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    def_id: RDefId,
+) -> GenericPredicates {
     let tcx = s.base().tcx;
-    let parent_id = tcx.parent(def_id);
-    // `item_bounds` cannot be called on a trait impl item, and returns empty on an inherent impl
-    // item. So we only call it for trait decl items.
-    let predicates = match tcx.def_kind(parent_id) {
-        rustc_hir::def::DefKind::Trait => {
-            // TODO: we probably want to use `explicit_item_bounds` instead, but should do so
-            // consistently.
-            let clauses = tcx.item_bounds(def_id).instantiate_identity();
-            use crate::rustc_middle::query::Key;
-            let span = clauses.default_span(tcx);
-            clauses.iter().map(|c| (c, span)).collect::<Vec<_>>()
-        }
-        _ => Vec::new(),
-    };
-    let predicates = normalize_trait_clauses(s, predicates.as_slice());
-    GenericPredicates {
-        parent: Some(parent_id.sinto(s)),
-        predicates,
-    }
+    normalize_trait_clauses(s, implied_predicates(tcx, def_id))
 }

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -172,7 +172,6 @@ pub enum FullDefKind<Body> {
             let tcx = s.base().tcx;
             let pred: ty::TraitPredicate =
                 crate::traits::self_predicate(tcx, s.owner_id())
-                    .unwrap()
                     .no_bound_vars()
                     .unwrap()
                     .upcast(tcx);


### PR DESCRIPTION
This concludes the work I started a while ago to clarify the predicates used for trait solving each item: the single source of truth is now `require_predicates`/`implied_predicates`. This made it possible to exclude some unnecessary derived predicates in the `implied_predicates` of associated types, which was a long-standing TODO.