### PR TITLE
fix(engine) Attempt to fix double return bug.

### DIFF
--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -419,7 +419,7 @@ let impl: t_Foo Prims.unit =
     f_i
     =
     fun (x: u8) (y: u8) ->
-      let hax_temp_output:Prims.unit = () <: Prims.unit in
+      let _:Prims.unit = () <: Prims.unit in
       y
   }
 '''

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -52,6 +52,31 @@ let looping (array: t_Array u8 (sz 5)) : t_Array u8 (sz 5) =
           t_Array u8 (sz 5))
   in
   array
+
+let looping_2_ (array: t_Array u8 (sz 5)) : t_Array u8 (sz 5) =
+  let array, result:(t_Array u8 (sz 5) & Prims.unit) =
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      (Core.Slice.impl__len #u8 (array <: t_Slice u8) <: usize)
+      (fun array temp_1_ ->
+          let array:t_Array u8 (sz 5) = array in
+          let _:usize = temp_1_ in
+          true)
+      array
+      (fun array i ->
+          let array:t_Array u8 (sz 5) = array in
+          let i:usize = i in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize array
+            i
+            (cast (i <: usize) <: u8)
+          <:
+          t_Array u8 (sz 5)),
+    ()
+    <:
+    (t_Array u8 (sz 5) & Prims.unit)
+  in
+  let _:Prims.unit = admit () (* Panic freedom *) in
+  let _:Prims.unit = result in
+  array
 '''
 "Loops.Control_flow.fst" = '''
 module Loops.Control_flow
@@ -489,7 +514,7 @@ let enumerate_chunks (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
   in
   acc
 
-let f (_: Prims.unit) : u8 =
+let f (_: Prims.unit) : (u8 & Prims.unit) =
   let acc:u8 = 0uy in
   Rust_primitives.Hax.Folds.fold_range 1uy
     10uy
@@ -503,7 +528,10 @@ let f (_: Prims.unit) : u8 =
         let i:u8 = i in
         let acc:u8 = acc +! i in
         let _:bool = bool_returning i in
-        acc)
+        acc),
+  ()
+  <:
+  (u8 & Prims.unit)
 
 let iterator (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
   let acc:usize = sz 0 in
@@ -679,7 +707,7 @@ module Loops.Recognized_loops
 open Core
 open FStar.Mul
 
-let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
+let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : (u64 & Prims.unit) =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_enumerated_chunked_slice (sz 3)
     slice
@@ -692,9 +720,12 @@ let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
         let count:u64 = count in
         let i:(usize & t_Slice v_T) = i in
         let count:u64 = count +! 3uL in
-        count)
+        count),
+  ()
+  <:
+  (u64 & Prims.unit)
 
-let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
+let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : (u64 & Prims.unit) =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_enumerated_slice slice
     (fun count i ->
@@ -706,9 +737,12 @@ let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
         let count:u64 = count in
         let i:(usize & v_T) = i in
         let count:u64 = count +! 2uL in
-        count)
+        count),
+  ()
+  <:
+  (u64 & Prims.unit)
 
-let range (_: Prims.unit) : u64 =
+let range (_: Prims.unit) : (u64 & Prims.unit) =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_range 0uy
     10uy
@@ -721,9 +755,12 @@ let range (_: Prims.unit) : u64 =
         let count:u64 = count in
         let i:u8 = i in
         let count:u64 = count +! 1uL in
-        count)
+        count),
+  ()
+  <:
+  (u64 & Prims.unit)
 
-let range_step_by (_: Prims.unit) : u64 =
+let range_step_by (_: Prims.unit) : (u64 & Prims.unit) =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_range_step_by 0uy
     10uy
@@ -737,7 +774,10 @@ let range_step_by (_: Prims.unit) : u64 =
         let count:u64 = count in
         let i:u8 = i in
         let count:u64 = count +! 1uL in
-        count)
+        count),
+  ()
+  <:
+  (u64 & Prims.unit)
 '''
 "Loops.While_loops.fst" = '''
 module Loops.While_loops

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -27,6 +27,32 @@ stderr = 'Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'
 diagnostics = []
 
 [stdout.files]
+"Loops.And_mut_side_effect_loop.fst" = '''
+module Loops.And_mut_side_effect_loop
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let looping (array: t_Array u8 (sz 5)) : t_Array u8 (sz 5) =
+  let array:t_Array u8 (sz 5) =
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      (Core.Slice.impl__len #u8 (array <: t_Slice u8) <: usize)
+      (fun array temp_1_ ->
+          let array:t_Array u8 (sz 5) = array in
+          let _:usize = temp_1_ in
+          true)
+      array
+      (fun array i ->
+          let array:t_Array u8 (sz 5) = array in
+          let i:usize = i in
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_usize array
+            i
+            (cast (i <: usize) <: u8)
+          <:
+          t_Array u8 (sz 5))
+  in
+  array
+'''
 "Loops.Control_flow.fst" = '''
 module Loops.Control_flow
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/loops/src/lib.rs
+++ b/tests/loops/src/lib.rs
@@ -252,4 +252,11 @@ mod and_mut_side_effect_loop {
             array[i] = i as u8;
         }
     }
+
+    #[hax_lib::fstar::verification_status(panic_free)]
+    fn looping_2(array: &mut [u8; 5]) {
+        for i in 0..array.len() {
+            array[i] = i as u8;
+        }
+    }
 }

--- a/tests/loops/src/lib.rs
+++ b/tests/loops/src/lib.rs
@@ -244,3 +244,12 @@ mod control_flow {
         sum
     }
 }
+
+mod and_mut_side_effect_loop {
+    // https://github.com/hacspec/hax/issues/720
+    fn looping(array: &mut [u8; 5]) {
+        for i in 0..array.len() {
+            array[i] = i as u8;
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to make things better for #720.

As far as we know, this bug happens when there is a loop with side effects at the end of a function. Then `AndMutDefSite` transforms this to:
```
let hax_temp_output: tuple0 = <loop>
hax_temp_output
```
And `LocalMutation` transforms this binding to:
```
let Tuple2(modified_var, hax_temp_output) = <loop>
...
```
but the transformation of the loop is made in such a way that here `<loop>` has the type of <modified_var>.

This fix is modifying `AndMutDefSite` so that if the expression has type unit, instead of the previous binding it produces:
```
let _ = <loop>
()
```
This works better with the assumptions of `LocalMutation` and fixes the bug (at least for the last reproducer that I added as a test). A more in depth rework of both those phases with a formalization of the invariants would be a better long-term solution.