### PR TITLE
ci(gha): drop magic-nix-cache action because of EOL

### DIFF
--- a/.github/workflows/bertie.yml
+++ b/.github/workflows/bertie.yml
@@ -26,8 +26,6 @@ jobs:
           path: hax
 
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: ⤵ Install hax
         run: |
           nix profile install ./hax

--- a/.github/workflows/engine_js_build.yml
+++ b/.github/workflows/engine_js_build.yml
@@ -14,5 +14,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - run: nix build .\#hax-engine.passthru.js -L  

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build documentation
         run: nix build .#docs
       - name: Upload static files as artifact

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -18,7 +18,6 @@ jobs:
       with:
         name: hax
         skipPush: true
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build -L
 

--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -26,8 +26,6 @@ jobs:
           path: hax
 
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: ⤵ Install hax
         run: |
           nix profile install ./hax

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build JS
       run: nix build .#hax-engine.passthru.js -L -o hax-engine.js
 


### PR DESCRIPTION
https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

This PR just runs `sd '.*DeterminateSystems/magic-nix-cache-action@main\n+' '' .github/**/*`