### PR TITLE
fix(engine) Add const parameter for assoc const of parametric impl.

### DIFF
--- a/test-harness/src/snapshots/toolchain__generics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__generics into-fstar.snap
@@ -27,6 +27,18 @@ stderr = 'Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'
 diagnostics = []
 
 [stdout.files]
+"Generics.Assoc_const_param.fst" = '''
+module Generics.Assoc_const_param
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_Test (v_N: usize) = | Test : t_Test v_N
+
+let impl__A (v_N: usize) : t_Test v_N = Test <: t_Test v_N
+
+let test (_: Prims.unit) : t_Test (mk_usize 1) = impl__A (mk_usize 1)
+'''
 "Generics.Defaults_generics.fst" = '''
 module Generics.Defaults_generics
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -72,3 +72,16 @@ mod impl_generics {
         }
     }
 }
+
+/// See https://github.com/cryspen/hax/issues/1289
+mod assoc_const_param {
+    struct Test<const N: usize>();
+
+    impl<const N: usize> Test<N> {
+        const A: Self = Self();
+    }
+
+    fn test() -> Test<1> {
+        Test::<1>::A
+    }
+}


### PR DESCRIPTION
Fixes #1289.

@W95Psp The changes fix the bug but feel a bit ad hoc, if you see some other cases of `NamedConst` which need an `App` with `args` or `generic_args` we can try to catch them as well.