### PR TITLE
Rustdoc for attributes

### DIFF
--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -18,7 +18,7 @@ paste = { version = "1.0.15" }
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "visit-mut"] }
+syn = { version = "2.0", features = ["full", "visit-mut", "extra-traits"] }
 proc-macro-error = { version = "1.0.4" }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -13,13 +13,13 @@ description = "Hax-specific proc-macros for Rust programs"
 proc-macro = true
 
 [target.'cfg(hax)'.dependencies]
-proc-macro-error = { version = "1.0.4" }
 hax-lib-macros-types = { workspace = true }
 paste = { version = "1.0.15" }
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "visit-mut"] }
+proc-macro-error = { version = "1.0.4" }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -18,7 +18,7 @@ paste = { version = "1.0.15" }
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "visit-mut", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "visit-mut", "extra-traits", "printing"] }
 proc-macro-error = { version = "1.0.4" }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -3,7 +3,7 @@ mod hax_paths;
 use hax_paths::*;
 use proc_macro as pm;
 use proc_macro2::*;
-pub use proc_macro_error::*;
+use proc_macro_error::*;
 use quote::*;
 use syn::{visit_mut::VisitMut, *};
 

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Pre-Condition: {}\n"#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: {}\"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +64,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}\n"#, attr.clone().to_string());
+    let payload = format!(r#"Post-Condition: {}\"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -42,6 +42,7 @@ identity_proc_macro_attribute!(
     fstar_after,
     coq_after,
     proverif_after,
+    decreases
 );
 
 

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -3,6 +3,7 @@ mod hax_paths;
 use hax_paths::*;
 use proc_macro as pm;
 use proc_macro2::*;
+pub use proc_macro_error::*;
 use quote::*;
 use syn::{visit_mut::VisitMut, *};
 

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,11 +49,11 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"/// Pre-Condition: {}"#, attr.clone().to_string());
+    let payload = format!(r#""Pre-Condition: {}""#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
-        #payload
+        #[doc=#payload]
         #item
     }
     .into()
@@ -64,11 +64,11 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"/// Post-Condition: {}"#, attr.clone().to_string());
+    let payload = format!(r#""Post-Condition: {}""#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
-        #payload
+        #[doc=#payload]
         #item
     }
     .into()

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Pre-Condition: ```rust {}```"#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: ``` {} ```"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +64,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: `{}`\"#, attr.clone().to_string());
+    let payload = format!(r#"Post-Condition: ``` {} ```\"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,11 +49,11 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}"#, attr.clone().to_string());
+    let payload = format!(r#"/// Pre-Condition: {}"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
-        #[doc=#payload]
+        #payload]
         #item
     }
     .into()
@@ -64,11 +64,11 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}"#, attr.clone().to_string());
+    let payload = format!(r#"/// Post-Condition: {}"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
-        #[doc=#payload]
+        #payload
         #item
     }
     .into()

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Pre-Condition: {}"#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: ```rust {}```"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +64,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}\"#, attr.clone().to_string());
+    let payload = format!(r#"Post-Condition: `{}`\"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#""Pre-Condition: {}""#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: {}\n"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +64,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#""Post-Condition: {}""#, attr.clone().to_string());
+    let payload = format!(r#"Post-Condition: {}\n"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr);
+    let phi: syn::Expr = parse_macro_input!(attr.clone());
     let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +64,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr);
+    let phi: syn::Expr = parse_macro_input!(attr.clone());
     let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -5,7 +5,7 @@ use proc_macro as pm;
 use proc_macro2::*;
 use proc_macro_error::*;
 use quote::*;
-use syn::{visit_mut::VisitMut, *};
+use syn::{visit_mut::VisitMut, spanned::Spanned, *};
 
 macro_rules! identity_proc_macro_attribute {
     ($($name:ident,)*) => {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,9 +49,9 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let lit_str = parse_macro_input!(attr as LitStr);
-    let payload = format!(r#"Pre-Condition: {}"#, lit_str.value());
-    let payload = LitStr::new(&payload, lit_str.span());
+    let phi: syn::Expr = parse_macro_input!(attr);
+    let payload = format!(r#"Pre-Condition: {:#?}"#, phi);
+    let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]
         #item
@@ -64,9 +64,9 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let lit_str = parse_macro_input!(attr as LitStr);
-    let payload = format!(r#"Post-Condition: {}"#, lit_str.value());
-    let payload = LitStr::new(&payload, lit_str.span());
+    let phi: syn::Expr = parse_macro_input!(attr);
+    let payload = format!(r#"Post-Condition: {:#?}"#, phi);
+    let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]
         #item

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,10 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Pre-Condition: ``` {} ```"#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: 
+```
+{} 
+```"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
@@ -64,7 +67,10 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: ``` {} ```\"#, attr.clone().to_string());
+    let payload = format!(r#"Post-Condition: 
+``` 
+{} 
+```"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,9 +49,10 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr);
-    let payload = format!(r#"Pre-Condition: {:#?}"#, phi);
-    let payload = LitStr::new(&payload, phi.span());
+    let payload = format!(r#"Post-Condition: {}"#, pm.to_string());
+//    let phi: syn::Expr = parse_macro_input!(attr);
+//    let payload = format!(r#"Pre-Condition: {:#?}"#, phi);
+    let payload = LitStr::new(&payload, attr.span());
     quote! {
         #[doc=#payload]
         #item
@@ -64,9 +65,8 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr);
-    let payload = format!(r#"Post-Condition: {:#?}"#, phi);
-    let payload = LitStr::new(&payload, phi.span());
+    let payload = format!(r#"Post-Condition: {}"#, pm.to_string());
+    let payload = LitStr::new(&payload, attr.span());
     quote! {
         #[doc=#payload]
         #item

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,7 +49,7 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Pre-Condition: {}\"#, attr.clone().to_string());
+    let payload = format!(r#"Pre-Condition: {}"#, attr.clone().to_string());
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -19,6 +19,7 @@ macro_rules! identity_proc_macro_attribute {
 }
 
 identity_proc_macro_attribute!(
+    decreases,
     fstar_options,
     fstar_verification_status,
     include,
@@ -42,7 +43,6 @@ identity_proc_macro_attribute!(
     fstar_after,
     coq_after,
     proverif_after,
-    decreases,
 );
 
 

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,8 +49,8 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr.clone());
-    let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
+    let payload = format!(r#"Post-Condition: {}"#, attr.clone().to_string());
+    let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]
@@ -64,8 +64,8 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let phi: syn::Expr = parse_macro_input!(attr.clone());
-    let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
+    let payload = format!(r#"Post-Condition: {}"#, attr.clone().to_string());
+    let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -42,7 +42,7 @@ identity_proc_macro_attribute!(
     fstar_after,
     coq_after,
     proverif_after,
-    decreases
+    decreases,
 );
 
 

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -53,7 +53,7 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
     let phi: syn::Expr = parse_macro_input!(attr);
     let payload = LitStr::new(&payload, phi.span());
     quote! {
-        #payload]
+        #payload
         #item
     }
     .into()

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -49,10 +49,9 @@ identity_proc_macro_attribute!(
 #[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}"#, pm.to_string());
-//    let phi: syn::Expr = parse_macro_input!(attr);
-//    let payload = format!(r#"Pre-Condition: {:#?}"#, phi);
-    let payload = LitStr::new(&payload, attr.span());
+    let phi: syn::Expr = parse_macro_input!(attr);
+    let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
+    let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]
         #item
@@ -65,8 +64,9 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 #[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
-    let payload = format!(r#"Post-Condition: {}"#, pm.to_string());
-    let payload = LitStr::new(&payload, attr.span());
+    let phi: syn::Expr = parse_macro_input!(attr);
+    let payload = format!(r#"Post-Condition: {}"#, attr.to_string());
+    let payload = LitStr::new(&payload, phi.span());
     quote! {
         #[doc=#payload]
         #item

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -253,9 +253,6 @@ pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     quote! { #attr #NeverErased #item }.into()
 }
 
-/*
-TODO: this is disabled for now, we need `dyn` types (see issue #296)
-
 /// Provide a measure for a function: this measure will be used once
 /// extracted in a backend for checking termination. The expression
 /// that decreases can be of any type. (TODO: this is probably as it
@@ -288,7 +285,6 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
     );
     quote! {#requires #attr #item}.into()
 }
-*/
 
 /// Add a logical precondition to a function.
 // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -277,7 +277,7 @@ pub fn make_fn_decoration(
                 sig.generics = merge_generics(generics, sig.generics);
             }
             sig.output = if let FnDecorationKind::Decreases = &kind {
-                syn::parse_quote! { -> usize }
+                syn::parse_quote! { -> hax_lib::int::Int }
             } else {
                 syn::parse_quote! { -> bool }
             };

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -277,7 +277,7 @@ pub fn make_fn_decoration(
                 sig.generics = merge_generics(generics, sig.generics);
             }
             sig.output = if let FnDecorationKind::Decreases = &kind {
-                syn::parse_quote! { -> Box<dyn Any> }
+                syn::parse_quote! { -> usize }
             } else {
                 syn::parse_quote! { -> bool }
             };
@@ -285,12 +285,7 @@ pub fn make_fn_decoration(
         };
         let uid_attr = AttrPayload::Uid(uid.clone());
         let late_skip = &AttrPayload::ItemStatus(ItemStatus::Included { late_skip: true });
-        let any_trait = if let FnDecorationKind::Decreases = &kind {
-            phi = parse_quote! {Box::new(#phi)};
-            quote! {#AttrHaxLang #[allow(unused)] trait Any {} impl<T> Any for T {}}
-        } else {
-            quote! {}
-        };
+        let any_trait = quote! {};
         let quantifiers = if let FnDecorationKind::Decreases = &kind {
             None
         } else {

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -2,8 +2,8 @@
 //! proc-macro crate cannot export anything but procedural macros.
 
 pub use hax_lib_macros::{
-    attributes, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant, opaque,
-    opaque_type, refinement_type, requires, decreases, trait_fn_decoration, transparent,
+    attributes, decreases, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant,
+    opaque, opaque_type, refinement_type, requires, trait_fn_decoration, transparent,
 };
 
 pub use hax_lib_macros::{

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -3,7 +3,7 @@
 
 pub use hax_lib_macros::{
     attributes, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant, opaque,
-    opaque_type, refinement_type, requires, trait_fn_decoration, transparent,
+    opaque_type, refinement_type, requires, decreases, trait_fn_decoration, transparent,
 };
 
 pub use hax_lib_macros::{


### PR DESCRIPTION
Show pre- and post-conditions on rust docs and in VS code.
Does not yet work on methods inside impl and trait.

As a drive-by fix, this also enables `decreases` clauses on functions.
