### PR TITLE
full_def: group generic and predicates into a common struct

### DIFF
--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -118,11 +118,11 @@ pub fn translate_span(span: rustc_span::Span, sess: &rustc_session::Session) -> 
     }
 }
 
-pub trait ParamEnv<'tcx> {
+pub trait HasParamEnv<'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx>;
 }
 
-impl<'tcx, S: UnderOwnerState<'tcx>> ParamEnv<'tcx> for S {
+impl<'tcx, S: UnderOwnerState<'tcx>> HasParamEnv<'tcx> for S {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.base().tcx.param_env(self.owner_id())
     }

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -50,7 +50,15 @@ pub fn predicates_defined_on(tcx: TyCtxt<'_>, def_id: DefId) -> GenericPredicate
     result
 }
 
-/// The predicates that must hold to mention this item.
+/// The predicates that must hold to mention this item. E.g.
+///
+/// ```ignore
+/// // `U: OtherTrait` is required, `Self: Sized` is implied.
+/// trait Trait<U: OtherTrait>: Sized {
+///     // `T: Clone` is required, `Self::Type<T>: Debug` is implied.
+///     type Type<T: Clone>: Debug;
+/// }
+/// ```
 pub fn required_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPredicates<'tcx> {
     use DefKind::*;
     match tcx.def_kind(def_id) {
@@ -86,7 +94,15 @@ pub fn self_predicate<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> PolyTraitRef<'t
 
 /// The predicates that can be deduced from the presence of this item in a signature. We only
 /// consider predicates implied by traits here, not implied bounds such as `&'a T` implying `T:
-/// 'a`.
+/// 'a`. E.g.
+///
+/// ```ignore
+/// // `U: OtherTrait` is required, `Self: Sized` is implied.
+/// trait Trait<U: OtherTrait>: Sized {
+///     // `T: Clone` is required, `Self::Type<T>: Debug` is implied.
+///     type Type<T: Clone>: Debug;
+/// }
+/// ```
 pub fn implied_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPredicates<'tcx> {
     use DefKind::*;
     let parent = tcx.opt_parent(def_id);

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -813,7 +813,7 @@ fn normalize_trait_clauses<'tcx, S: UnderOwnerState<'tcx>>(
                     .try_normalize_erasing_regions(s.param_env(), clause)
                     .unwrap_or(clause);
             }
-            (clause.as_predicate(), *span)
+            (clause, *span)
         })
         .collect();
     GenericPredicates {

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -817,7 +817,6 @@ fn normalize_trait_clauses<'tcx, S: UnderOwnerState<'tcx>>(
         })
         .collect();
     GenericPredicates {
-        parent: predicates.parent.sinto(s),
         predicates: clauses.sinto(s),
     }
 }

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1219,7 +1219,6 @@ impl<T> Binder<T> {
 #[derive_group(Serializers)]
 #[derive(Clone, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenericPredicates {
-    pub parent: Option<DefId>,
     #[value(self.predicates.iter().map(|x| x.sinto(s)).collect())]
     pub predicates: Vec<(Clause, Span)>,
 }

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1220,9 +1220,8 @@ impl<T> Binder<T> {
 #[derive(Clone, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GenericPredicates {
     pub parent: Option<DefId>,
-    // FIXME: Switch from `Predicate` to `Clause` (will require correct handling of binders).
-    #[value(self.predicates.iter().map(|(clause, span)| (clause.as_predicate().sinto(s), span.sinto(s))).collect())]
-    pub predicates: Vec<(Predicate, Span)>,
+    #[value(self.predicates.iter().map(|x| x.sinto(s)).collect())]
+    pub predicates: Vec<(Clause, Span)>,
 }
 
 #[cfg(feature = "rustc")]


### PR DESCRIPTION
Since they always come together, grouping them makes things a bit more consistent. In fact we were getting confused about GAT predicates, which this clarifies.