### PR TITLE
Avoid an ICE by matching on type earlier

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -632,49 +632,49 @@ mod rustc {
         span: rustc_span::Span,
     ) -> ConstantExpr {
         let tcx = s.base().tcx;
-
-        let dc = tcx
-            .try_destructure_mir_constant_for_user_output(val, ty)
-            .s_unwrap(s);
-
-        // Iterate over the fields, which should be values
-        // Below: we are mutually recursive with [const_value_to_constant_expr],
-        // which takes a [Const] as input, but it should be
-        // ok because we call it on a strictly smaller value.
-        let fields = dc
-            .fields
-            .iter()
-            .copied()
-            .map(|(val, ty)| const_value_to_constant_expr(s, ty, val, span));
-
-        // The type should be tuple
-        let hax_ty: Ty = ty.sinto(s);
         match ty.kind() {
-            ty::TyKind::Tuple(_) => {
-                assert!(dc.variant.is_none());
-                let fields = fields.collect();
-                ConstantExprKind::Tuple { fields }
+            ty::TyKind::Tuple(_) | ty::TyKind::Adt(..) => {
+                let dc = tcx
+                    .try_destructure_mir_constant_for_user_output(val, ty)
+                    .s_unwrap(s);
+
+                // Iterate over the fields, which should be values
+                // Below: we are mutually recursive with [const_value_to_constant_expr],
+                // which takes a [Const] as input, but it should be
+                // ok because we call it on a strictly smaller value.
+                let fields = dc
+                    .fields
+                    .iter()
+                    .copied()
+                    .map(|(val, ty)| const_value_to_constant_expr(s, ty, val, span));
+
+                let kind = match ty.kind() {
+                    ty::TyKind::Tuple(_) => {
+                        assert!(dc.variant.is_none());
+                        let fields = fields.collect();
+                        ConstantExprKind::Tuple { fields }
+                    }
+                    ty::TyKind::Adt(adt_def, ..) => {
+                        let variant = dc.variant.unwrap_or(rustc_target::abi::FIRST_VARIANT);
+                        let variants_info = get_variant_information(adt_def, variant, s);
+                        let fields = fields
+                            .zip(&adt_def.variant(variant).fields)
+                            .map(|(value, field)| ConstantFieldExpr {
+                                field: field.did.sinto(s),
+                                value,
+                            })
+                            .collect();
+                        ConstantExprKind::Adt {
+                            info: variants_info,
+                            fields,
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+                kind.decorate(ty.sinto(s), span.sinto(s))
             }
-            ty::TyKind::Adt(adt_def, ..) => {
-                let variant = dc.variant.unwrap_or(rustc_target::abi::FIRST_VARIANT);
-                let variants_info = get_variant_information(adt_def, variant, s);
-                let fields = fields
-                    .zip(&adt_def.variant(variant).fields)
-                    .map(|(value, field)| ConstantFieldExpr {
-                        field: field.did.sinto(s),
-                        value,
-                    })
-                    .collect();
-                ConstantExprKind::Adt {
-                    info: variants_info,
-                    fields,
-                }
-            }
-            _ => {
-                fatal!(s[span], "Expected the type to be tuple or adt: {:?}", val)
-            }
+            _ => fatal!(s[span], "Expected the type to be tuple or adt: {:?}", val),
         }
-        .decorate(hax_ty, span.sinto(s))
     }
 
     pub fn const_value_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(


### PR DESCRIPTION
This fixes an ICE on promoted MIR with some non-trivial constants (the `try_destructure_mir_constant_for_user_output` method panics for some values of `ty.kind()`).