### PR TITLE
 Not all evaluated MIR constants are byte strings

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -852,9 +852,10 @@ end) : EXPR = struct
       | Borrow arg ->
           Borrow { arg = constant_expr_to_expr arg; borrow_kind = Thir.Shared }
       | ConstRef { id } -> ConstRef { id }
-      | Cast _ | RawBorrow _ | TraitConst _ | FnPtr _ ->
+      | Cast _ | RawBorrow _ | TraitConst _ | FnPtr _ | Memory _ ->
           assertion_failure [ span ]
-            "constant_lit_to_lit: TraitConst | FnPtr | MutPtr"
+            "constant_lit_to_lit: TraitConst | FnPtr | RawBorrow | Cast | \
+             Memory"
       | Todo _ -> assertion_failure [ span ] "ConstantExpr::Todo"
     and constant_lit_to_lit (l : Thir.constant_literal) _span :
         Thir.lit_kind * bool =

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -871,8 +871,8 @@ end) : EXPR = struct
           match String.chop_prefix v ~prefix:"-" with
           | Some v -> (Float (v, Suffixed ty), true)
           | None -> (Float (v, Suffixed ty), false))
-      | Str (v, style) -> (Str (v, style), false)
-      | ByteStr (v, style) -> (ByteStr (v, style), false)
+      | Str v -> (Str (v, Cooked), false)
+      | ByteStr v -> (ByteStr (v, Cooked), false)
     and constant_field_expr ({ field; value } : Thir.constant_field_expr) :
         Thir.field_expr =
       { field; value = constant_expr_to_expr value }

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -562,27 +562,32 @@ mod rustc {
             (_, ty::Ref(_, inner_ty, _)) => {
                 ConstantExprKind::Borrow(valtree_to_constant_expr(s, valtree, *inner_ty, span))
             }
-            (ty::ValTree::Branch(valtrees), ty::Str) => ConstantExprKind::Literal(
-                ConstantLiteral::byte_str(valtrees.iter().map(|x| match x {
-                    ty::ValTree::Leaf(leaf) => leaf.to_u8(),
-                    _ => fatal!(s[span], "Expected a flat list of leaves while translating a str literal, got a arbitrary valtree.")
-                }).collect(), StrStyle::Cooked))
-                ,
+            (ty::ValTree::Branch(valtrees), ty::Str) => {
+                let bytes = valtrees
+                    .iter()
+                    .map(|x| match x {
+                        ty::ValTree::Leaf(leaf) => leaf.to_u8(),
+                        _ => fatal!(
+                            s[span],
+                            "Expected a flat list of leaves while translating \
+                            a str literal, got a arbitrary valtree."
+                        ),
+                    })
+                    .collect();
+                ConstantExprKind::Literal(ConstantLiteral::byte_str(bytes, StrStyle::Cooked))
+            }
             (ty::ValTree::Branch(_), ty::Array(..) | ty::Tuple(..) | ty::Adt(..)) => {
                 let contents: rustc_middle::ty::DestructuredConst = s
-                    .base().tcx
+                    .base()
+                    .tcx
                     .destructure_const(ty::Const::new_value(s.base().tcx, valtree, ty));
                 let fields = contents.fields.iter().copied();
                 match ty.kind() {
                     ty::Array(_, _) => ConstantExprKind::Array {
-                        fields: fields
-                            .map(|field| field.sinto(s))
-                            .collect(),
+                        fields: fields.map(|field| field.sinto(s)).collect(),
                     },
                     ty::Tuple(_) => ConstantExprKind::Tuple {
-                        fields: fields
-                            .map(|field| field.sinto(s))
-                            .collect(),
+                        fields: fields.map(|field| field.sinto(s)).collect(),
                     },
                     ty::Adt(def, _) => {
                         let variant_idx = contents
@@ -590,9 +595,10 @@ mod rustc {
                             .s_expect(s, "destructed const of adt without variant idx");
                         let variant_def = &def.variant(variant_idx);
 
-                        ConstantExprKind::Adt{
+                        ConstantExprKind::Adt {
                             info: get_variant_information(def, variant_idx, s),
-                            fields: fields.into_iter()
+                            fields: fields
+                                .into_iter()
                                 .zip(&variant_def.fields)
                                 .map(|(value, field)| ConstantFieldExpr {
                                     field: field.did.sinto(s),
@@ -611,12 +617,12 @@ mod rustc {
                 let usize_ty = rustc_middle::ty::Ty::new_usize(s.base().tcx).sinto(s);
                 let lit = ConstantLiteral::Int(ConstantInt::Uint(raw_address, uint_ty));
                 ConstantExprKind::Cast {
-                    source: ConstantExprKind::Literal(lit).decorate(usize_ty, span.sinto(s))
+                    source: ConstantExprKind::Literal(lit).decorate(usize_ty, span.sinto(s)),
                 }
             }
-            (ty::ValTree::Leaf(x), _) => ConstantExprKind::Literal (
-                scalar_int_to_constant_literal(s, x, ty)
-            ),
+            (ty::ValTree::Leaf(x), _) => {
+                ConstantExprKind::Literal(scalar_int_to_constant_literal(s, x, ty))
+            }
             _ => supposely_unreachable_fatal!(
                 s[span], "valtree_to_expr";
                 {valtree, ty}


### PR DESCRIPTION
We incorrectly fell back to `ByteStr` for evaluated constants but that's unfortunately wildly incorrect: with promoted_mir, most constants end up of that form. This just adds a new variant to catch this case.

Charon breakage is expected and fine since we're adding a variant.