### PR TITLE
mkdocs: add Maxime description

### DIFF
--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -9,5 +9,6 @@ authors:
     avatar: https://cryspen.com/images/lucas_hu1387702743353212719.jpg
   maxime:
     name: Maxime Buyse
+    description: Engineer
     avatar: https://cryspen.com/images/maxime_hu_8da610acc29fd826.png
     


### PR DESCRIPTION
Feel free to use a different description. But without a description it doesn't build.

We also need to file an issue that we apparently don't build the docs on CI and hence didn't notice that this failed.