### PR TITLE
fix(nix): MacOS: add rustc and libz dylib to `DYLD_LIBRARY_PATH`

### DIFF
--- a/cli/default.nix
+++ b/cli/default.nix
@@ -73,7 +73,13 @@ in stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     makeWrapper ${hax}/bin/cargo-hax $out/bin/cargo-hax \
-      --prefix PATH : ${lib.makeBinPath binaries}
+      --prefix PATH : ${lib.makeBinPath binaries} \
+      ${
+        if stdenv.hostPlatform.isDarwin then
+          "--suffix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libz rustc ]}"
+        else
+          ""
+      }
   '';
   meta.mainProgram = "cargo-hax";
   passthru = {

--- a/flake.nix
+++ b/flake.nix
@@ -204,9 +204,10 @@
             pkgs.rustup
           ];
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          DYLD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.libz rustc ];
         in {
           examples = pkgs.mkShell {
-            inherit inputsFrom LIBCLANG_PATH;
+            inherit inputsFrom LIBCLANG_PATH DYLD_LIBRARY_PATH;
             HACL_HOME = "${hacl-star}";
             shellHook = ''
               HAX_ROOT=$(git rev-parse --show-toplevel)
@@ -216,7 +217,7 @@
             packages = packages ++ [ fstar pkgs.proverif ];
           };
           default = pkgs.mkShell {
-            inherit packages inputsFrom LIBCLANG_PATH;
+            inherit packages inputsFrom LIBCLANG_PATH DYLD_LIBRARY_PATH;
             shellHook = ''
               echo "Commands available: $(ls ${utils}/bin | tr '\n' ' ')" 1>&2'';
           };


### PR DESCRIPTION
This PR fixes an issue of nix-built hax on darwin.
Some library were not resolved correctly.

Thanks Sebastian Ertel who raised the issue on the zulip (see https://hacspec.zulipchat.com/#narrow/channel/269544-general/topic/Hax.20on.20darwin).