### PR TITLE
fix(setup.sh): rustup 1.28

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -117,6 +117,9 @@ for binary in opam node rustup jq; do
 done
 ensure_node_is_recent_enough
 
+# Make sure the correct rust toolchain is installed
+rustup show active-toolchain || rustup toolchain install 
+
 if [ "$CLEANUP_WORKSPACE" = "on" ]; then
     cleanup_workspace
 fi


### PR DESCRIPTION
Since rustup 1.28, toolchains don't get installed automatically.

See https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html