### PR TITLE
ci(nix): use F* bin cache in mlkem.yml

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -26,6 +26,12 @@ jobs:
           path: hax
 
       - uses: DeterminateSystems/nix-installer-action@main
+      - name: Set up Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: fstar-nix-versions
+          push: false
+    
       - name: ⤵ Install hax
         run: |
           nix profile install ./hax


### PR DESCRIPTION
This PR uses cachix to get prebuilt F* binaries.