### PR TITLE
fix(engine/gen-printer): fixes #1294

### DIFF
--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -443,8 +443,8 @@ struct
         string "Notation" ^^ space ^^ string "\"'" ^^ name#p ^^ string "'\""
         ^^ space ^^ string ":=" ^^ space ^^ ty#p ^^ dot
 
-      method item'_Type_struct ~super:_ ~name ~generics ~tuple_struct:_
-          ~arguments =
+      method item'_Type_struct ~super:_ ~type_name:name ~constructor_name:_
+          ~generics ~tuple_struct:_ ~arguments =
         CoqNotation.record name#p generics#p [] (string "Type")
           (braces
              (nest 2

--- a/engine/lib/generic_printer/generic_printer_template.ml
+++ b/engine/lib/generic_printer/generic_printer_template.ml
@@ -238,8 +238,8 @@ struct
       method item'_Type_enum ~super:_ ~name:_ ~generics:_ ~variants:_ =
         default_document_for "item'_Type_enum"
 
-      method item'_Type_struct ~super:_ ~name:_ ~generics:_ ~tuple_struct:_
-          ~arguments:_ =
+      method item'_Type_struct ~super:_ ~type_name:_ ~constructor_name:_
+          ~generics:_ ~tuple_struct:_ ~arguments:_ =
         default_document_for "item'_Type_struct"
 
       method item'_Use ~super:_ ~path:_ ~is_external:_ ~rename:_ =


### PR DESCRIPTION
This PR changes the method of the generic printer `item'_Type_struct` so that it now takes two arguments `type_name` and `constructor_name`, instead of only one `name`.

That latter `name` was the type name. Now we also pass explicitely a constructor name.

The constructor and type name for a struct are different, although rendered in the same way in some backends. The rendering depends on the name policy chosen by the backend.