### PR TITLE
feat(engine/names): extend name policy expressivity

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident_render_sig.ml
+++ b/engine/lib/concrete_ident/concrete_ident_render_sig.ml
@@ -10,9 +10,15 @@ module type NAME_POLICY = sig
   val anonymous_field_transform : string -> string
   (** Transformation applied to anonymous tuple fields (i.e. [x.1]) *)
 
+  val named_field_prefix : [ `ConstructorName | `TypeName ] option
+  (** Should fields be prefixed? *)
+
   val prefix_struct_constructors_with_type : bool
   val prefix_enum_constructors_with_type : bool
   val prefix_union_constructors_with_type : bool
+  val struct_constructor_prefix : string option
+  val enum_constructor_prefix : string option
+  val union_constructor_prefix : string option
 end
 
 module Make (T : sig


### PR DESCRIPTION
This commit allows for a better control over name rendering.

This is useful for PR #1108.