### PR TITLE
feat(hax-lib): add support for `decreases` clauses in F*

### DIFF
--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -95,6 +95,7 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
 
     let _ = hax_lib::inline("");
     let _: () = hax_lib::inline_unsafe("");
+    let _: () = hax_lib::any_to_unit(());
     use hax_lib::{RefineAs, Refinement};
 
     fn refinements<T: Refinement + Clone, U: RefineAs<T>>(x: T, y: U) -> T {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -23,6 +23,7 @@ identity_proc_macro_attribute!(
     exclude,
     requires,
     ensures,
+    decreases,
     pv_handwritten,
     pv_constructor,
     protocol_messages,

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -253,9 +253,6 @@ pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     quote! { #attr #NeverErased #item }.into()
 }
 
-/*
-TODO: this is disabled for now, we need `dyn` types (see issue #296)
-
 /// Provide a measure for a function: this measure will be used once
 /// extracted in a backend for checking termination. The expression
 /// that decreases can be of any type. (TODO: this is probably as it
@@ -288,7 +285,6 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
     );
     quote! {#requires #attr #item}.into()
 }
-*/
 
 /// Add a logical precondition to a function.
 // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -265,7 +265,7 @@ pub fn make_fn_decoration(
                 sig.generics = merge_generics(generics, sig.generics);
             }
             sig.output = if let FnDecorationKind::Decreases = &kind {
-                syn::parse_quote! { -> Box<dyn Any> }
+                syn::parse_quote! { -> () }
             } else {
                 syn::parse_quote! { -> impl Into<::hax_lib::Prop> }
             };
@@ -273,11 +273,8 @@ pub fn make_fn_decoration(
         };
         let uid_attr = AttrPayload::Uid(uid.clone());
         let late_skip = &AttrPayload::ItemStatus(ItemStatus::Included { late_skip: true });
-        let any_trait = if let FnDecorationKind::Decreases = &kind {
-            phi = parse_quote! {Box::new(#phi)};
-            quote! {#AttrHaxLang #[allow(unused)] trait Any {} impl<T> Any for T {}}
-        } else {
-            quote! {}
+        if let FnDecorationKind::Decreases = &kind {
+            phi = parse_quote! {::hax_lib::any_to_unit(#phi)};
         };
         let quantifiers = if let FnDecorationKind::Decreases = &kind {
             None
@@ -295,7 +292,6 @@ pub fn make_fn_decoration(
             #late_skip
             const _: () = {
                 #quantifiers
-                #any_trait
                 #future
                 #uid_attr
                 #late_skip

--- a/hax-lib/src/implementation.rs
+++ b/hax-lib/src/implementation.rs
@@ -131,6 +131,14 @@ pub fn inline_unsafe<T>(_: &str) -> T {
     unreachable!()
 }
 
+/// Sink for any value into unit. This is used internally by hax to capture
+/// value of any type. Specifically, this is useful for the `decreases` clauses
+/// for the F* backend.
+#[doc(hidden)]
+pub fn any_to_unit<T>(_: T) -> () {
+    unreachable!()
+}
+
 /// A dummy function that holds a loop invariant.
 #[doc(hidden)]
 pub fn _internal_loop_invariant<T, R: Into<Prop>, P: FnOnce(T) -> R>(_: P) {}

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -2,8 +2,8 @@
 //! proc-macro crate cannot export anything but procedural macros.
 
 pub use hax_lib_macros::{
-    attributes, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant, opaque,
-    opaque_type, refinement_type, requires, trait_fn_decoration, transparent,
+    attributes, decreases, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant,
+    opaque, opaque_type, refinement_type, requires, trait_fn_decoration, transparent,
 };
 
 pub use hax_lib_macros::{

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -593,4 +593,11 @@ let after 2 = "example after 2"
 let after 3 = "example after 3"
 
 unfold let some_function _ = "hello from F*"
+
+let rec fib (x: usize) : Prims.Tot usize (decreases x) =
+  if x <=. mk_usize 2
+  then x
+  else
+    Core.Num.impl_usize__wrapping_add (fib (x -! mk_usize 1 <: usize) <: usize)
+      (fib (x -! mk_usize 2 <: usize) <: usize)
 '''

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -47,6 +47,15 @@ pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {
     }
 }
 
+#[hax::decreases(x)]
+fn fib(x: usize) -> usize {
+    if x <= 2 {
+        x
+    } else {
+        fib(x - 1).wrapping_add(fib(x - 2))
+    }
+}
+
 #[hax::attributes]
 pub struct Foo {
     pub x: u32,


### PR DESCRIPTION
This PR adds support for `#[hax_lib::decreases(e)]` in hax-lib and in the F* backend.
Most of the code was already there.

In `#[hax_lib::decreases(e)]`, `e` can be of any type.

Fixes https://github.com/cryspen/hax/issues/1233