### PR TITLE
Engine: import static items (but mutable ones), reject asm blocks

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1504,6 +1504,13 @@ and c_item_unwrapped ~ident ~type_only (item : Thir.item) : item list =
              params = [];
              safety = Safe;
            }
+  | Static (_, true, _) ->
+      unimplemented ~issue_id:1343 [ item.span ]
+        "Mutable static items are not supported."
+  | Static (_ty, false, body) ->
+      let name = Concrete_ident.of_def_id ~value:true (assert_item_def_id ()) in
+      let generics = { params = []; constraints = [] } in
+      mk (Fn { name; generics; body = c_body body; params = []; safety = Safe })
   | TyAlias (ty, generics) ->
       mk
       @@ TyAlias
@@ -1817,8 +1824,8 @@ and c_item_unwrapped ~ident ~type_only (item : Thir.item) : item list =
       ]
   | Union _ ->
       unimplemented ~issue_id:998 [ item.span ] "Union types: not supported"
-  | ExternCrate _ | Static _ | Macro _ | Mod _ | ForeignMod _ | GlobalAsm _
-  | TraitAlias _ ->
+  | ExternCrate _ | Macro _ | Mod _ | ForeignMod _ | GlobalAsm _ | TraitAlias _
+    ->
       mk NotImplementedYet
 
 let import_item ~type_only (item : Thir.item) :

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1824,8 +1824,10 @@ and c_item_unwrapped ~ident ~type_only (item : Thir.item) : item list =
       ]
   | Union _ ->
       unimplemented ~issue_id:998 [ item.span ] "Union types: not supported"
-  | ExternCrate _ | Macro _ | Mod _ | ForeignMod _ | GlobalAsm _ | TraitAlias _
-    ->
+  | GlobalAsm _ ->
+      unimplemented ~issue_id:1344 [ item.span ]
+        "Inline assembly blocks are not supported"
+  | ExternCrate _ | Macro _ | Mod _ | ForeignMod _ | TraitAlias _ ->
       mk NotImplementedYet
 
 let import_item ~type_only (item : Thir.item) :

--- a/test-harness/src/snapshots/toolchain__statics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__statics into-fstar.snap
@@ -1,0 +1,38 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: statics
+    manifest: statics/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: false
+      stdout: true
+    include_flag: ~
+    backend_options: ~
+---
+exit = 0
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Statics.fst" = '''
+module Statics
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let v_FOO: usize = mk_usize 0
+
+let get_foo (_: Prims.unit) : usize = v_FOO
+'''

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -907,6 +907,10 @@ name = "slices"
 version = "0.1.0"
 
 [[package]]
+name = "statics"
+version = "0.1.0"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,5 +37,6 @@ members = [
         "cyclic-modules",
         "unsafe",
         "constructor-as-closure",
+        "statics",
 ]
 resolver = "2"

--- a/tests/statics/Cargo.toml
+++ b/tests/statics/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "statics"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.hax-tests]
+into."fstar" = { snapshot = "stdout" }

--- a/tests/statics/src/lib.rs
+++ b/tests/statics/src/lib.rs
@@ -1,0 +1,5 @@
+static FOO: usize = 0;
+
+fn get_foo() -> usize {
+    FOO
+}


### PR DESCRIPTION
This PR:
 - reject explicitly mutable static items
 - reject explicitly asm blocks
 - imports static items (as constants, essentially). This is OK since hax cannot hanlde interior mutability anyway. Pure static items behave just as constants.

Fixes #1240
Fixes #1127 