### PR TITLE
fix(engine/fstar backend): subst self_ to self

### DIFF
--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -19,7 +19,7 @@ paste = { version = "1.0.15" }
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "visit-mut"] }
+syn = { version = "2.0", features = ["full", "visit", "visit-mut"] }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -126,6 +126,19 @@ class t_T (v_Self: Type0) = {
   f_v:x0: v_Self -> Prims.Pure v_Self (f_v_pre x0) (fun result -> f_v_post x0 result)
 }
 '''
+"Attributes.Issue_1276_.fst" = '''
+module Attributes.Issue_1276_
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_S = | S : u8 -> t_S
+
+let impl_S__f (self: t_S) (self_ self_0_ self_1_ self_2_: u8)
+    : Prims.Pure Prims.unit
+      (requires self._0 =. mk_u8 0 && self_ =. self_1_ && self_2_ =. mk_u8 9)
+      (fun _ -> Prims.l_True) = ()
+'''
 "Attributes.Nested_refinement_elim.fst" = '''
 module Attributes.Nested_refinement_elim
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -434,3 +434,13 @@ mod props {
         !(p | y).implies(forall(|x: u8| x <= u8::MAX) & exists(|x: u16| x > 300))
     }
 }
+
+mod issue_1276 {
+    struct S(pub u8);
+
+    #[hax_lib::attributes]
+    impl S {
+        #[hax_lib::requires(self.0 == 0 && self_ == self_1 && self_2 == 9)]
+        fn f(&self, self_: u8, self_0: u8, self_1: u8, self_2: u8) {}
+    }
+}


### PR DESCRIPTION
    fix(engine/F*): `self_` -> `self` for clauses of methods

    Consider the following piece of code:
    ```rust
    struct S(pub  u8);

    impl S {
        #[hax_lib::requires(self.0 == 0)]
        fn f(&self) {}
    }
    ```

    The `requires` annotation produces a standalone function that looks like the following:

    ```rust
    fn requires(self_: S) -> bool {
        self_.0 == 0
    }
    ```

    Here, we can't use `self`: this is a reserved keyword in Rust, and we are not in a `impl` context.
    Thus, the macro renames `self` into `self_`.
    The bug described in #1276 comes from this renaming not being reverted in the engine.

    With this commit, when the F* backend inteprets
    such clauses, if the function on which a clause
    exists have a `self` as first argument, we now
    substitute the first argument of the clause
    function to replace it with the first argument of
    the original function.
    In the example above, we replace `self_` with `self`.

    This PR also improves the macro to always pick a fresh name, not always `self_`.
