### PR TITLE
fix(engine) Avoid replacing 'let rec' in interfaces.

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1740,13 +1740,16 @@ let string_of_items ~mod_name ~bundles (bo : BackendOptions.t) m items :
           |> String.concat ~sep:"")
         ^ "\n\n"
   in
-  let map_string ~f (str, space) =
-    ((match str with `Impl s -> `Impl (f s) | `Intf s -> `Intf (f s)), space)
+  let map_string ~f ?(map_intf = true) (str, space) =
+    ( (match str with
+      | `Impl s -> `Impl (f s)
+      | `Intf s -> `Intf (if map_intf then f s else s)),
+      space )
   in
   let replace_in_strs ~pattern ~with_ =
     List.map
       ~f:
-        (map_string ~f:(fun str ->
+        (map_string ~map_intf:false ~f:(fun str ->
              String.substr_replace_first ~pattern ~with_ str))
   in
 

--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -124,4 +124,15 @@ let impl_T2_for_u8: t_T2 u8 =
     f_d_post = (fun (_: Prims.unit) (out: Prims.unit) -> true);
     f_d = fun (_: Prims.unit) -> ()
   }
+
+assume
+val padlen': b: t_Slice u8 -> n: usize
+  -> Prims.Pure usize
+      (requires (Core.Slice.impl__len #u8 b <: usize) >=. n)
+      (ensures
+        fun out ->
+          let out:usize = out in
+          out <=. n)
+
+let padlen = padlen'
 '''

--- a/tests/cli/interface-only/src/lib.rs
+++ b/tests/cli/interface-only/src/lib.rs
@@ -91,3 +91,13 @@ impl T2 for u8 {
     #[hax_lib::requires(false)]
     fn d() {}
 }
+
+#[hax_lib::requires(b.len() >= n)]
+#[hax_lib::ensures(|out| out <= n)]
+fn padlen(b: &[u8], n: usize) -> usize {
+    if n > 0 && b[n - 1] == 0 {
+        1 + padlen(b, n - 1)
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
Fixes #1341 

That's a stupid bug. We replace `let` by `let rec` for recursive functions, but this substitution should be done only for the `fst`, not the `fsti`.