### PR TITLE
fix(hax-lib/assume): fixes assume and assert_prop

### DIFF
--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -817,24 +817,28 @@ macro_rules! make_quoting_proc_macro {
             #[proc_macro]
             pub fn [<$backend _expr>](payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Unit, payload).into();
-                quote!{
+                quote!{{
                     #[cfg([< hax_backend_ $backend >])]
                     {
                         #ts
                     }
-                }.into()
+                }}.into()
             }
 
             #[doc = concat!("The `Prop` version of `", stringify!($backend), "_expr`.")]
             #[proc_macro]
             pub fn [<$backend _prop_expr>](payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Prop, payload).into();
-                quote!{
+                quote!{{
                     #[cfg([< hax_backend_ $backend >])]
                     {
                         #ts
                     }
-                }.into()
+                    #[cfg(not([< hax_backend_ $backend >]))]
+                    {
+                        ::hax_lib::Prop::from_bool(true)
+                    }
+                }}.into()
             }
 
             #[doc = concat!("The unsafe (because polymorphic: even computationally relevant code can be inlined!) version of `", stringify!($backend), "_expr`.")]
@@ -842,12 +846,12 @@ macro_rules! make_quoting_proc_macro {
             #[doc(hidden)]
             pub fn [<$backend _unsafe_expr>](payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Anything, payload).into();
-                quote!{
+                quote!{{
                     #[cfg([< hax_backend_ $backend >])]
                     {
                         #ts
                     }
-                }.into()
+                }}.into()
             }
 
             make_quoting_item_proc_macro!($backend, [< $backend _before >], ItemQuotePosition::Before, [< hax_backend_ $backend >]);

--- a/hax-lib/src/implementation.rs
+++ b/hax-lib/src/implementation.rs
@@ -63,7 +63,7 @@ macro_rules! assert {
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assert!` only in
 /// appropriate situations.
-pub fn assert(_formula: bool) {}
+pub fn assert(_formula: impl Into<Prop>) {}
 
 #[macro_export]
 /// Assert a logical proposition [`Prop`]: this exists only in the backends of
@@ -73,7 +73,7 @@ macro_rules! assert_prop {
         {
             #[cfg(hax)]
             {
-                $crate::assert_prop($crate::Prop::from($($arg)*));
+                $crate::assert_prop($($arg)*);
             }
         }
     };
@@ -91,13 +91,13 @@ pub fn assert_prop(_formula: Prop) {}
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assume!` only in
 /// appropriate situations.
-pub fn assume(_formula: Prop) {}
+pub fn assume(_formula: impl Into<Prop>) {}
 
 #[cfg(hax)]
 #[macro_export]
 macro_rules! assume {
     ($formula:expr) => {
-        $crate::assume(Prop::from($formula))
+        $crate::assume($formula)
     };
 }
 

--- a/hax-lib/src/implementation.rs
+++ b/hax-lib/src/implementation.rs
@@ -63,7 +63,7 @@ macro_rules! assert {
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assert!` only in
 /// appropriate situations.
-pub fn assert(_formula: impl Into<Prop>) {}
+pub fn assert(_formula: bool) {}
 
 #[macro_export]
 /// Assert a logical proposition [`Prop`]: this exists only in the backends of
@@ -73,7 +73,7 @@ macro_rules! assert_prop {
         {
             #[cfg(hax)]
             {
-                $crate::assert_prop($($arg)*);
+                $crate::assert_prop(::hax_lib::Prop::from($($arg)*));
             }
         }
     };
@@ -91,13 +91,13 @@ pub fn assert_prop(_formula: Prop) {}
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assume!` only in
 /// appropriate situations.
-pub fn assume(_formula: impl Into<Prop>) {}
+pub fn assume(_formula: Prop) {}
 
 #[cfg(hax)]
 #[macro_export]
 macro_rules! assume {
     ($formula:expr) => {
-        $crate::assume($formula)
+        $crate::assume(::hax_lib::Prop::from($formula))
     };
 }
 

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -576,6 +576,12 @@ type t_Foo = {
   f_z:f_z: u32{b2t (((f_y +! f_x <: u32) +! f_z <: u32) >. mk_u32 3 <: bool)}
 }
 
+let props (_: Prims.unit) : Prims.unit =
+  let _:Prims.unit = Hax_lib.v_assume #Hax_lib.Prop.t_Prop True in
+  let _:Prims.unit = Hax_lib.assert_prop True in
+  let _:Prims.unit = () in
+  ()
+
 let inlined_code__v_V: u8 = mk_u8 12
 
 let before_inlined_code = "example before"

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -577,7 +577,7 @@ type t_Foo = {
 }
 
 let props (_: Prims.unit) : Prims.unit =
-  let _:Prims.unit = Hax_lib.v_assume #Hax_lib.Prop.t_Prop True in
+  let _:Prims.unit = Hax_lib.v_assume True in
   let _:Prims.unit = Hax_lib.assert_prop True in
   let _:Prims.unit = () in
   ()

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -75,6 +75,11 @@ impl Foo {
     fn h(&self) {}
 }
 
+fn props() {
+    hax_lib::assume!(hax_lib::fstar::prop!("True"));
+    hax_lib::assert_prop!(hax_lib::fstar::prop!("True"));
+}
+
 #[hax::attributes]
 mod refined_arithmetic {
     use core::ops::{Add, Mul};


### PR DESCRIPTION
This PR makes the following work:
```rust
fn props() {
    hax_lib::assume!(hax_lib::fstar::prop!("True"));
    hax_lib::assert_prop!(hax_lib::fstar::prop!("True"));
}
```