### PR TITLE
fix(hax-lib/dummy): intro `int!`

### DIFF
--- a/hax-lib/src/dummy.rs
+++ b/hax-lib/src/dummy.rs
@@ -61,6 +61,13 @@ pub trait RefineAs<RefinedType> {
 pub mod int {
     use core::ops::*;
 
+    #[macro_export]
+    macro_rules! int {
+        ($lit:expr) => {
+            Int($lit)
+        };
+    }
+
     #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
     pub struct Int(pub u8);
 


### PR DESCRIPTION
The dummy implementation of hax-lib was missing a `int!` macro. This commit adds such a (trivial) macro.