### PR TITLE
fix(hax-lib): allow `future(self)`

### DIFF
--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -48,6 +48,40 @@ let basically_a_constant (_: Prims.unit)
           let x:u8 = x in
           x >. mk_u8 100) = mk_u8 127
 '''
+"Attributes.Future_self.fst" = '''
+module Attributes.Future_self
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_Dummy = | Dummy : t_Dummy
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core.Marker.t_StructuralPartialEq t_Dummy
+
+let impl_1 = impl_1'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core.Cmp.t_PartialEq t_Dummy t_Dummy
+
+let impl_2 = impl_2'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl': Core.Cmp.t_Eq t_Dummy
+
+let impl = impl'
+
+let impl_Dummy__f (self: t_Dummy)
+    : Prims.Pure t_Dummy
+      Prims.l_True
+      (ensures
+        fun self_e_future ->
+          let self_e_future:t_Dummy = self_e_future in
+          self_e_future =. self) = self
+'''
 "Attributes.Inlined_code_ensures_requires.fst" = '''
 module Attributes.Inlined_code_ensures_requires
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -194,6 +194,17 @@ fn some_function() -> String {
     String::from("hello from Rust")
 }
 
+mod future_self {
+    #[derive(Eq, PartialEq)]
+    struct Dummy;
+
+    #[hax_lib::attributes]
+    impl Dummy {
+        #[hax_lib::ensures(|_| future(self) == self)]
+        fn f(&mut self) {}
+    }
+}
+
 mod replace_body {
     #[hax_lib::fstar::replace_body("magic ${x}")]
     fn f(x: u8, y: u8) -> u8 {


### PR DESCRIPTION
This commit allows us to write:
```rust
struct Dummy;

impl Dummy {
    #[hax_lib::ensures(|_| future(self) == self)]
    fn f(&mut self) {}
}
```

`RewriteSelf` was not taking into account the mutability or lifetime of `self` in function signature: this commit fixes that.