### PR TITLE
fix: update flake.lock

### DIFF
--- a/.github/workflows/flake_lock.yml
+++ b/.github/workflows/flake_lock.yml
@@ -1,0 +1,17 @@
+name: Make sure flake.lock is up-to-date
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  flake_lock_up_to_date:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - name: Lock flake
+      run: nix flake lock
+    - name: Diff `flake.lock`
+      run: git diff --exit-code flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -48,16 +48,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1705191588,
-        "narHash": "sha256-xjSWDP8mSjLcn+0hsRpEdzsBgBR+mKCZB8yLmHl+WqE=",
+        "lastModified": 1739895440,
+        "narHash": "sha256-QRZdyaHpVZafdk398yQ4LXmSrcqL/cQeYUBj9dwLDlQ=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "a32b316e521fa4f239b610ec8f1d15e78d62cbe8",
+        "rev": "4b3fc11774003a6ff7c09500ecb5f0145ca6d862",
         "type": "github"
       },
       "original": {
         "owner": "FStarLang",
-        "ref": "v2024.01.13",
+        "ref": "v2025.02.17",
         "repo": "FStar",
         "type": "github"
       }


### PR DESCRIPTION
PR #1361 updated flake.nix but not flake.lock, this yields an error in the playground.
This PR fixes the playground.

This PR also adds a CI job that checks for the lockfile to be up to date.