### PR TITLE
Correctly handle impl exprs for closures

### DIFF
--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -197,6 +197,36 @@ pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
     solve_item_traits_inner(s, generics, predicates)
 }
 
+/// Like `solve_item_required_traits`, but also includes predicates coming from the parent items.
+#[cfg(feature = "rustc")]
+#[tracing::instrument(level = "trace", skip(s), ret)]
+pub fn solve_item_and_parents_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    def_id: RDefId,
+    generics: ty::GenericArgsRef<'tcx>,
+) -> Vec<ImplExpr> {
+    fn accumulate<'tcx, S: UnderOwnerState<'tcx>>(
+        s: &S,
+        def_id: RDefId,
+        generics: ty::GenericArgsRef<'tcx>,
+        impl_exprs: &mut Vec<ImplExpr>,
+    ) {
+        let tcx = s.base().tcx;
+        use rustc_hir::def::DefKind::*;
+        match tcx.def_kind(def_id) {
+            AssocTy | AssocFn | AssocConst | Closure | Ctor(..) | Variant => {
+                let parent = tcx.parent(def_id);
+                accumulate(s, parent, generics, impl_exprs);
+            }
+            _ => {}
+        }
+        impl_exprs.extend(solve_item_required_traits(s, def_id, generics));
+    }
+    let mut impl_exprs = vec![];
+    accumulate(s, def_id, generics, &mut impl_exprs);
+    impl_exprs
+}
+
 /// Solve the trait obligations for implementing a trait (or for trait associated type bounds) in
 /// the current context.
 #[cfg(feature = "rustc")]

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1313,10 +1313,9 @@ impl ClosureArgs {
             parent_args: from.parent_args().sinto(s),
             // The solved predicates from the parent (i.e., the item which defines the closure).
             parent_trait_refs: {
-                // TODO: handle nested closures
                 let parent = tcx.generics_of(def_id).parent.unwrap();
                 let parent_generics_ref = tcx.mk_args(from.parent_args());
-                solve_item_required_traits(s, parent, parent_generics_ref)
+                solve_item_and_parents_required_traits(s, parent, parent_generics_ref)
             },
             tupled_sig: sig.sinto(s),
             untupled_sig: tcx


### PR DESCRIPTION
Closures inherit the predicates from their parent items, yet when solving these predicates we only took the first parent. This caused issues for closures inside impls and likely for closures inside closures.

Fixes https://github.com/AeneasVerif/charon/issues/627.