### PR TITLE
Switch to proc-macro-error2 because original is unmaintained.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "hax-lib",
  "hax-lib-macros-types",
  "paste",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -571,7 +571,7 @@ dependencies = [
 name = "hax-lib-protocol-macros"
 version = "0.2.0"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -1080,6 +1080,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/hax-lib-protocol-macros/Cargo.toml
+++ b/hax-lib-protocol-macros/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro-error = "1.0.4"
+proc-macro-error2 = { version = "2.0" }
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { version = "2.0", features = [

--- a/hax-lib-protocol-macros/src/lib.rs
+++ b/hax-lib-protocol-macros/src/lib.rs
@@ -105,7 +105,7 @@ pub fn init(
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn init_empty(
     attr: proc_macro::TokenStream,

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -13,7 +13,7 @@ description = "Hax-specific proc-macros for Rust programs"
 proc-macro = true
 
 [target.'cfg(hax)'.dependencies]
-proc-macro-error = { version = "1.0.4" }
+proc-macro-error2 = { version = "2.0" }
 hax-lib-macros-types = { workspace = true }
 paste = { version = "1.0.15" }
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -10,7 +10,7 @@ mod prelude {
     pub use crate::syn_ext::*;
     pub use proc_macro as pm;
     pub use proc_macro2::*;
-    pub use proc_macro_error::*;
+    pub use proc_macro_error2::*;
     pub use quote::*;
     pub use std::collections::HashSet;
     pub use syn::spanned::Spanned;
@@ -751,7 +751,7 @@ macro_rules! make_quoting_item_proc_macro {
                         r#impl: ident_str == "impl" || ident_str == "both",
                     });
                     if !matches!(ident_str.as_str(), "impl" | "both" | "interface") {
-                        proc_macro_error::abort!(
+                        proc_macro_error2::abort!(
                             ident.span(),
                             "Expected `impl`, `both` or `interface`"
                         );
@@ -931,7 +931,7 @@ pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::
     let mut item = parse_macro_input!(item as syn::ItemStruct);
 
     let syn::Fields::Unnamed(fields) = &item.fields else {
-        proc_macro_error::abort!(
+        proc_macro_error2::abort!(
             item.generics.span(),
             "Expected a newtype (a struct with one unnamed field), got one or more named field"
         );
@@ -939,14 +939,14 @@ pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::
     let paren_token = fields.paren_token;
     let fields = fields.unnamed.iter().collect::<Vec<_>>();
     let [field] = &fields[..] else {
-        proc_macro_error::abort!(
+        proc_macro_error2::abort!(
             item.generics.span(),
             "Expected a newtype (a struct with one unnamed field), got {} fields",
             fields.len()
         );
     };
     if !matches!(field.vis, syn::Visibility::Inherited) {
-        proc_macro_error::abort!(field.vis.span(), "This field was expected to be private");
+        proc_macro_error2::abort!(field.vis.span(), "This field was expected to be private");
     }
 
     let no_debug_assert = {
@@ -955,10 +955,10 @@ pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::
             (tokens.next(), tokens.next())
         {
             if ident.to_string() != "no_debug_runtime_check" {
-                proc_macro_error::abort!(ident.span(), "Expected 'no_debug_runtime_check'");
+                proc_macro_error2::abort!(ident.span(), "Expected 'no_debug_runtime_check'");
             }
             if comma.as_char() != ',' {
-                proc_macro_error::abort!(ident.span(), "Expected a comma");
+                proc_macro_error2::abort!(ident.span(), "Expected a comma");
             }
             attr = pm::TokenStream::from_iter(tokens);
             true

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -356,7 +356,7 @@ version = "0.2.0"
 dependencies = [
  "hax-lib-macros-types",
  "paste",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -384,7 +384,7 @@ dependencies = [
 name = "hax-lib-protocol-macros"
 version = "0.2.0"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -736,27 +736,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1015,12 +1013,6 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"


### PR DESCRIPTION
Fixes #1369, this replaces proc-macro-error by [proc-macro-error2](https://github.com/GnomedDev/proc-macro-error-2) which is a maintained fork.