### PR TITLE
Fix fstar quotes inside impls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+ "uuid",
 ]
 
 [[package]]

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -22,6 +22,7 @@ syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 syn = { version = "2.0", features = ["full", "visit", "visit-mut"] }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+uuid = { version = "1.5", features = ["v4"] }
 
 [dev-dependencies]
 hax-lib = { path = ".." }

--- a/hax-lib/macros/src/quote.rs
+++ b/hax-lib/macros/src/quote.rs
@@ -142,12 +142,14 @@ pub(super) fn item(
     let kind_attr = AttrPayload::ItemQuote(kind);
     let status_attr = AttrPayload::ItemStatus(ItemStatus::Included { late_skip: true });
     use AttrPayload::NeverErased;
+    let id = uuid::Uuid::new_v4().as_u128();
+    let name = format_ident!("_{}", id);
     quote! {
         #assoc_attr
         #item
         #attribute_to_inject
         #status_attr
-        const _: () = {
+        const #name: () = {
             #NeverErased
             #uid_attr
             #kind_attr

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -173,6 +173,30 @@ let impl_S__f (self: t_S) (self_ self_0_ self_1_ self_2_: u8)
       (requires self._0 =. mk_u8 0 && self_ =. self_1_ && self_2_ =. mk_u8 9)
       (fun _ -> Prims.l_True) = ()
 '''
+"Attributes.Issue_1315_.fst" = '''
+module Attributes.Issue_1315_
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_T = | T : u8 -> t_T
+
+#push-options "--admit_smt_queries true"
+
+let impl_T__f (_: Prims.unit) : Prims.unit = ()
+
+#pop-options
+
+let x = 1 in
+
+let impl_T__h (_: Prims.unit) : Prims.unit = ()
+
+#push-options "--admit_smt_queries true"
+
+let g (_: Prims.unit) : Prims.unit = ()
+
+#pop-options
+'''
 "Attributes.Nested_refinement_elim.fst" = '''
 module Attributes.Nested_refinement_elim
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+ "uuid",
 ]
 
 [[package]]

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -460,3 +460,16 @@ mod issue_1276 {
         fn f(&self, self_: u8, self_0: u8, self_1: u8, self_2: u8) {}
     }
 }
+
+mod issue_1315 {
+    struct T(u8);
+    #[hax_lib::attributes]
+    impl T {
+        #[hax_lib::fstar::verification_status(lax)]
+        fn f() {}
+        #[hax_lib::fstar::before("let x = 1 in")]
+        fn h() {}
+    }
+    #[hax_lib::fstar::verification_status(lax)]
+    fn g() {}
+}


### PR DESCRIPTION
Fixes #1315. Quote items are always named `_` which works outside impls, but gives an error inside impls. If we change the name to something else, we need it to be unique, otherwise rust complains about name clashes. I made a first version with uuids to generate unique identifiers, but we can switch to something simpler.