### PR TITLE
Remove AST printing in import_thir errors.

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -363,8 +363,7 @@ end) : EXPR = struct
         with Diagnostics.SpanFreeError.Exn _ -> U.hax_failure_typ
       in
       let span = Span.of_thir e.span in
-      U.hax_failure_expr' span typ (ctx, kind)
-        ([%show: Thir.decorated_for__expr_kind] e)
+      U.hax_failure_expr' span typ (ctx, kind) ""
 
   (** Extracts an expression as the global name `dropped_body`: this
       drops the computational part of the expression, but keeps a


### PR DESCRIPTION
Fixes #1370 

To elaborate on what was discussed in the issue, the AST printing happens only when the error is produced in `import_thir`. When the error is produced later, we have some pretty-printed Rust, which can be nice and should be compact enough to have no performance issue. So I think it makes sense to drop only the raw ASTs. I replaced it by an empty string, not sure if instead we can have something compact but useful out of a `Thir.decorated_for__expr_kind`.