### PR TITLE
Cut ASTs printed in errors when they are too long.

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -949,6 +949,16 @@ module Make (F : Features.T) = struct
     { span; typ = TStr; e = Literal (String s) }
 
   let hax_failure_expr' span (typ : ty) (context, kind) (ast : string) =
+    let ast =
+      (* Remove consecutive withe spaces *)
+      String.split ~on:' ' ast
+      |> List.filter ~f:(String.is_empty >> not)
+      |> String.concat ~sep:" "
+    in
+    let ast =
+      if String.length ast > 200 then String.sub ~pos:0 ~len:200 ast ^ "..."
+      else ast
+    in
     let error = Diagnostics.pretty_print_context_kind context kind in
     let args = List.map ~f:(string_lit span) [ error; ast ] in
     call Rust_primitives__hax__failure args span typ


### PR DESCRIPTION
This is a followup on #1388 

Seems like even pretty printed ASTs that result from errors in the different phases can get big. This was the case in the problem described by https://github.com/cryspen/hax/issues/1370#issuecomment-2769380136.

So we should also cut them to avoid big performance issues in the F* backend. I also added something to remove consecutive whitespaces. Indeed, the pretty-printed rust is formatted with indentation but placed in a string where new lines appear as `\n` so these consecutive whitespaces just make it harder to read.