### PR TITLE
Tell crane to keep references to the rust toolchain

### DIFF
--- a/cli/default.nix
+++ b/cli/default.nix
@@ -16,6 +16,7 @@ let
           || is-webapp-static-asset path);
     };
     inherit buildInputs doCheck;
+    doNotRemoveReferencesToRustToolchain = true;
   } // (if doCheck then {
     # [cargo test] builds independent workspaces. Each time another
     # workspace is added, it's corresponding lockfile should be added


### PR DESCRIPTION
Recent versions of crane scrape references to the rust toolchain in the compiled output, but we need them for dynamic linking. This opts out of that behavior.