### PR TITLE
Replace `paste` by `with_builtin_macros`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,11 +541,11 @@ version = "0.2.0"
 dependencies = [
  "hax-lib",
  "hax-lib-macros-types",
- "paste",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+ "with_builtin_macros",
 ]
 
 [[package]]
@@ -1948,6 +1948,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "with_builtin_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24deb3cd6e530e7617b12b1f0f1ce160a3a71d92feb351c4db5156d1d10e398a"
+dependencies = [
+ "with_builtin_macros-proc_macros",
+]
+
+[[package]]
+name = "with_builtin_macros-proc_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2259ae9b1285596f1ee52ce8f627013c65853d4d7f271cb10bfe2d048769804a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [target.'cfg(hax)'.dependencies]
 proc-macro-error2 = { version = "2.0" }
 hax-lib-macros-types = { workspace = true }
-paste = { version = "1.0.15" }
+with_builtin_macros = "0.1.0"
 syn = { version = "2.0", features = ["full", "visit-mut", "visit"] }
 
 [dependencies]

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -782,7 +782,7 @@ macro_rules! make_quoting_item_proc_macro {
 
 macro_rules! make_quoting_proc_macro {
     ($backend:ident) => {
-        paste::paste! {
+        with_builtin_macros::with_eager_expansions! {
             #[doc = concat!("Embed ", stringify!($backend), " expression inside a Rust expression. This macro takes only one argument: some raw ", stringify!($backend), " code as a string literal.")]
             ///
 
@@ -815,10 +815,10 @@ macro_rules! make_quoting_proc_macro {
 
             /// Types can be refered to with the syntax `$:{TYPE}`.
             #[proc_macro]
-            pub fn [<$backend _expr>](payload: pm::TokenStream) -> pm::TokenStream {
+            pub fn #{ concat_idents!($backend, _expr) }(payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Unit, payload).into();
                 quote!{{
-                    #[cfg([< hax_backend_ $backend >])]
+                    #[cfg(#{ concat_idents!(hax_backend_, $backend) })]
                     {
                         #ts
                     }
@@ -827,14 +827,14 @@ macro_rules! make_quoting_proc_macro {
 
             #[doc = concat!("The `Prop` version of `", stringify!($backend), "_expr`.")]
             #[proc_macro]
-            pub fn [<$backend _prop_expr>](payload: pm::TokenStream) -> pm::TokenStream {
+            pub fn #{ concat_idents!($backend, _prop_expr) }(payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Prop, payload).into();
                 quote!{{
-                    #[cfg([< hax_backend_ $backend >])]
+                    #[cfg(#{ concat_idents!(hax_backend_, $backend) })]
                     {
                         #ts
                     }
-                    #[cfg(not([< hax_backend_ $backend >]))]
+                    #[cfg(not(#{ concat_idents!(hax_backend_, $backend) }))]
                     {
                         ::hax_lib::Prop::from_bool(true)
                     }
@@ -844,32 +844,32 @@ macro_rules! make_quoting_proc_macro {
             #[doc = concat!("The unsafe (because polymorphic: even computationally relevant code can be inlined!) version of `", stringify!($backend), "_expr`.")]
             #[proc_macro]
             #[doc(hidden)]
-            pub fn [<$backend _unsafe_expr>](payload: pm::TokenStream) -> pm::TokenStream {
+            pub fn #{ concat_idents!($backend, _unsafe_expr) }(payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(quote::InlineExprType::Anything, payload).into();
                 quote!{{
-                    #[cfg([< hax_backend_ $backend >])]
+                    #[cfg(#{ concat_idents!(hax_backend_, $backend) })]
                     {
                         #ts
                     }
                 }}.into()
             }
 
-            make_quoting_item_proc_macro!($backend, [< $backend _before >], ItemQuotePosition::Before, [< hax_backend_ $backend >]);
-            make_quoting_item_proc_macro!($backend, [< $backend _after >], ItemQuotePosition::After, [< hax_backend_ $backend >]);
+            make_quoting_item_proc_macro!($backend, #{ concat_idents!($backend, _before) }, ItemQuotePosition::Before, #{ concat_idents!(hax_backend_, $backend) });
+            make_quoting_item_proc_macro!($backend, #{ concat_idents!($backend, _after) }, ItemQuotePosition::After, #{ concat_idents!(hax_backend_, $backend) });
 
             #[doc = concat!("Replaces a Rust item with some verbatim ", stringify!($backend)," code.")]
             #[proc_macro_error]
             #[proc_macro_attribute]
-            pub fn [< $backend _replace >](payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+            pub fn #{ concat_idents!($backend, _replace)}(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
                 let item: TokenStream = item.into();
                 let attr = AttrPayload::ItemStatus(ItemStatus::Included { late_skip: true });
-                [< $backend _before >](payload, quote!{#attr #item}.into())
+                #{ concat_idents!($backend, _before) }(payload, quote!{#attr #item}.into())
             }
 
             #[doc = concat!("Replaces the body of a Rust function with some verbatim ", stringify!($backend)," code.")]
             #[proc_macro_error]
             #[proc_macro_attribute]
-            pub fn [< $backend _replace_body >](payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+            pub fn #{ concat_idents!($backend, _replace_body)}(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
                 let payload: TokenStream = payload.into();
                 let item: ItemFn = parse_macro_input!(item);
                 let mut hax_item = item.clone();
@@ -879,10 +879,10 @@ macro_rules! make_quoting_proc_macro {
                     }
                 };
                 quote!{
-                    #[cfg([< hax_backend_ $backend >])]
+                    #[cfg(#{ concat_idents!(hax_backend_, $backend) })]
                     #hax_item
 
-                    #[cfg(not([< hax_backend_ $backend >]))]
+                    #[cfg(not(#{ concat_idents!(hax_backend_, $backend) }))]
                     #item
                 }.into()
             }

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -355,11 +355,11 @@ name = "hax-lib-macros"
 version = "0.2.0"
 dependencies = [
  "hax-lib-macros-types",
- "paste",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+ "with_builtin_macros",
 ]
 
 [[package]]
@@ -674,12 +674,6 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pattern-or"
@@ -1218,6 +1212,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "with_builtin_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24deb3cd6e530e7617b12b1f0f1ce160a3a71d92feb351c4db5156d1d10e398a"
+dependencies = [
+ "with_builtin_macros-proc_macros",
+]
+
+[[package]]
+name = "with_builtin_macros-proc_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2259ae9b1285596f1ee52ce8f627013c65853d4d7f271cb10bfe2d048769804a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #1379. 

I looked for a solution without introducing a new dependency. `concat_idents` seems like a good candidate but it doesn't work for function names as discussed in https://github.com/rust-lang/rust/issues/29599. So I replaced `paste` by [`with_builtin_macros`](https://crates.io/crates/with_builtin_macros) which builts on top of `concat_idents` to provide the functionality we need.