### PR TITLE
Put macro_metavar_expr_concat feature under hax cfg.

### DIFF
--- a/hax-lib/macros/src/lib.rs
+++ b/hax-lib/macros/src/lib.rs
@@ -1,7 +1,7 @@
 // Proc-macros must "reside in the root of the crate": whence the use
 // of `std::include!` instead of proper module declaration.
 
-#![feature(macro_metavar_expr_concat)]
+#![cfg_attr(hax, feature(macro_metavar_expr_concat))]
 
 #[cfg(hax)]
 std::include!("implementation.rs");


### PR DESCRIPTION
Follow-up on #1394. This fixes compilation using stable rust for crate that use `hax-lib`.