### PR TITLE
feat(backends/fstar): make `unfold` the opaque proxy functions

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1010,7 +1010,7 @@ struct
       [
         F.decl ~quals:[ Assumption ] ~fsti:false ~attrs
         @@ F.AST.Assume (name', ty);
-        F.decl ~fsti:false
+        F.decl ~quals:[ Unfold_for_unification_and_vcgen ] ~fsti:false
         @@ F.AST.TopLevelLet (NoLetQualifier, [ (F.pat @@ pat, term) ]);
       ]
     in

--- a/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
@@ -38,22 +38,26 @@ open FStar.Mul
 assume
 val t_OpaqueStruct': v_X: usize -> v_T: Type0 -> v_U: Type0 -> eqtype
 
+unfold
 let t_OpaqueStruct (v_X: usize) (v_T v_U: Type0) = t_OpaqueStruct' v_X v_T v_U
 
 assume
 val t_OpaqueEnum': v_X: usize -> v_T: Type0 -> v_U: Type0 -> eqtype
 
+unfold
 let t_OpaqueEnum (v_X: usize) (v_T v_U: Type0) = t_OpaqueEnum' v_X v_T v_U
 
 assume
 val ff_generic': v_X: usize -> #v_T: Type0 -> #v_U: Type0 -> x: v_U
   -> Prims.Pure (t_OpaqueEnum v_X v_T v_U) Prims.l_True (fun _ -> Prims.l_True)
 
+unfold
 let ff_generic (v_X: usize) (#v_T #v_U: Type0) = ff_generic' v_X #v_T #v_U
 
 assume
 val f': x: bool -> y: bool -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
 
+unfold
 let f = f'
 
 assume
@@ -65,34 +69,40 @@ val ff_pre_post': x: bool -> y: bool
           let result:bool = result in
           result =. y)
 
+unfold
 let ff_pre_post = ff_pre_post'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl_T_for_u8': t_T u8
 
+unfold
 let impl_T_for_u8 = impl_T_for_u8'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl_2': #v_U: Type0 -> {| i1: Core.Clone.t_Clone v_U |} -> t_TrGeneric i32 v_U
 
+unfold
 let impl_2 (#v_U: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Clone.t_Clone v_U) =
   impl_2' #v_U #i1
 
 assume
 val v_C': u8
 
+unfold
 let v_C = v_C'
 
 assume
 val impl_S1__ff_s1': Prims.unit -> Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
 
+unfold
 let impl_S1__ff_s1 = impl_S1__ff_s1'
 
 assume
 val impl_S2__ff_s2': Prims.unit -> Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
 
+unfold
 let impl_S2__ff_s2 = impl_S2__ff_s2'
 '''
 "Attribute_opaque.fsti" = '''

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -60,18 +60,21 @@ type t_Dummy = | Dummy : t_Dummy
 assume
 val impl_1': Core.Marker.t_StructuralPartialEq t_Dummy
 
+unfold
 let impl_1 = impl_1'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl_2': Core.Cmp.t_PartialEq t_Dummy t_Dummy
 
+unfold
 let impl_2 = impl_2'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl': Core.Cmp.t_Eq t_Dummy
 
+unfold
 let impl = impl'
 
 let impl_Dummy__f (self: t_Dummy)
@@ -130,12 +133,14 @@ unfold type t_Int = int
 assume
 val impl_1': Core.Clone.t_Clone t_Int
 
+unfold
 let impl_1 = impl_1'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl': Core.Marker.t_Copy t_Int
 
+unfold
 let impl = impl'
 
 unfold let add x y = x + y

--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -47,6 +47,7 @@ val f': x: u8
           let r:t_Array u8 (mk_usize 4) = r in
           (r.[ mk_usize 0 ] <: u8) >. x)
 
+unfold
 let f = f'
 
 type t_Bar = | Bar : t_Bar
@@ -58,6 +59,7 @@ type t_Bar = | Bar : t_Bar
 assume
 val impl': Core.Convert.t_From t_Bar Prims.unit
 
+unfold
 let impl = impl'
 
 /// If you need to drop the body of a method, please hoist it:
@@ -65,11 +67,13 @@ let impl = impl'
 assume
 val impl_1': Core.Convert.t_From t_Bar u8
 
+unfold
 let impl_1 = impl_1'
 
 assume
 val f_from__from': u8 -> t_Bar
 
+unfold
 let f_from__from = f_from__from'
 
 type t_Holder (v_T: Type0) = { f_value:Alloc.Vec.t_Vec v_T Alloc.Alloc.t_Global }
@@ -78,6 +82,7 @@ type t_Holder (v_T: Type0) = { f_value:Alloc.Vec.t_Vec v_T Alloc.Alloc.t_Global 
 assume
 val impl_2': #v_T: Type0 -> Core.Convert.t_From (t_Holder v_T) Prims.unit
 
+unfold
 let impl_2 (#v_T: Type0) = impl_2' #v_T
 
 type t_Param (v_SIZE: usize) = { f_value:t_Array u8 v_SIZE }
@@ -86,11 +91,13 @@ type t_Param (v_SIZE: usize) = { f_value:t_Array u8 v_SIZE }
 assume
 val impl_3': v_SIZE: usize -> Core.Convert.t_From (t_Param v_SIZE) Prims.unit
 
+unfold
 let impl_3 (v_SIZE: usize) = impl_3' v_SIZE
 
 assume
 val ff_generic': v_X: usize -> #v_U: Type0 -> e_x: v_U -> t_Param v_X
 
+unfold
 let ff_generic (v_X: usize) (#v_U: Type0) = ff_generic' v_X #v_U
 
 class t_T (v_Self: Type0) = {
@@ -134,5 +141,6 @@ val padlen': b: t_Slice u8 -> n: usize
           let out:usize = out in
           out <=. n)
 
+unfold
 let padlen = padlen'
 '''

--- a/test-harness/src/snapshots/toolchain__literals into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__literals into-fstar.snap
@@ -80,18 +80,21 @@ type t_Foo = { f_field:u8 }
 assume
 val impl': Core.Marker.t_StructuralPartialEq t_Foo
 
+unfold
 let impl = impl'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl_1': Core.Cmp.t_PartialEq t_Foo t_Foo
 
+unfold
 let impl_1 = impl_1'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
 val impl_2': Core.Cmp.t_Eq t_Foo
 
+unfold
 let impl_2 = impl_2'
 
 let v_CONSTANT: t_Foo = { f_field = mk_u8 3 } <: t_Foo


### PR DESCRIPTION
Consider:
```
fn f() {}
```

Before this commit we extracted to:
```
assume val f': Prims.unit -> Prims.unit
let f = f'
```

Now we extract to:
```
assume val f': Prims.unit -> Prims.unit
unfold let f = f'
```

This is a bit nicer to work with in F*. 

This is something that makes my life slightly easier with ML-DSA proofs.