### PR TITLE
feat(fstar/proof-libs): add a lemma for simplifying double casts

### DIFF
--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -169,7 +169,7 @@ let cast_mod (#t:inttype) (#t':inttype)
     (u1:int_t t) = 
     mk_int #t' (v u1 @%. t')
 
-#push-options "--split_queries always"
+#push-options "--split_queries always --z3rlimit 150 --z3version 4.13.3"
 /// Simplifies double casts when possible.
 /// For example, with `x` a i32, this lemma rewrites `x as i64 as i32` into `x`.
 let cast_identity_lemma

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -169,6 +169,17 @@ let cast_mod (#t:inttype) (#t':inttype)
     (u1:int_t t) = 
     mk_int #t' (v u1 @%. t')
 
+#push-options "--split_queries always"
+/// Simplifies double casts when possible.
+/// For example, with `x` a i32, this lemma rewrites `x as i64 as i32` into `x`.
+let cast_identity_lemma
+  (a: inttype) (b: inttype {bits b >= bits a})
+  (n: int_t a)
+  : Lemma (cast_mod #b #a (cast_mod #a #b n) == n)
+    [SMTPat (cast_mod #b #a (cast_mod #a #b n))]
+  = ()
+#pop-options
+
 /// Arithmetic operations
 /// 
 


### PR DESCRIPTION
This commit adds a lemma that rewrites `x as T as U` into `x` when `x` as type `T` and that `U` is an integer type bigger than `T`.