### PR TITLE
Typeclass for`BitAnd`; Instantiations for `Prims.bool`

### DIFF
--- a/proof-libs/fstar/core/Core.Ops.Bit.fsti
+++ b/proof-libs/fstar/core/Core.Ops.Bit.fsti
@@ -21,3 +21,12 @@ class t_BitAnd self rhs = {
   f_bitand: x:self -> y:rhs -> Pure f_Output (f_bitand_pre x y) (fun r -> f_bitand_post x y r);
 }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_bitxor_bool: Core.Ops.Bit.t_BitXor Prims.bool Prims.bool =
+  {
+    f_Output = Prims.bool;
+    f_bitxor_pre = (fun (self: Prims.bool) (rhs: Prims.bool) -> true);
+    f_bitxor_post = (fun (self: Prims.bool) (rhs: Prims.bool) (out: Prims.bool) -> (self <> rhs) = out );
+    f_bitxor = fun (self: Prims.bool) (rhs: Prims.bool) -> (self <> rhs) <: Prims.bool
+  }
+

--- a/proof-libs/fstar/core/Core.Ops.Bit.fsti
+++ b/proof-libs/fstar/core/Core.Ops.Bit.fsti
@@ -12,3 +12,12 @@ class t_BitXor self rhs = {
   f_bitxor_post: self -> rhs -> f_Output -> bool;
   f_bitxor: x:self -> y:rhs -> Pure f_Output (f_bitxor_pre x y) (fun r -> f_bitxor_post x y r);
 }
+
+class t_BitAnd self rhs = {
+  [@@@ Tactics.Typeclasses.no_method]
+  f_Output: Type;
+  f_bitand_pre: self -> rhs -> bool;
+  f_bitand_post: self -> rhs -> f_Output -> bool;
+  f_bitand: x:self -> y:rhs -> Pure f_Output (f_bitand_pre x y) (fun r -> f_bitand_post x y r);
+}
+

--- a/proof-libs/fstar/core/Core.Ops.Bit.fsti
+++ b/proof-libs/fstar/core/Core.Ops.Bit.fsti
@@ -30,3 +30,11 @@ let impl_bitxor_bool: Core.Ops.Bit.t_BitXor Prims.bool Prims.bool =
     f_bitxor = fun (self: Prims.bool) (rhs: Prims.bool) -> (self <> rhs) <: Prims.bool
   }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_bitand_bool: Core.Ops.Bit.t_BitAnd Prims.bool Prims.bool =
+  {
+    f_Output = Prims.bool;
+    f_bitand_pre = (fun (self: Prims.bool) (rhs: Prims.bool) -> true);
+    f_bitand_post = (fun (self: Prims.bool) (rhs: Prims.bool) (out: Prims.bool) -> (self && rhs) = out );
+    f_bitand = fun (self: Prims.bool) (rhs: Prims.bool) -> (self && rhs) <: Prims.bool
+  }


### PR DESCRIPTION
This PR adds a typeclass for the `core::ops::BitAnd` trait.

It also provides instantiations of the `BitAnd` and `BitXor` typeclasses for `Prims.bool`.