### PR TITLE
Use `ConstantExprKind::Todo` more

### DIFF
--- a/frontend/exporter/src/constant_utils/uneval.rs
+++ b/frontend/exporter/src/constant_utils/uneval.rs
@@ -374,9 +374,7 @@ fn op_to_const<'tcx, S: UnderOwnerState<'tcx>>(
                 _ => unreachable!(),
             }
         }
-        _ => {
-            fatal!(s[span], "Cannot convert constant back to an expression"; {op})
-        }
+        _ => ConstantExprKind::Todo("Unhandled type".into()),
     };
     let val = kind.decorate(ty.sinto(s), span.sinto(s));
     interp_ok(val)

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -270,7 +270,7 @@ fn translate_mir_const<'tcx, S: UnderOwnerState<'tcx>>(
             }
         }
         Const::Ty(_ty, c) => Value(c.sinto(s)),
-        Const::Unevaluated(ucv, _ty) => {
+        Const::Unevaluated(ucv, ty) => {
             use crate::rustc_middle::query::Key;
             let span = span.substitute_dummy(
                 tcx.def_ident_span(ucv.def)
@@ -288,7 +288,8 @@ fn translate_mir_const<'tcx, S: UnderOwnerState<'tcx>>(
                         Some(val) => val.sinto(s),
                         // TODO: This is triggered when compiling using `generic_const_exprs`. We
                         // might be able to get a MIR body from the def_id.
-                        None => supposely_unreachable_fatal!(s, "TranslateUneval"; {konst, ucv}),
+                        None => ConstantExprKind::Todo("TranslateUneval".into())
+                            .decorate(ty.sinto(s), span.sinto(s)),
                     },
                 }),
             }


### PR DESCRIPTION
Currently, hax frequently fails during constant evaluation -- in particular when closures are involved/when attempting to translate the std library. 
However, these constants are sometimes not needed in the end result: in our use case, we translate whole crates (std included) with [charon](https://github.com/AeneasVerif/charon), and symbolically execute the result; many of our tests fail, simply because hax panics on a constant that appears in a translated file, despite not being used. 
This PR gracefully falls back to `ConstantExprKind::Todo` on const evaluation failure or when hax doesn't know how to translate a constant; this allows the translation to progress, and for the end consumer to decide what to do with these.