### PR TITLE
fix(proof-libs): give a computable definition to `>>`

### DIFF
--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -294,8 +294,10 @@ unfold type shiftval (t:inttype) (t':inttype) =
 unfold type rotval (t:inttype) (t':inttype) =
      b:int_t t'{v b > 0 /\ v b < bits t}
 
-val shift_right (#t:inttype) (#t':inttype)
-    (a:int_t t) (b:shiftval t t') : int_t t 
+[@@"opaque_to_smt"]
+let shift_right (#t:inttype) (#t':inttype)
+    (a:int_t t) (b:shiftval t t') : int_t t
+    = v a / pow2 (v b)
 
 val shift_right_lemma (#t:inttype) (#t':inttype)
     (a:int_t t) (b:shiftval t t'):

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -294,10 +294,12 @@ unfold type shiftval (t:inttype) (t':inttype) =
 unfold type rotval (t:inttype) (t':inttype) =
      b:int_t t'{v b > 0 /\ v b < bits t}
 
+#push-options "--z3version 4.13.3"
 [@@"opaque_to_smt"]
 let shift_right (#t:inttype) (#t':inttype)
     (a:int_t t) (b:shiftval t t') : int_t t
     = mk_int #t (v a / pow2 (v b))
+#pop-options
 
 val shift_right_lemma (#t:inttype) (#t':inttype)
     (a:int_t t) (b:shiftval t t'):

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -297,7 +297,7 @@ unfold type rotval (t:inttype) (t':inttype) =
 [@@"opaque_to_smt"]
 let shift_right (#t:inttype) (#t':inttype)
     (a:int_t t) (b:shiftval t t') : int_t t
-    = v a / pow2 (v b)
+    = mk_int #t (v a / pow2 (v b))
 
 val shift_right_lemma (#t:inttype) (#t':inttype)
     (a:int_t t) (b:shiftval t t'):


### PR DESCRIPTION
Make `>>` unfoldable, but hide it to the SMT, to preserve the previous behavior when not normalizing.