### PR TITLE
fix(engine) Fix name clashes for functions defined in impl methods.

### DIFF
--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -71,10 +71,10 @@ unfold
 let impl_1 = impl_1'
 
 assume
-val f_from__from': u8 -> t_Bar
+val f_from__impl_1__from': u8 -> t_Bar
 
 unfold
-let f_from__from = f_from__from'
+let f_from__impl_1__from = f_from__impl_1__from'
 
 type t_Holder (v_T: Type0) = { f_value:Alloc.Vec.t_Vec v_T Alloc.Alloc.t_Global }
 

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -80,6 +80,48 @@ let ff_expand (_: Prims.unit) : Prims.unit =
   let _:Prims.unit = debug (mk_u32 1) a in
   debug (mk_u32 0) a
 '''
+"Naming.Functions_defined_in_trait_impls.fst" = '''
+module Naming.Functions_defined_in_trait_impls
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_A = | A : t_A
+
+let f_eq__impl__panic_cold_explicit (_: Prims.unit) : Rust_primitives.Hax.t_Never =
+  Core.Panicking.panic_explicit ()
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core.Cmp.t_PartialEq t_A t_A =
+  {
+    f_eq_pre = (fun (self: t_A) (other: t_A) -> true);
+    f_eq_post = (fun (self: t_A) (other: t_A) (out: bool) -> true);
+    f_eq
+    =
+    fun (self: t_A) (other: t_A) ->
+      Rust_primitives.Hax.never_to_any (f_eq__impl__panic_cold_explicit ()
+          <:
+          Rust_primitives.Hax.t_Never)
+  }
+
+type t_B = | B : t_B
+
+let f_eq__impl_1__panic_cold_explicit (_: Prims.unit) : Rust_primitives.Hax.t_Never =
+  Core.Panicking.panic_explicit ()
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core.Cmp.t_PartialEq t_B t_B =
+  {
+    f_eq_pre = (fun (self: t_B) (other: t_B) -> true);
+    f_eq_post = (fun (self: t_B) (other: t_B) (out: bool) -> true);
+    f_eq
+    =
+    fun (self: t_B) (other: t_B) ->
+      Rust_primitives.Hax.never_to_any (f_eq__impl_1__panic_cold_explicit ()
+          <:
+          Rust_primitives.Hax.t_Never)
+  }
+'''
 "Naming.fst" = '''
 module Naming
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/naming/src/lib.rs
+++ b/tests/naming/src/lib.rs
@@ -158,3 +158,22 @@ mod ambiguous_names {
 
 /// From issue https://github.com/hacspec/hax/issues/839
 fn string_shadows(string: &str, n: &str) {}
+
+/// From issue https://github.com/cryspen/hax/issues/1411
+mod functions_defined_in_trait_impls {
+    struct A;
+
+    impl PartialEq for A {
+        fn eq(&self, other: &Self) -> bool {
+            panic!()
+        }
+    }
+
+    struct B;
+
+    impl PartialEq for B {
+        fn eq(&self, other: &Self) -> bool {
+            panic!()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1411. The solution implemented here corresponds to what is described in https://github.com/cryspen/hax/issues/1411#issuecomment-2820386290