### PR TITLE
Add a fake `DefId` for promoted constants

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident_view.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view.ml
@@ -128,12 +128,12 @@ let rec poly :
           (match List.last_exn (Explicit_def_id.to_def_id did).path with
           | { data = GlobalAsm; disambiguator } -> into_d did disambiguator
           | _ -> broken_invariant "last path chunk to be GlobalAsm" did)
-    | TyParam | ConstParam | InlineConst | LifetimeParam | Closure
-    | SyntheticCoroutineBody ->
+    | TyParam | ConstParam | InlineConst | PromotedConst | LifetimeParam
+    | Closure | SyntheticCoroutineBody ->
         (* It should be impossible for such items to ever be referenced by anyting in hax. *)
         broken_invariant
-          "non (TyParam | ConstParam | InlineConst | LifetimeParam | Closure | \
-           SyntheticCoroutineBody) identifier"
+          "non (TyParam | ConstParam | InlineConst | PromotedConst | \
+           LifetimeParam | Closure | SyntheticCoroutineBody) identifier"
           did
   in
   result

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -67,6 +67,7 @@ fn def_path_item_to_str(path_item: DefPathItem) -> String {
         DefPathItem::Closure => "Closure".into(),
         DefPathItem::Ctor => "Ctor".into(),
         DefPathItem::AnonConst => "AnonConst".into(),
+        DefPathItem::PromotedConst => "PromotedConst".into(),
         DefPathItem::TypeNs(None) | DefPathItem::OpaqueTy => "OpaqueTy".into(),
     }
 }

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -364,7 +364,7 @@ let export_record = (fields, path, name) => {
     let record_expression = fields.map(([field, type, _doc], i) => {
         if (field == 'index' && name == 'def_id_contents') {
             // This is a hack to always parse Rust DefId indexes to `(0, 0)`
-            return 'index = Base.Int64.(zero, zero)';
+            return 'index = Base.Int64.(zero, zero, None)';
         }
         let p = [...path, 'field_' + field];
         let sub = mk_match('x', ocaml_arms_of_type_expr(type, p), p);

--- a/frontend/exporter/src/body.rs
+++ b/frontend/exporter/src/body.rs
@@ -30,6 +30,14 @@ mod module {
 
     pub trait IsBody: Sized + Clone + 'static {
         fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self;
+
+        /// Reuse a MIR body we already got. Panic if that's impossible.
+        fn from_mir<'tcx, S: UnderOwnerState<'tcx>>(
+            _s: &S,
+            _body: rustc_middle::mir::Body<'tcx>,
+        ) -> Self {
+            panic!("Can't convert MIR to the requested body type")
+        }
     }
 
     pub fn make_fn_def<'tcx, Body: IsBody, S: UnderOwnerState<'tcx>>(
@@ -67,6 +75,12 @@ mod module {
         use super::*;
         impl IsBody for () {
             fn body<'tcx, S: UnderOwnerState<'tcx>>(_did: RLocalDefId, _s: &S) -> Self {}
+            fn from_mir<'tcx, S: UnderOwnerState<'tcx>>(
+                _s: &S,
+                _body: rustc_middle::mir::Body<'tcx>,
+            ) -> Self {
+                ()
+            }
         }
         impl IsBody for ThirBody {
             fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self {
@@ -105,6 +119,20 @@ mod module {
                     ))
                 });
                 mir.s_unwrap(s)
+            }
+            fn from_mir<'tcx, S: UnderOwnerState<'tcx>>(
+                s: &S,
+                body: rustc_middle::mir::Body<'tcx>,
+            ) -> Self {
+                let body = Rc::new(body.clone());
+                let s = &State {
+                    base: s.base(),
+                    owner_id: s.owner_id(),
+                    mir: body.clone(),
+                    binder: (),
+                    thir: (),
+                };
+                body.sinto(s)
             }
         }
     }

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -136,13 +136,21 @@ mod types {
         type Value<Body: TypeMappable> = Arc<FullDef<Body>>;
     }
 
+    /// Defines a mapping from types to types, for use with `TypeMap`.
+    pub struct PromotedFullDefsMapper {}
+    impl TypeMapper for PromotedFullDefsMapper {
+        type Value<Body: TypeMappable> = HashMap<PromotedId, Arc<FullDef<Body>>>;
+    }
+
     /// Per-item cache
     #[derive(Default)]
     pub struct ItemCache<'tcx> {
         /// The translated `DefId`.
         pub def_id: Option<DefId>,
-        /// The translated definitions, generic in the body.
+        /// The translated definitions, generic in the Body kind.
         pub full_def: TypeMap<FullDefMapper>,
+        /// The Promoted constants of this body, if any.
+        pub promoteds: TypeMap<PromotedFullDefsMapper>,
         /// Cache the `Ty` translations.
         pub tys: HashMap<ty::Ty<'tcx>, Ty>,
         /// Cache the trait resolution engine for each item.

--- a/frontend/exporter/src/types/def_id.rs
+++ b/frontend/exporter/src/types/def_id.rs
@@ -197,7 +197,7 @@ impl std::fmt::Debug for DefId {
 impl std::fmt::Debug for DefId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Use the more legible rustc debug implementation.
-        write!(f, "{:?}", rustc_span::def_id::DefId::from(self))
+        write!(f, "{:?}", self.to_rust_def_id())
     }
 }
 
@@ -259,21 +259,6 @@ impl<'s, S: BaseState<'s>> SInto<S, DefId> for RDefId {
         let def_id = translate_def_id(s, *self);
         s.with_item_cache(*self, |cache| cache.def_id = Some(def_id.clone()));
         def_id
-    }
-}
-
-#[cfg(feature = "rustc")]
-impl From<&DefId> for RDefId {
-    fn from<'tcx>(def_id: &DefId) -> Self {
-        def_id.to_rust_def_id()
-    }
-}
-
-// Impl to be able to use hax's `DefId` for many rustc queries.
-#[cfg(feature = "rustc")]
-impl rustc_middle::query::IntoQueryParam<RDefId> for &DefId {
-    fn into_query_param(self) -> RDefId {
-        self.into()
     }
 }
 

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -442,9 +442,8 @@ pub enum ImplAssocItemValue<Body> {
 }
 
 impl<Body> FullDef<Body> {
-    #[cfg(feature = "rustc")]
-    pub fn rust_def_id(&self) -> RDefId {
-        (&self.def_id).into()
+    pub fn def_id(&self) -> &DefId {
+        &self.def_id
     }
 
     pub fn kind(&self) -> &FullDefKind<Body> {
@@ -503,7 +502,7 @@ impl<Body> FullDef<Body> {
         };
         // Add inherent impl items if any.
         let tcx = s.base().tcx;
-        for impl_def_id in tcx.inherent_impls(self.rust_def_id()) {
+        for impl_def_id in tcx.inherent_impls(self.def_id.to_rust_def_id()) {
             children.extend(
                 tcx.associated_items(impl_def_id)
                     .in_definition_order()

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -517,18 +517,7 @@ impl<Body> ImplAssocItem<Body> {
     }
 }
 
-/// Gets the kind of the definition.
-#[cfg(feature = "rustc")]
-pub fn get_def_kind<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: RDefId) -> RDefKind {
-    if def_id == rustc_span::def_id::CRATE_DEF_ID.to_def_id() {
-        // Horrible hack: without this, `def_kind` crashes on the crate root. Presumably some table
-        // isn't properly initialized otherwise.
-        let _ = tcx.def_span(def_id);
-    };
-    tcx.def_kind(def_id)
-}
-
-/// Gets the attributes of the definition.
+/// Gets the span of the definition.
 #[cfg(feature = "rustc")]
 pub fn get_def_span<'tcx>(
     tcx: ty::TyCtxt<'tcx>,

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -78,6 +78,8 @@ where
                 predicates: GenericPredicates { predicates: vec![] },
             };
             let body = get_promoted_mir(tcx, rust_def_id, promoted_id.as_rust_promoted_id());
+            source_span = Some(body.span);
+
             let ty: Ty = body.local_decls[rustc_middle::mir::Local::ZERO]
                 .ty
                 .sinto(&state_with_id);
@@ -88,7 +90,7 @@ where
                 body,
             };
 
-            source_span = None;
+            // None of these make sense for a promoted constant.
             attributes = Default::default();
             visibility = Default::default();
             lang_item = Default::default();

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -77,7 +77,7 @@ where
                 },
                 predicates: GenericPredicates { predicates: vec![] },
             };
-            let body = get_promoted_mir(s, rust_def_id, promoted_id.as_rust_promoted_id());
+            let body = get_promoted_mir(tcx, rust_def_id, promoted_id.as_rust_promoted_id());
             let ty: Ty = body.local_decls[rustc_middle::mir::Local::ZERO]
                 .ty
                 .sinto(&state_with_id);

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -647,6 +647,13 @@ pub struct TyGenerics {
     pub has_late_bound_regions: Option<Span>,
 }
 
+#[cfg(feature = "rustc")]
+impl TyGenerics {
+    pub(crate) fn count_total_params(&self) -> usize {
+        self.parent_count + self.params.len()
+    }
+}
+
 /// This type merges the information from
 /// `rustc_type_ir::AliasKind` and `ty::AliasTy`
 #[derive_group(Serializers)]

--- a/frontend/exporter/src/utils/type_map.rs
+++ b/frontend/exporter/src/utils/type_map.rs
@@ -34,6 +34,15 @@ impl<M: TypeMapper> TypeMap<M> {
             .map(|val: &mut Box<dyn TypeMappable>| &mut **val)
             .and_then(|val: &mut dyn TypeMappable| (val as &mut dyn Any).downcast_mut())
     }
+    pub fn or_default<T: TypeMappable>(&mut self) -> &mut M::Value<T>
+    where
+        M::Value<T>: Default,
+    {
+        if self.get::<T>().is_none() {
+            self.insert::<T>(Default::default());
+        }
+        self.get_mut().unwrap()
+    }
 
     pub fn insert<T: TypeMappable>(&mut self, val: M::Value<T>) -> Option<Box<M::Value<T>>> {
         self.data

--- a/test-harness/src/snapshots/toolchain__include-flag into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__include-flag into-coq.snap
@@ -58,7 +58,7 @@ Class t_Trait `{v_Self : Type} : Type :=
 Arguments t_Trait:clear implicits.
 Arguments t_Trait (_).
 
-Instance t_Trait_373159623 : t_Trait ((t_Foo)) :=
+Instance t_Trait_257736684 : t_Trait ((t_Foo)) :=
   {
   }.
 


### PR DESCRIPTION
Promoted constants have their own ad-hoc identifier scheme which is a `(DefId, u32)` pair. They would have a normal `DefId` if not for performance reasons (https://github.com/rust-lang/rust/pull/111693). To simplify Charon's life, this makes hax give a `DefId` to promoted constants, along with a `FullDef` when requested.