### PR TITLE
Barrett example tutorial

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -248,7 +248,7 @@ checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hax-bounded-integers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "duplicate",
  "hax-lib",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -266,11 +266,10 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hax-lib-macros-types",
- "paste",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -278,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -586,6 +585,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/examples/barrett/proofs/fstar/extraction/Makefile
+++ b/examples/barrett/proofs/fstar/extraction/Makefile
@@ -53,7 +53,7 @@ all:
 	rm -f .depend && $(MAKE) .depend
 	$(MAKE) verify
 
-HAX_CLI = "cargo hax into fstar --z3rlimit 1000"
+HAX_CLI = "cargo hax into fstar --z3rlimit 100"
 
 # If $HACL_HOME doesn't exist, clone it
 ${HACL_HOME}:

--- a/examples/barrett/src/lib.rs
+++ b/examples/barrett/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) const FIELD_MODULUS: i32 = 3329;
 /// `|result| ≤ FIELD_MODULUS / 2 · (|value|/BARRETT_R + 1)
 ///
 /// In particular, if `|value| < BARRETT_R`, then `|result| < FIELD_MODULUS`.
+#[hax_lib::fstar::options("--z3rlimit 100")]
 #[hax::requires((i64::from(value) >= -BARRETT_R && i64::from(value) <= BARRETT_R))]
 #[hax::ensures(|result| result > -FIELD_MODULUS && result < FIELD_MODULUS &&
                    result % FIELD_MODULUS == value % FIELD_MODULUS)]


### PR DESCRIPTION
This PR fixes https://github.com/cryspen/hax/issues/1421

It adds an explicit rlimit to the barrett example in the repo and the tutorial.
It also adds some text around the lemma call.

