### PR TITLE
feat(hax-lib&backend): F*: support for SMT patterns

### DIFF
--- a/engine/lib/attr_payloads.ml
+++ b/engine/lib/attr_payloads.ml
@@ -63,6 +63,7 @@ module AssocRole = struct
       | Requires
       | Ensures
       | Decreases
+      | SMTPat
       | Refine
       | ProcessRead
       | ProcessWrite
@@ -84,6 +85,7 @@ module AssocRole = struct
     | Requires -> Requires
     | Ensures -> Ensures
     | Decreases -> Decreases
+    | SMTPat -> SMTPat
     | Refine -> Refine
     | ItemQuote -> ItemQuote
     | ProcessRead -> ProcessRead

--- a/hax-lib/build.rs
+++ b/hax-lib/build.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 const FSTAR_EXTRA: &str = r"
 pub use hax_lib_macros::fstar_options as options;
 pub use hax_lib_macros::fstar_verification_status as verification_status;
+pub use hax_lib_macros::fstar_smt_pat as smt_pat;
 ";
 
 fn main() {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -46,6 +46,7 @@ identity_proc_macro_attribute!(
     fstar_after,
     coq_after,
     proverif_after,
+    fstar_smt_pat,
 );
 
 #[proc_macro]

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -317,6 +317,18 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
     quote! {#requires #attr #item}.into()
 }
 
+/// Allows to add SMT patterns to a lemma.
+/// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn fstar_smt_pat(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+    let phi: syn::Expr = parse_macro_input!(attr);
+    let item: FnLike = parse_macro_input!(item);
+    let (requires, attr) =
+        make_fn_decoration(phi, item.sig.clone(), FnDecorationKind::SMTPat, None, None);
+    quote! {#requires #attr #item}.into()
+}
+
 /// Add a logical precondition to a function.
 // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
 /// In the case of a function that has one or more `&mut` inputs, in

--- a/hax-lib/macros/types/src/lib.rs
+++ b/hax-lib/macros/types/src/lib.rs
@@ -54,6 +54,7 @@ pub enum AssociationRole {
     Requires,
     Ensures,
     Decreases,
+    SMTPat,
     Refine,
     /// A quoted piece of backend code to place after or before the
     /// extraction of the marked item

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -678,6 +678,11 @@ let add3_lemma (x: u32)
       x <=. mk_u32 10 || x >=. (u32_max /! mk_u32 3 <: u32) ||
       (add3 x x x <: u32) =. (x *! mk_u32 3 <: u32)) = ()
 
+let dummy_function (x: u32) : u32 = x
+
+let apply_dummy_function_lemma (x: u32) : Lemma (ensures x =. (dummy_function x <: u32)) [SMTPat x] =
+  ()
+
 type t_Foo = {
   f_x:u32;
   f_y:f_y: u32{b2t (f_y >. mk_u32 3 <: bool)};

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -38,6 +38,14 @@ mod ensures_on_arity_zero_fns {
 #[hax::lemma]
 fn add3_lemma(x: u32) -> Proof<{ x <= 10 || x >= u32_max / 3 || add3(x, x, x) == x * 3 }> {}
 
+fn dummy_function(x: u32) -> u32 {
+    x
+}
+
+#[hax::lemma]
+#[hax::fstar::smt_pat(x)]
+fn apply_dummy_function_lemma(x: u32) -> Proof<{ x == dummy_function(x) }> {}
+
 #[hax::exclude]
 pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {
     if c {


### PR DESCRIPTION
This PR adds support for SMT patterns in lemmas written in Rust.

For example:
```rust
fn dummy_function(x: u32) -> u32 {
    x
}

#[hax::lemma]
#[hax::fstar::smt_pat(x)]
fn apply_dummy_function_lemma(x: u32) -> Proof<{ x == dummy_function(x) }> {}
```