### PR TITLE
Translate evaluated closure constants

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -33,6 +33,7 @@ pub enum ConstantLiteral {
 #[derive(Clone, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ConstantExprKind {
     Literal(ConstantLiteral),
+    // Adts (structs, enums, unions) or closures.
     Adt {
         info: VariantInformations,
         fields: Vec<ConstantFieldExpr>,


### PR DESCRIPTION
That's the most common remaining constant-related failure. I still don't know how to translate evaluated constants of function pointer type, will have to poke at const eval some more.