### PR TITLE
Consistently translate impl exprs for parent items

### DIFF
--- a/frontend/exporter/src/constant_utils/uneval.rs
+++ b/frontend/exporter/src/constant_utils/uneval.rs
@@ -114,7 +114,7 @@ pub fn translate_constant_reference<'tcx>(
         if assoc.trait_item_def_id.is_some() {
             // This must be a trait declaration constant
             let name = assoc.name.to_string();
-            let impl_expr = self_clause_for_item(s, &assoc, ucv.args).unwrap();
+            let impl_expr = self_clause_for_item(s, ucv.def, ucv.args).unwrap();
             ConstantExprKind::TraitConst { impl_expr, name }
         } else {
             // Constant appearing in an inherent impl block.

--- a/frontend/exporter/src/constant_utils/uneval.rs
+++ b/frontend/exporter/src/constant_utils/uneval.rs
@@ -118,8 +118,7 @@ pub fn translate_constant_reference<'tcx>(
             ConstantExprKind::TraitConst { impl_expr, name }
         } else {
             // Constant appearing in an inherent impl block.
-            let parent_def_id = tcx.parent(ucv.def);
-            let trait_refs = solve_item_required_traits(s, parent_def_id, ucv.args);
+            let trait_refs = solve_item_required_traits(s, ucv.def, ucv.args);
             ConstantExprKind::GlobalName {
                 id: ucv.def.sinto(s),
                 generics: ucv.args.sinto(s),

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -185,10 +185,10 @@ pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
 }
 
 /// Solve the trait obligations for a specific item use (for example, a method call, an ADT, etc.)
-/// in the current context.
+/// in the current context. Does _not_ include impl exprs for parent items.
 #[cfg(feature = "rustc")]
 #[tracing::instrument(level = "trace", skip(s), ret)]
-pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
+pub fn solve_item_required_traits_no_parents<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
@@ -200,7 +200,7 @@ pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
 /// Like `solve_item_required_traits`, but also includes predicates coming from the parent items.
 #[cfg(feature = "rustc")]
 #[tracing::instrument(level = "trace", skip(s), ret)]
-pub fn solve_item_and_parents_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
+pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
@@ -220,7 +220,7 @@ pub fn solve_item_and_parents_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
             }
             _ => {}
         }
-        impl_exprs.extend(solve_item_required_traits(s, def_id, generics));
+        impl_exprs.extend(solve_item_required_traits_no_parents(s, def_id, generics));
     }
     let mut impl_exprs = vec![];
     accumulate(s, def_id, generics, &mut impl_exprs);

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -262,13 +262,13 @@ fn solve_item_traits_inner<'tcx, S: UnderOwnerState<'tcx>>(
 #[cfg(feature = "rustc")]
 pub fn self_clause_for_item<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
-    assoc: &rustc_middle::ty::AssocItem,
+    def_id: RDefId,
     generics: rustc_middle::ty::GenericArgsRef<'tcx>,
 ) -> Option<ImplExpr> {
     use rustc_middle::ty::EarlyBinder;
     let tcx = s.base().tcx;
 
-    let tr_def_id = tcx.trait_of_item(assoc.def_id)?;
+    let tr_def_id = tcx.trait_of_item(def_id)?;
     // The "self" predicate in the context of the trait.
     let self_pred = self_predicate(tcx, tr_def_id);
     // Substitute to be in the context of the current item.

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -76,9 +76,6 @@ pub fn required_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPre
         | TraitAlias
         | TyAlias
         | Union => predicates_defined_on(tcx, def_id),
-        // The tuple struct/variant constructor functions inherit the generics and predicates from
-        // their parents.
-        Variant | Ctor(..) => return required_predicates(tcx, tcx.parent(def_id)),
         // We consider all predicates on traits to be outputs
         Trait => Default::default(),
         // `predicates_defined_on` ICEs on other def kinds.

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -5,8 +5,6 @@
 use crate::prelude::*;
 #[cfg(feature = "rustc")]
 use rustc_middle::{mir, ty};
-#[cfg(feature = "rustc")]
-use tracing::trace;
 
 #[derive_group(Serializers)]
 #[derive(AdtInto, Clone, Debug, JsonSchema)]
@@ -342,53 +340,20 @@ pub struct Terminator {
 }
 
 #[cfg(feature = "rustc")]
-pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + HasOwnerId>(
+/// Compute the
+pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     def_id: rustc_hir::def_id::DefId,
     generics: rustc_middle::ty::GenericArgsRef<'tcx>,
 ) -> (DefId, Vec<GenericArg>, Vec<ImplExpr>, Option<ImplExpr>) {
-    let tcx = s.base().tcx;
-
     // Retrieve the trait requirements for the item.
     let trait_refs = solve_item_required_traits(s, def_id, generics);
 
+    // If this is a trait method call, retreive the impl expr information for that trait.
     // Check if this is a trait method call: retrieve the trait source if
-    // it is the case (i.e., where does the method come from? Does it refer
-    // to a top-level implementation? Or the method of a parameter? etc.).
-    // At the same time, retrieve the trait obligations for this **trait**.
-    // Remark: the trait obligations for the method are not the same as
-    // the trait obligations for the trait. More precisely:
-    //
-    // ```
-    // trait Foo<T : Bar> {
-    //              ^^^^^
-    //      trait level trait obligation
-    //   fn baz(...) where T : ... {
-    //      ...                ^^^
-    //             method level trait obligation
-    //   }
-    // }
-    // ```
-    //
-    // Also, a function doesn't need to belong to a trait to have trait
-    // obligations:
-    // ```
-    // fn foo<T : Bar>(...)
-    //            ^^^
-    //     method level trait obligation
-    // ```
-    let (generics, source) = if let Some(assoc) = tcx.opt_associated_item(def_id) {
-        // There is an associated item.
-        use tracing::*;
-        trace!("def_id: {:?}", def_id);
-        trace!("assoc: def_id: {:?}", assoc.def_id);
-        // Retrieve the `DefId` of the trait declaration or the impl block.
-        let container_def_id = match assoc.container {
-            rustc_middle::ty::AssocItemContainer::Trait => tcx.trait_of_item(assoc.def_id).unwrap(),
-            rustc_middle::ty::AssocItemContainer::Impl => tcx.impl_of_method(assoc.def_id).unwrap(),
-        };
-        // The generics are split in two: the arguments of the container (trait decl or impl block)
-        // and the arguments of the method.
+    let (generics, trait_impl) = if let Some(tinfo) = self_clause_for_item(s, def_id, generics) {
+        // The generics are split in two: the arguments of the container (trait decl or impl
+        // block) and the arguments of the method.
         //
         // For instance, if we have:
         // ```
@@ -403,34 +368,16 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + H
         // ```
         // The generics for the call to `baz` will be the concatenation: `<T, u32, U>`, which we
         // split into `<T, u32>` and `<U>`.
-        //
-        // If we have:
-        // ```
-        // impl<T: Ord> Map<T> {
-        //     pub fn insert<U: Clone>(&mut self, x: U) { ... }
-        // }
-        // pub fn test(mut tree: Map<u32>) {
-        //     tree.insert(false);
-        // }
-        // ```
-        // The generics for `insert` are `<u32>` for the impl and `<bool>` for the method.
-        match assoc.container {
-            rustc_middle::ty::AssocItemContainer::Trait => {
-                let num_container_generics = tcx.generics_of(container_def_id).own_params.len();
-                // Retrieve the trait information
-                let impl_expr = self_clause_for_item(s, &assoc, generics).unwrap();
-                // Return only the method generics; the trait generics are included in `impl_expr`.
-                let method_generics = &generics[num_container_generics..];
-                (method_generics.sinto(s), Some(impl_expr))
-            }
-            rustc_middle::ty::AssocItemContainer::Impl => (generics.sinto(s), None),
-        }
+        let num_trait_generics = tinfo.r#trait.hax_skip_binder_ref().generic_args.len();
+        // Return only the method generics; the trait generics are included in `trait_impl_expr`.
+        let method_generics = &generics[num_trait_generics..];
+        (method_generics.sinto(s), Some(tinfo))
     } else {
         // Regular function call
         (generics.sinto(s), None)
     };
 
-    (def_id.sinto(s), generics, trait_refs, source)
+    (def_id.sinto(s), generics, trait_refs, trait_impl)
 }
 
 #[cfg(feature = "rustc")]

--- a/frontend/exporter/src/types/thir.rs
+++ b/frontend/exporter/src/types/thir.rs
@@ -627,7 +627,7 @@ pub enum ExprKind {
                 let tcx = gstate.base().tcx;
                 r#trait = (|| {
                     let assoc_item = tcx.opt_associated_item(*def_id)?;
-                    let impl_expr = self_clause_for_item(gstate, &assoc_item, generics)?;
+                    let impl_expr = self_clause_for_item(gstate, assoc_item.def_id, generics)?;
                     let assoc_generics = tcx.generics_of(assoc_item.def_id);
                     let assoc_generics = translated_generics.drain(0..assoc_generics.parent_count).collect();
                     Some((impl_expr, assoc_generics))
@@ -881,12 +881,7 @@ pub enum ExprKind {
         args: Vec<GenericArg>,
         user_ty: Option<CanonicalUserType>,
         #[not_in_source]
-        #[value({
-            let tcx = gstate.base().tcx;
-            tcx.opt_associated_item(*def_id).as_ref().and_then(|assoc| {
-                self_clause_for_item(gstate, assoc, args)
-            })
-        })]
+        #[value(self_clause_for_item(gstate, *def_id, args))]
         r#impl: Option<ImplExpr>,
     },
     ConstParam {

--- a/frontend/exporter/src/types/thir.rs
+++ b/frontend/exporter/src/types/thir.rs
@@ -633,8 +633,7 @@ pub enum ExprKind {
                     Some((impl_expr, assoc_generics))
                 })();
                 generic_args = translated_generics;
-                // FIXME: is this `no_parents` required?
-                bounds_impls = solve_item_required_traits_no_parents(gstate, *def_id, generics);
+                bounds_impls = solve_item_required_traits(gstate, *def_id, generics);
                 Expr {
                     contents,
                     span: e.span.sinto(gstate),

--- a/frontend/exporter/src/types/thir.rs
+++ b/frontend/exporter/src/types/thir.rs
@@ -633,7 +633,8 @@ pub enum ExprKind {
                     Some((impl_expr, assoc_generics))
                 })();
                 generic_args = translated_generics;
-                bounds_impls = solve_item_required_traits(gstate, *def_id, generics);
+                // FIXME: is this `no_parents` required?
+                bounds_impls = solve_item_required_traits_no_parents(gstate, *def_id, generics);
                 Expr {
                     contents,
                     span: e.span.sinto(gstate),

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1327,7 +1327,7 @@ impl ClosureArgs {
             parent_trait_refs: {
                 let parent = tcx.generics_of(def_id).parent.unwrap();
                 let parent_generics_ref = tcx.mk_args(from.parent_args());
-                solve_item_and_parents_required_traits(s, parent, parent_generics_ref)
+                solve_item_required_traits(s, parent, parent_generics_ref)
             },
             tupled_sig: sig.sinto(s),
             untupled_sig: tcx


### PR DESCRIPTION
Generic args always include parent arguments (e.g. the args of an impl if we're talking of a method impl, or the args of the enclosing function if we're talking about a closure). This makes it so we also consistently include parent impl exprs.

The second commit it optional, tests pass with or without it, I'm not sure which one you want.