### PR TITLE
feat(hax_lib/macros): F*: add `postprocess_with`

### DIFF
--- a/hax-lib/build.rs
+++ b/hax-lib/build.rs
@@ -6,6 +6,7 @@ const FSTAR_EXTRA: &str = r"
 pub use hax_lib_macros::fstar_options as options;
 pub use hax_lib_macros::fstar_verification_status as verification_status;
 pub use hax_lib_macros::fstar_smt_pat as smt_pat;
+pub use hax_lib_macros::fstar_postprocess_with as postprocess_with;
 ";
 
 fn main() {

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -47,6 +47,7 @@ identity_proc_macro_attribute!(
     coq_after,
     proverif_after,
     fstar_smt_pat,
+    fstar_postprocess_with,
 );
 
 #[proc_macro]

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -209,6 +209,30 @@ let impl_1 (#v_T: Type0) : Core.Ops.Index.t_Index (t_Array v_T (mk_usize 10)) t_
     f_index = fun (self: t_Array v_T (mk_usize 10)) (index: t_SafeIndex) -> self.[ index.f_i ]
   }
 '''
+"Attributes.Postprocess_with.Somewhere.fst" = '''
+module Attributes.Postprocess_with.Somewhere
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let some_hypothetical_tactic (some_param: u8) : Prims.unit = ()
+'''
+"Attributes.Postprocess_with.fst" = '''
+module Attributes.Postprocess_with
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+[@@FStar.Tactics.postprocess_with (fun _ -> FStar.Tactics.trefl ())]
+
+let f (_: Prims.unit) : Prims.unit = ()
+
+[@@FStar.Tactics.postprocess_with ( fun temp_0_ ->
+  let ():Prims.unit = temp_0_ in
+  Attributes.Postprocess_with.Somewhere.some_hypothetical_tactic (mk_u8 12) )]
+
+let g (_: Prims.unit) : Prims.unit = ()
+'''
 "Attributes.Pre_post_on_traits_and_impls.fst" = '''
 module Attributes.Pre_post_on_traits_and_impls
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -46,6 +46,19 @@ fn dummy_function(x: u32) -> u32 {
 #[hax::fstar::smt_pat(x)]
 fn apply_dummy_function_lemma(x: u32) -> Proof<{ x == dummy_function(x) }> {}
 
+mod postprocess_with {
+    #[hax_lib::fstar::postprocess_with("fun _ -> FStar.Tactics.trefl ()")]
+    fn f() {}
+
+    pub mod somewhere {
+        pub fn some_hypothetical_tactic(some_param: u8) {}
+    }
+    use somewhere::some_hypothetical_tactic;
+
+    #[hax_lib::fstar::postprocess_with(|()| some_hypothetical_tactic(12))]
+    fn g() {}
+}
+
 #[hax::exclude]
 pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {
     if c {


### PR DESCRIPTION
This PR adds a `fstar::postprocess_with` macro to be able to use tactics to postprocess an item.

Related to https://github.com/cryspen/libcrux/pull/937