### PR TITLE
fix(engine/nix): pin ocamlgraph, waiting for https://github.com/NixOS/nixpkgs/pull/397883

### DIFF
--- a/engine/dune-project
+++ b/engine/dune-project
@@ -41,7 +41,7 @@
         ppx_matches
         ppx_string
         logs
-        ocamlgraph
+        (ocamlgraph (>= "2.2.0"))
 
         js_of_ocaml-compiler
         js_of_ocaml

--- a/engine/hax-engine.opam
+++ b/engine/hax-engine.opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_matches"
   "ppx_string"
   "logs"
-  "ocamlgraph"
+  "ocamlgraph" {>= "2.2.0"}
   "js_of_ocaml-compiler"
   "js_of_ocaml"
   "js_of_ocaml-ppx"
@@ -59,7 +59,4 @@ build: [
 dev-repo: "git+https://github.com/hacspec/hax.git"
 depexts: [
   ["nodejs"] {}
-]
-pin-depends: [
-  ["ocamlgraph.dev" "git+https://github.com/maximebuyse/ocamlgraph.git#fix-stable-topological-sort"]
 ]

--- a/engine/hax-engine.opam.template
+++ b/engine/hax-engine.opam.template
@@ -1,6 +1,3 @@
 depexts: [
   ["nodejs"] {}
 ]
-pin-depends: [
-  ["ocamlgraph.dev" "git+https://github.com/maximebuyse/ocamlgraph.git#fix-stable-topological-sort"]
-]

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,17 @@
             cat "${hax-env-file}" | xargs -I{} echo "export {}"
           fi
         '';
-        ocamlPackages = pkgs.ocamlPackages;
+        ocamlPackages = pkgs.ocamlPackages.overrideScope (final: prev: {
+          ocamlgraph = prev.ocamlgraph.overrideAttrs (_: rec {
+            name = "ocamlgraph-${version}";
+            version = "2.2.0";
+            src = pkgs.fetchurl {
+              url =
+                "https://github.com/backtracking/ocamlgraph/releases/download/${version}/ocamlgraph-${version}.tbz";
+              hash = "sha256-sJViEIY8wk9IAgO6PC7wbfrlV5U2oFdENk595YgisjA=";
+            };
+          });
+        });
       in rec {
         packages = {
           inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs;


### PR DESCRIPTION
This pins ocamlgraph in nix, waiting for https://github.com/NixOS/nixpkgs/pull/397883.
Fixes https://github.com/cryspen/hax/issues/1371.

I opened https://github.com/cryspen/hax/issues/1453 to track this pin.