### PR TITLE
Resolve Drop calls

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -194,6 +194,7 @@ impl From<ExtractionCallbacks> for hax_frontend_exporter_options::Options {
     fn from(opts: ExtractionCallbacks) -> hax_frontend_exporter_options::Options {
         hax_frontend_exporter_options::Options {
             inline_anon_consts: true,
+            resolve_drop_bounds: false,
         }
     }
 }

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -483,7 +483,7 @@ module MakeRenderAPI (NP : NAME_POLICY) : RENDER_API = struct
       let*? _no_generics = List.is_empty impl_infos.generics.params in
       match impl_infos.trait_ref with
       | None -> Some ty
-      | Some { def_id = trait; generic_args = [ _self ] } ->
+      | Some { def_id = trait; generic_args = [ _self ]; _ } ->
           let* trait = Explicit_def_id.of_def_id trait in
           let trait = View.of_def_id trait in
           let*? _same_ns = [%eq: View.ModPath.t] namespace trait.mod_path in

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1147,6 +1147,7 @@ end) : EXPR = struct
     | Dyn -> Dyn
     | SelfImpl { path; _ } -> List.fold ~init:Self ~f:browse_path path
     | Builtin { trait; _ } -> Builtin (c_trait_ref span trait.value)
+    | Drop _ -> failwith @@ "impl_expr_atom: Drop"
     | Error str -> failwith @@ "impl_expr_atom: Error " ^ str
 
   and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) : generic_value

--- a/frontend/exporter/options/src/lib.rs
+++ b/frontend/exporter/options/src/lib.rs
@@ -101,4 +101,7 @@ pub struct Options {
     /// blocks or advanced constant expressions as in `[T; N+1]`), or refer to them as
     /// `GlobalName`s.
     pub inline_anon_consts: bool,
+    /// Add `T: Drop` bounds to every type generic, so that we can build `ImplExpr`s to know what
+    /// code is run on drop.
+    pub resolve_drop_bounds: bool,
 }

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -93,6 +93,11 @@ pub enum ImplExprAtom {
     /// `dyn Trait` implements `Trait` using a built-in implementation; this refers to that
     /// built-in implementation.
     Dyn,
+    /// A virtual `Drop` implementation.
+    /// `Drop` doesn't work like a real trait but we want to pretend it does. If a type has a
+    /// user-defined `impl Drop for X` we just use the `Concrete` variant, but if it doesn't we use
+    /// this variant to supply the data needed to know what code will run on drop.
+    Drop(DropData),
     /// A built-in trait whose implementation is computed by the compiler, such as `FnMut`. This
     /// morally points to an invisible `impl` block; as such it contains the information we may
     /// need from one.
@@ -107,6 +112,30 @@ pub enum ImplExprAtom {
     },
     /// An error happened while resolving traits.
     Error(String),
+}
+
+#[derive(AdtInto)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: resolution::DropData<'tcx>, state: S as s)]
+#[derive_group(Serializers)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
+pub enum DropData {
+    /// A drop that does nothing, e.g. for scalars and pointers.
+    Noop,
+    /// An implicit `Drop` local clause, if the `resolve_drop_bounds` option is `false`. If that
+    /// option is `true`, we'll add `Drop` bounds to every type param, and use that to resolve
+    /// `Drop` impls of generics. If it's `false`, we use this variant to indicate that the drop
+    /// clause comes from a generic or associated type.
+    Implicit,
+    /// The implicit `Drop` impl that exists for every type without an explicit `Drop` impl. The
+    /// virtual impl is considered to have one `T: Drop` bound for each generic argument of the
+    /// target type; it then simply drops each field in order.
+    Glue {
+        /// The type we're generating glue for.
+        ty: Ty,
+        /// The `ImplExpr`s for the `T: Drop` bounds of the virtual impl. There is one for each
+        /// generic argument, in order.
+        impl_exprs: Vec<ImplExpr>,
+    },
 }
 
 /// An `ImplExpr` describes the full data of a trait implementation. Because of generics, this may

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -173,7 +173,13 @@ pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
     let resolved = s.with_cache(|cache| {
         cache
             .predicate_searcher
-            .get_or_insert_with(|| PredicateSearcher::new_for_owner(s.base().tcx, s.owner_id()))
+            .get_or_insert_with(|| {
+                PredicateSearcher::new_for_owner(
+                    s.base().tcx,
+                    s.owner_id(),
+                    s.base().options.resolve_drop_bounds,
+                )
+            })
             .resolve(&trait_ref, &warn)
     });
     let impl_expr = match resolved {
@@ -209,7 +215,7 @@ pub fn solve_item_required_traits<'tcx, S: UnderOwnerState<'tcx>>(
             }
             _ => {}
         }
-        let predicates = required_predicates(tcx, def_id);
+        let predicates = required_predicates(tcx, def_id, s.base().options.resolve_drop_bounds);
         impl_exprs.extend(solve_item_traits_inner(s, generics, predicates));
     }
     let mut impl_exprs = vec![];
@@ -226,7 +232,7 @@ pub fn solve_item_implied_traits<'tcx, S: UnderOwnerState<'tcx>>(
     def_id: RDefId,
     generics: ty::GenericArgsRef<'tcx>,
 ) -> Vec<ImplExpr> {
-    let predicates = implied_predicates(s.base().tcx, def_id);
+    let predicates = implied_predicates(s.base().tcx, def_id, s.base().options.resolve_drop_bounds);
     solve_item_traits_inner(s, generics, predicates)
 }
 

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -347,7 +347,7 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: UnderOwnerState<'tc
     generics: rustc_middle::ty::GenericArgsRef<'tcx>,
 ) -> (DefId, Vec<GenericArg>, Vec<ImplExpr>, Option<ImplExpr>) {
     // Retrieve the trait requirements for the item.
-    let trait_refs = solve_item_required_traits(s, def_id, generics);
+    let mut trait_refs = solve_item_required_traits(s, def_id, generics);
 
     // If this is a trait method call, retreive the impl expr information for that trait.
     // Check if this is a trait method call: retrieve the trait source if
@@ -369,8 +369,10 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: UnderOwnerState<'tc
         // The generics for the call to `baz` will be the concatenation: `<T, u32, U>`, which we
         // split into `<T, u32>` and `<U>`.
         let num_trait_generics = tinfo.r#trait.hax_skip_binder_ref().generic_args.len();
+        let num_trait_trait_clauses = tinfo.r#trait.hax_skip_binder_ref().impl_exprs.len();
         // Return only the method generics; the trait generics are included in `trait_impl_expr`.
         let method_generics = &generics[num_trait_generics..];
+        trait_refs.drain(0..num_trait_trait_clauses);
         (method_generics.sinto(s), Some(tinfo))
     } else {
         // Regular function call

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -470,6 +470,38 @@ fn translate_terminator_kind_call<'tcx, S: BaseState<'tcx> + HasMir<'tcx> + HasO
     }
 }
 
+#[cfg(feature = "rustc")]
+fn translate_terminator_kind_drop<'tcx, S: BaseState<'tcx> + HasMir<'tcx> + HasOwnerId>(
+    s: &S,
+    terminator: &rustc_middle::mir::TerminatorKind<'tcx>,
+) -> TerminatorKind {
+    let tcx = s.base().tcx;
+    let mir::TerminatorKind::Drop {
+        place,
+        target,
+        unwind,
+        ..
+    } = terminator
+    else {
+        unreachable!()
+    };
+
+    let local_decls = &s.mir().local_decls;
+    let place_ty = place.ty(local_decls, tcx).ty;
+    let drop_trait = tcx.lang_items().drop_trait().unwrap();
+    let impl_expr = solve_trait(
+        s,
+        ty::Binder::dummy(ty::TraitRef::new(tcx, drop_trait, [place_ty])),
+    );
+
+    TerminatorKind::Drop {
+        place: place.sinto(s),
+        impl_expr,
+        target: target.sinto(s),
+        unwind: unwind.sinto(s),
+    }
+}
+
 // We don't use the LitIntType on purpose (we don't want the "unsuffixed" case)
 #[derive_group(Serializers)]
 #[derive(Clone, Copy, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -570,11 +602,17 @@ pub enum TerminatorKind {
     },
     Return,
     Unreachable,
+    #[custom_arm(
+        x @ rustc_middle::mir::TerminatorKind::Drop { .. } => {
+          translate_terminator_kind_drop(s, x)
+        }
+    )]
     Drop {
         place: Place,
+        /// Implementation of `place.ty(): Drop`.
+        impl_expr: ImplExpr,
         target: BasicBlock,
         unwind: UnwindAction,
-        replace: bool,
     },
     #[custom_arm(
         x @ rustc_middle::mir::TerminatorKind::Call { .. } => {

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -217,7 +217,7 @@ pub enum FullDefKind<Body> {
         parent: DefId,
         #[value(get_param_env(s, s.owner_id()))]
         param_env: ParamEnv,
-        #[value(implied_predicates(s.base().tcx, s.owner_id()).sinto(s))]
+        #[value(implied_predicates(s.base().tcx, s.owner_id(), s.base().options.resolve_drop_bounds).sinto(s))]
         implied_predicates: GenericPredicates,
         #[value(s.base().tcx.associated_item(s.owner_id()).sinto(s))]
         associated_item: AssocItem,
@@ -238,7 +238,7 @@ pub enum FullDefKind<Body> {
     Trait {
         #[value(get_param_env(s, s.owner_id()))]
         param_env: ParamEnv,
-        #[value(implied_predicates(s.base().tcx, s.owner_id()).sinto(s))]
+        #[value(implied_predicates(s.base().tcx, s.owner_id(), s.base().options.resolve_drop_bounds).sinto(s))]
         implied_predicates: GenericPredicates,
         /// The special `Self: Trait` clause.
         #[value({
@@ -919,6 +919,6 @@ fn get_param_env<'tcx, S: BaseState<'tcx>>(s: &S, def_id: RDefId) -> ParamEnv {
     let s = &with_owner_id(s.base(), (), (), def_id);
     ParamEnv {
         generics: tcx.generics_of(def_id).sinto(s),
-        predicates: required_predicates(tcx, def_id).sinto(s),
+        predicates: required_predicates(tcx, def_id, s.base().options.resolve_drop_bounds).sinto(s),
     }
 }

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1004,13 +1004,17 @@ pub type PolyFnSig = Binder<TyFnSig>;
 /// Reflects [`ty::TraitRef`]
 #[derive_group(Serializers)]
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: ty::TraitRef<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: ty::TraitRef<'tcx>, state: S as s)]
 #[derive(Clone, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TraitRef {
     pub def_id: DefId,
     #[from(args)]
-    /// reflects the `args` field
+    /// Generic arguments to the trait. The first type argument is the type on which the trait is
+    /// implemented.
     pub generic_args: Vec<GenericArg>,
+    /// Implementations of the predicates required by the trait.
+    #[value(solve_item_required_traits(s, self.def_id, self.args))]
+    pub impl_exprs: Vec<ImplExpr>,
 }
 
 /// Reflects [`ty::TraitPredicate`]

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -536,6 +536,7 @@ impl From<Options> for hax_frontend_exporter_options::Options {
     fn from(_opts: Options) -> hax_frontend_exporter_options::Options {
         hax_frontend_exporter_options::Options {
             inline_anon_consts: true,
+            resolve_drop_bounds: false,
         }
     }
 }

--- a/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
@@ -133,7 +133,7 @@ class t_T (v_Self: Type0) = {
 val impl_T_for_u8:t_T u8
 
 class t_TrGeneric (v_Self: Type0) (v_U: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_11075708886900110455:Core.Clone.t_Clone v_U;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16006850527666200319:Core.Clone.t_Clone v_U;
   f_f_pre:v_U -> Type0;
   f_f_post:v_U -> v_Self -> Type0;
   f_f:x0: v_U -> Prims.Pure v_Self (f_f_pre x0) (fun result -> f_f_post x0 result)

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -35,11 +35,11 @@ open FStar.Mul
 class t_BlockSizeUser (v_Self: Type0) = { f_BlockSize:Type0 }
 
 class t_ParBlocksSizeUser (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12386035071644742916:t_BlockSizeUser v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_7386178880507589171:t_BlockSizeUser v_Self
 }
 
 class t_BlockBackend (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_5078033630945970482:t_ParBlocksSizeUser v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_5132789780856779344:t_ParBlocksSizeUser v_Self;
   f_proc_block_pre:Alloc.Vec.t_Vec _ Alloc.Alloc.t_Global -> Type0;
   f_proc_block_post:Alloc.Vec.t_Vec _ Alloc.Alloc.t_Global -> Prims.unit -> Type0;
   f_proc_block:x0: Alloc.Vec.t_Vec _ Alloc.Alloc.t_Global
@@ -55,7 +55,7 @@ open FStar.Mul
 class t_Bar (v_Self: Type0) (v_T: Type0) = { __marker_trait_t_Bar:Prims.unit }
 
 class t_Foo (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_13709452385921529338:t_Bar v_Self f_U;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12633113900214769645:t_Bar v_Self f_U;
   f_U:Type0
 }
 '''
@@ -425,11 +425,11 @@ let associated_function_caller
   ()
 
 class t_SubTrait (v_Self: Type0) (v_TypeArg: Type0) (v_ConstArg: usize) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_5670955395916535991:t_Trait v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2013377997652678570:t_Trait v_Self
     v_TypeArg
     v_ConstArg;
   f_AssocType:Type0;
-  f_AssocType_6891123870612467806:t_Trait f_AssocType v_TypeArg v_ConstArg
+  f_AssocType_4339496849715937257:t_Trait f_AssocType v_TypeArg v_ConstArg
 }
 '''
 "Traits.Interlaced_consts_types.fst" = '''
@@ -506,11 +506,11 @@ open FStar.Mul
 
 class t_Trait1 (v_Self: Type0) = {
   f_T:Type0;
-  f_T_6736093233391770582:t_Trait1 f_T
+  f_T_14544816729875926394:t_Trait1 f_T
 }
 
 class t_Trait2 (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15807083732906695011:t_Trait1 v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_17908617371471168181:t_Trait1 v_Self;
   f_U:Type0
 }
 '''
@@ -567,7 +567,7 @@ open Core
 open FStar.Mul
 
 class t_SuperTrait (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16027770981543256320:Core.Clone.t_Clone v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12761901852309354934:Core.Clone.t_Clone v_Self;
   f_function_of_super_trait_pre:v_Self -> Type0;
   f_function_of_super_trait_post:v_Self -> u32 -> Type0;
   f_function_of_super_trait:x0: v_Self
@@ -579,7 +579,7 @@ class t_SuperTrait (v_Self: Type0) = {
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl: t_SuperTrait i32 =
   {
-    _super_16027770981543256320 = FStar.Tactics.Typeclasses.solve;
+    _super_12761901852309354934 = FStar.Tactics.Typeclasses.solve;
     f_function_of_super_trait_pre = (fun (self: i32) -> true);
     f_function_of_super_trait_post = (fun (self: i32) (out: u32) -> true);
     f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl_i32__abs self <: i32) <: u32
@@ -651,7 +651,7 @@ let uuse_iimpl_trait (_: Prims.unit) : Prims.unit =
 
 class t_Foo (v_Self: Type0) = {
   f_AssocType:Type0;
-  f_AssocType_6638784903434849583:t_SuperTrait f_AssocType;
+  f_AssocType_16421706098796818672:t_SuperTrait f_AssocType;
   f_N:usize;
   f_assoc_f_pre:Prims.unit -> Type0;
   f_assoc_f_post:Prims.unit -> Prims.unit -> Type0;
@@ -688,7 +688,7 @@ let g (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x
 let impl_Foo_for_tuple_: t_Foo Prims.unit =
   {
     f_AssocType = i32;
-    f_AssocType_6638784903434849583 = FStar.Tactics.Typeclasses.solve;
+    f_AssocType_16421706098796818672 = FStar.Tactics.Typeclasses.solve;
     f_N = mk_usize 32;
     f_assoc_f_pre = (fun (_: Prims.unit) -> true);
     f_assoc_f_post = (fun (_: Prims.unit) (out: Prims.unit) -> true);


### PR DESCRIPTION
This PR makes it so we gather the data needed to know what code is called on a `drop` terminator. To do this well, this adds an optional `resolve_drop_bounds` option which adds `T: Drop` bounds to every possible generic parameter and associated type. This way, we can reuse the normal `ImplExpr` system. The one thing that's missing is the implicit Drop impls (so-called "drop glue") that are generated for ADTs without an explicit `impl Drop`; these are represented as `DropData::Glue`, and generating an adequate `Drop` impl is left as an exercice for the consumer.

Left as draft while I finish the charon side.