### PR TITLE
fix(engine) Add InlineConst in concrete_idents.

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -352,6 +352,7 @@ module MakeRenderAPI (NP : NAME_POLICY) : RENDER_API = struct
           [
             "impl";
             "anon_const";
+            "inline_const";
             "foreign";
             "use";
             "opaque";
@@ -535,6 +536,9 @@ module MakeRenderAPI (NP : NAME_POLICY) : RENDER_API = struct
       match chunk with
       | `AnonConst d ->
           prefix ~global:true ~disable_when:[ `SameCase ] "anon_const"
+            (NameAst.UnsafeString (Int64.to_string d))
+      | `InlineConst d ->
+          prefix ~global:true ~disable_when:[ `SameCase ] "inline_const"
             (NameAst.UnsafeString (Int64.to_string d))
       | `Use d -> prefix_d "use" d
       | `Foreign d -> prefix_d "foreign" d

--- a/engine/lib/concrete_ident/concrete_ident_view.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view.ml
@@ -133,7 +133,12 @@ let rec poly :
           (match List.last_exn (Explicit_def_id.to_def_id did).path with
           | { data = GlobalAsm; disambiguator } -> into_d did disambiguator
           | _ -> broken_invariant "last path chunk to be GlobalAsm" did)
-    | TyParam | ConstParam | InlineConst | PromotedConst | LifetimeParam
+    | InlineConst ->
+        `InlineConst
+          (match List.last_exn (Explicit_def_id.to_def_id did).path with
+          | { data = AnonConst; disambiguator } -> into_d did disambiguator
+          | _ -> broken_invariant "last path chunk to be InlineConst" did)
+    | TyParam | ConstParam | PromotedConst | LifetimeParam
     | SyntheticCoroutineBody ->
         (* It should be impossible for such items to ever be referenced by anyting in hax. *)
         broken_invariant

--- a/engine/lib/concrete_ident/concrete_ident_view.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view.ml
@@ -137,7 +137,7 @@ let rec poly :
         `InlineConst
           (match List.last_exn (Explicit_def_id.to_def_id did).path with
           | { data = AnonConst; disambiguator } -> into_d did disambiguator
-          | _ -> broken_invariant "last path chunk to be InlineConst" did)
+          | _ -> broken_invariant "last path chunk to be AnonConst" did)
     | TyParam | ConstParam | PromotedConst | LifetimeParam
     | SyntheticCoroutineBody ->
         (* It should be impossible for such items to ever be referenced by anyting in hax. *)

--- a/engine/lib/concrete_ident/concrete_ident_view_types.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view_types.ml
@@ -124,6 +124,13 @@ module RelPath = struct
       | `Use of 'disambiguator
       | `AnonConst of 'disambiguator
       | `InlineConst of 'disambiguator
+        (** This is e.g.: {[
+            const {
+                fn f() {}
+            }
+          ]} 
+          Here, `f` is under an `InlineConst`.
+          *)
       | `TraitAlias of 'name
       | `Foreign of 'disambiguator
       | `ForeignTy of 'name

--- a/engine/lib/concrete_ident/concrete_ident_view_types.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view_types.ml
@@ -123,6 +123,7 @@ module RelPath = struct
       | ('name, 'disambiguator) assoc_parent
       | `Use of 'disambiguator
       | `AnonConst of 'disambiguator
+      | `InlineConst of 'disambiguator
       | `TraitAlias of 'name
       | `Foreign of 'disambiguator
       | `ForeignTy of 'name
@@ -181,6 +182,7 @@ module RelPath = struct
       | `Opaque n
       | `GlobalAsm n
       | `AnonConst n
+      | `InlineConst n
       | `Impl (n, _, _)
       | `Use n
       | `Closure n

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -354,7 +354,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hax-bounded-integers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "duplicate",
  "hax-lib",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -394,14 +394,14 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-protocol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libcrux",
 ]
 
 [[package]]
 name = "hax-lib-protocol-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",


### PR DESCRIPTION
This adds support for InlineConst in concrete idents. Should fix the following example: https://hax-playground.cryspen.com/#fstar/27ba29ff72/gist=c2fec53eb7833900672a10c116498021