### PR TITLE
full_def: support trait aliases

### DIFF
--- a/frontend/exporter/src/traits/resolution.rs
+++ b/frontend/exporter/src/traits/resolution.rs
@@ -140,7 +140,7 @@ fn initial_search_predicates<'tcx>(
                 let parent = tcx.parent(def_id);
                 acc_predicates(tcx, parent, predicates, pred_id);
             }
-            Trait => {
+            Trait | TraitAlias => {
                 let self_pred = self_predicate(tcx, def_id).upcast(tcx);
                 predicates.push(AnnotatedTraitPred {
                     origin: BoundPredicateOrigin::SelfPred,

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -73,11 +73,10 @@ pub fn required_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPre
         | OpaqueTy
         | Static { .. }
         | Struct
-        | TraitAlias
         | TyAlias
         | Union => predicates_defined_on(tcx, def_id),
         // We consider all predicates on traits to be outputs
-        Trait => Default::default(),
+        Trait | TraitAlias => Default::default(),
         // `predicates_defined_on` ICEs on other def kinds.
         _ => Default::default(),
     }
@@ -105,7 +104,7 @@ pub fn implied_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> GenericPred
     let parent = tcx.opt_parent(def_id);
     match tcx.def_kind(def_id) {
         // We consider all predicates on traits to be outputs
-        Trait => predicates_defined_on(tcx, def_id),
+        Trait | TraitAlias => predicates_defined_on(tcx, def_id),
         AssocTy if matches!(tcx.def_kind(parent.unwrap()), Trait) => {
             GenericPredicates {
                 parent,

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -247,16 +247,7 @@ pub enum FullDefKind<Body> {
         #[value(implied_predicates(s.base().tcx, s.owner_id()).sinto(s))]
         implied_predicates: GenericPredicates,
         /// The special `Self: Trait` clause.
-        #[value({
-            use ty::Upcast;
-            let tcx = s.base().tcx;
-            let pred: ty::TraitPredicate =
-                crate::traits::self_predicate(tcx, s.owner_id())
-                    .no_bound_vars()
-                    .unwrap()
-                    .upcast(tcx);
-            pred.sinto(s)
-        })]
+        #[value(get_self_predicate(s))]
         self_predicate: TraitPredicate,
         /// Associated items, in definition order.
         #[value(
@@ -274,7 +265,15 @@ pub enum FullDefKind<Body> {
         items: Vec<(AssocItem, Arc<FullDef<Body>>)>,
     },
     /// Trait alias: `trait IntIterator = Iterator<Item = i32>;`
-    TraitAlias,
+    TraitAlias {
+        #[value(get_param_env(s, s.owner_id()))]
+        param_env: ParamEnv,
+        #[value(implied_predicates(s.base().tcx, s.owner_id()).sinto(s))]
+        implied_predicates: GenericPredicates,
+        /// The special `Self: Trait` clause.
+        #[value(get_self_predicate(s))]
+        self_predicate: TraitPredicate,
+    },
     #[custom_arm(
         // Returns `TraitImpl` or `InherentImpl`.
         RDefKind::Impl { .. } => get_impl_contents(s),
@@ -537,6 +536,7 @@ impl<Body> FullDef<Body> {
             | Union { param_env, .. }
             | Enum { param_env, .. }
             | Trait { param_env, .. }
+            | TraitAlias { param_env, .. }
             | TyAlias { param_env, .. }
             | AssocTy { param_env, .. }
             | Fn { param_env, .. }
@@ -720,6 +720,17 @@ fn get_foreign_mod_children<'tcx>(tcx: ty::TyCtxt<'tcx>, def_id: RDefId) -> Vec<
             .collect(),
         None => vec![],
     }
+}
+
+#[cfg(feature = "rustc")]
+fn get_self_predicate<'tcx, S: UnderOwnerState<'tcx>>(s: &S) -> TraitPredicate {
+    use ty::Upcast;
+    let tcx = s.base().tcx;
+    let pred: ty::TraitPredicate = crate::traits::self_predicate(tcx, s.owner_id())
+        .no_bound_vars()
+        .unwrap()
+        .upcast(tcx);
+    pred.sinto(s)
 }
 
 #[cfg(feature = "rustc")]


### PR DESCRIPTION
This translates trait aliases exactly like traits. The difference with trait is that they have a magic blanket impl, which is implicitly referenced with a `ImplExprAtom::BuiltinOrAuto` trait expression.

Generating the impl is left to consumers of the frontend; I tried adding a fake `DefId` like I did for promoted constants, but trait resolution operates on real `DefId`s so it was hard to get it to resolve clauses correctly. In the end it was easier to construct the blanket impl in charon.