### PR TITLE
docs: Escape "*" in "F*" from Markdown

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -53,7 +53,7 @@ manager</a> <i>(with <a href="https://nixos.wiki/wiki/Flakes">flakes</a> enabled
   - or following [those steps](https://github.com/mschwaig/howto-install-nix-with-flake-support).
 
 + **Run hax on a crate directly** to get F\*/Coq/... (assuming you are in the crate's folder):
-   - `nix run github:hacspec/hax -- into fstar` extracts F*.
+   - `nix run github:hacspec/hax -- into fstar` extracts F\*.
 
 + **Install hax**:  `nix profile install github:hacspec/hax`, then run `cargo hax --help` anywhere
 + **Note**: in any of the Nix commands above, replace `github:hacspec/hax` by `./dir` to compile a local checkout of hax that lives in `./some-dir`

--- a/docs/manual/quick_start/index.md
+++ b/docs/manual/quick_start/index.md
@@ -2,7 +2,7 @@
 weight: 0
 ---
 
-# Quick start with hax and F*
+# Quick start with hax and F\*
 
 Do you want to try hax out on a Rust crate of yours? This chapter is
 what you are looking for!
@@ -11,7 +11,7 @@ what you are looking for!
 
  - <input type="checkbox" class="user-checkable"/> [Install the hax toolchain](https://github.com/hacspec/hax?tab=readme-ov-file#installation).  
    <span style="margin-right:30px;"></span>🪄 Running `cargo hax --version` should print some version info.
- - <input type="checkbox" class="user-checkable"/> [Install F*](https://github.com/FStarLang/FStar/blob/master/INSTALL.md) *(optional: only if want to run F\*)*
+ - <input type="checkbox" class="user-checkable"/> [Install F\*](https://github.com/FStarLang/FStar/blob/master/INSTALL.md) *(optional: only if want to run F\*)*
 
 ## Setup the crate you want to verify
 
@@ -34,7 +34,7 @@ what you are looking for!
 specific crate you want to extract.*
 
 Run the command `cargo hax into fstar` to extract every item of your
-crate as F* modules in the subfolder `proofs/fstar/extraction`.
+crate as F\* modules in the subfolder `proofs/fstar/extraction`.
 
 **What is critical? What is worth verifying?**  
 Probably, your Rust crate contains mixed kinds of code: some parts are
@@ -68,22 +68,22 @@ about the `-i` flag [in the FAQ](../faq/include-flags.md).
 
 
 
-## Start F* verification
+## Start F\* verification
 After running the hax toolchain on your Rust code, you will end up
-with various F* modules in the `proofs/fstar/extraction` folder. The
-`Makefile` in `proofs/fstar/extraction` will run F*.
+with various F\* modules in the `proofs/fstar/extraction` folder. The
+`Makefile` in `proofs/fstar/extraction` will run F\*.
 
 1. **Lax check:** the first step is to run `OTHERFLAGS="--lax" make`,
-   which will run F* in "lax" mode. The lax mode just makes sure basic
+   which will run F\* in "lax" mode. The lax mode just makes sure basic
    typechecking works: it is not proving anything. This first step is
-   important because there might be missing libraries. If F* is not
+   important because there might be missing libraries. If F\* is not
    able to find a definition, it is probably a `libcore` issue: you
-   probably need to edit the F* library, which lives in the
+   probably need to edit the F\* library, which lives in the
    `proofs-libs` directory in the root of the hax repo.
-2. **Typecheck:** the second step is to run `make`. This will ask F*
+2. **Typecheck:** the second step is to run `make`. This will ask F\*
    to typecheck fully your crate. This is very likely that you need to
    add preconditions and postconditions at this stage. Indeed, this
-   second step is about panic freedom: if F* can typecheck your crate,
+   second step is about panic freedom: if F\* can typecheck your crate,
    it means your code *never* panics, which already is an important
    property.
 

--- a/docs/manual/tutorial/data-invariants.md
+++ b/docs/manual/tutorial/data-invariants.md
@@ -94,7 +94,7 @@ impl Add for F {
 }
 ```
 
-Here, F* is able to prove automatically that (1) the addition doesn't
+Here, F\* is able to prove automatically that (1) the addition doesn't
 overflow and (2) that the invariant of `F` is preserved. The
-definition of type `F` in F* (named `t_F`) very explicitly requires
+definition of type `F` in F\* (named `t_F`) very explicitly requires
 the invariant as a refinement on `v`.

--- a/docs/manual/tutorial/index.md
+++ b/docs/manual/tutorial/index.md
@@ -9,11 +9,11 @@ programs using the hax toolchain. hax is a tool that translates Rust
 programs to various formal programming languages.
 
 The formal programming languages we target are called *backends*. Some
-of them, e.g. [F*](https://fstar-lang.org/) or
+of them, e.g. [F\*](https://fstar-lang.org/) or
 [Coq](https://coq.inria.fr/), are general purpose formal programming
 languages. Others are specialized tools:
 [ProVerif](https://bblanche.gitlabpages.inria.fr/proverif/) is
 dedicated to proving properties about protocols.
 
 This tutorial focuses on proving properties with the
-[F* programming language](https://fstar-lang.org/).
+[F\* programming language](https://fstar-lang.org/).

--- a/docs/manual/tutorial/panic-freedom.md
+++ b/docs/manual/tutorial/panic-freedom.md
@@ -5,7 +5,7 @@ weight: 0
 # Panic freedom
 
 Let's start with a simple example: a function that squares a `u8`
-integer. To extract this function to F* using hax, we simply need to
+integer. To extract this function to F\* using hax, we simply need to
 run the command `cargo hax into fstar` in the directory of the crate
 in which the function `square` is defined.
 
@@ -18,8 +18,8 @@ fn square(x: u8) -> u8 {
 }
 ```
 
-Though, if we try to verify this function, F* is complaining about a
-subtyping issue: F* tells us that it is not able to prove that the
+Though, if we try to verify this function, F\* is complaining about a
+subtyping issue: F\* tells us that it is not able to prove that the
 result of the multiplication `x * x` fits the range of `u8`. The
 multiplication `x * x` might indeed be overflowing!
 
@@ -70,7 +70,7 @@ fn square_option(x: u8) -> Option<u8> {
 }
 ```
 
-Here, F* is able to prove panic-freedom: calling `square` with any
+Here, F\* is able to prove panic-freedom: calling `square` with any
 input is safe. Though, one may argue that `square`'s input being small
 enough should really be an assumption. Having to deal with the
 possible integer overflowing whenever squaring is a huge burden. Can
@@ -102,7 +102,7 @@ fn square_requires(x: u8) -> u8 {
 }
 ```
 
-With this precondition, F* is able to prove panic freedom. From now
+With this precondition, F\* is able to prove panic freedom. From now
 on, it is the responsibility of the clients of `square` to respect the
 contact. The next step is thus be to verify, through hax extraction,
 that `square` is used correctly at every call site.

--- a/docs/manual/tutorial/properties.md
+++ b/docs/manual/tutorial/properties.md
@@ -66,14 +66,14 @@ fn barrett_reduce(value: i32) -> i32 {
 ```
 
 <!-- Note that we call to `cancel_mul_mod`, a lemma: in Rust, this have no
-effect, but in F*, that establishes that `(quotient * 3329) % 3329` is
+effect, but in F\*, that establishes that `(quotient * 3329) % 3329` is
 zero. -->
 
 The proof for the code above uses the Z3 SMT solver to prive the
 post-condition.  Since the SMT solver needs to reason about non-linear
 arithmetic (multiplication, modulus, division) it needs more
 resources, hence we bump up the `rlimit` to 100 in an annotation above
-the function. With this annotation F* and Z3 are able to automatically
+the function. With this annotation F\* and Z3 are able to automatically
 verify this function. However, it is worth noting that the heuristic
 strategies used by Z3 for non-linear arithmetic may sometimes fail to
 complete in the given `rlimit` depending on the solver version or random
@@ -82,7 +82,7 @@ number generator, so we often give Z3 a generous resource limit.
 Conversely, instead of relying on the SMT solver, we can also
 elaborate the proof of this function by hand to make it more
 predictable.  For example, before the final line of the function, 
-we could call a mathematical lemma may have to help F* prove
+we could call a mathematical lemma may have to help F\* prove
 the correctness of the reduction.  The lemma call would be:
 ```
     fstar!("Math.Lemmas.cancel_mul_mod (v quotient) 3329");


### PR DESCRIPTION
Documentation occasionally suffers from lines such as `F* does this, F* does that` being rendered as "F *does this, F* does that" (because different Markdown interpreters are differently smart about deciding when a `*` means italics, and then hides the star from output). Example:

> ![Screenshot 2025-06-11 at 11-27-53 Panic freedom - hax](https://github.com/user-attachments/assets/44abe6a4-8e70-4335-84e8-2526562461e1)

This PR goes replaces the `F*` in the Markdown files with `F\*` (as it already was in some places), which renders correctly.