### PR TITLE
feat(rengine): intro. resugared AST fragment

### DIFF
--- a/rust-engine/src/ast.rs
+++ b/rust-engine/src/ast.rs
@@ -14,6 +14,7 @@ pub mod diagnostics;
 pub mod fragment;
 pub mod identifiers;
 pub mod literals;
+pub mod resugared;
 pub mod span;
 
 use crate::symbol::Symbol;
@@ -22,6 +23,7 @@ use fragment::Fragment;
 use hax_rust_engine_macros::*;
 use identifiers::*;
 use literals::*;
+use resugared::*;
 use span::Span;
 
 /// Represents a generic value used in type applications (e.g., `T` in `Vec<T>`).
@@ -170,6 +172,11 @@ pub enum TyKind {
     /// dyn Tr
     /// ```
     Dyn(Vec<DynTraitGoal>),
+
+    /// A resugared type.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredTyKind),
 
     /// Fallback constructor to carry errors.
     Error(Diagnostic),
@@ -367,6 +374,11 @@ pub enum PatKind {
         /// A list of fields.
         fields: Vec<(GlobalId, Pat)>,
     },
+
+    /// A resugared pattern.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredPatKind),
 
     /// Fallback constructor to carry errors.
     Error(Diagnostic),
@@ -582,6 +594,11 @@ pub enum ImplItemKind {
         /// The list of the argument for the associated function (`&self` in the example).
         params: Vec<Param>,
     },
+
+    /// A resugared impl item.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredImplItemKind),
 }
 
 /// Represents a trait item (associated type, fn, or default)
@@ -628,6 +645,11 @@ pub enum TraitItemKind {
         /// The default body of the associated function (`x + 2` in the example).
         body: Expr,
     },
+
+    /// A resugared trait item.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredTraitItemKind),
 }
 
 /// A QuoteContent is a component of a quote: it can be a verbatim string, a Rust expression to embed in the quote, a pattern etc.
@@ -1019,6 +1041,11 @@ pub enum ExprKind {
         contents: Quote,
     },
 
+    /// A resugared expression.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredExprKind),
+
     /// Fallback constructor to carry errors.
     Error(Diagnostic),
 }
@@ -1387,6 +1414,11 @@ pub enum ItemKind {
 
     /// Fallback constructor to carry errors.
     Error(Diagnostic),
+
+    /// A resugared item.
+    /// This variant is introduced before printing only.
+    /// Phases must not produce this variant.
+    Resugared(ResugaredTyKind),
 
     /// Item that is not implemented yet
     NotImplementedYet,

--- a/rust-engine/src/ast/resugared.rs
+++ b/rust-engine/src/ast/resugared.rs
@@ -1,0 +1,33 @@
+//! This module contains resugared fragments of the AST of hax.
+//!
+//! In hax, a resugared fragment of AST is an extra node that is relevant only for printers.
+//!
+//! As an example, we represent (just as Rust does) the type `unit` as a tuple of size zero.
+//! This may be unsuited for some backend: in F* for instance, `unit` is not denoted `()` but `unit.`
+//! Thus, we add a resugared fragment for the type unit.
+
+use hax_rust_engine_macros::*;
+
+/// Resugared variants for items. This represent extra printing-only items, see [`super::ItemKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredItemKind {}
+
+/// Resugared variants for expressions. This represent extra printing-only expressions, see [`super::ExprKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredExprKind {}
+
+/// Resugared variants for patterns. This represent extra printing-only patterns, see [`super::PatKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredPatKind {}
+
+/// Resugared variants for types. This represent extra printing-only types, see [`super::TyKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredTyKind {}
+
+/// Resugared variants for impl. items. This represent extra printing-only impl. items, see [`super::ImplItemKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredImplItemKind {}
+
+/// Resugared variants for trait items. This represent extra printing-only trait items, see [`super::TraitItemKind::Resugared`].
+#[derive_group_for_ast]
+pub enum ResugaredTraitItemKind {}


### PR DESCRIPTION
This PR adds a new module to the hax Rust engine
defining resugared fragments in the AST.

Resugared fragments are additional AST nodes used
exclusively for pretty-printing. While they carry
no semantic meaning in the Hax core logic, they
enable more accurate and backend-specific surface
syntax reconstruction.

For example, the unit type is internally
represented as a zero-sized tuple `()`, following
Rust conventions. However, some backends (such as
F*) expect unit to be printed explicitly as unit,
not `()`. To handle such cases, we introduce
resugared fragments like UnitType that guide the
printer in producing the appropriate syntax
without altering internal semantics.