### PR TITLE
Update hax version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 (2025-06-21)
+
+Changes to hax frontend:
+- TODO TODO
+
+## 0.3.1 (2025-05-26)
+
+Changes to hax-lib:
+- Bug fix with PartialOrd in f* lib: [#1473](https://github.com/cryspen/hax/pull/1473)
+- Move `proof-libs` into `hax-lib` to allow dependencies using crates.io
+
 ## 0.3.0 (2025-05-16)
 
 Changes to hax-lib:
@@ -15,13 +26,7 @@ Changes to hax-lib:
 - `hax_lib::BACKEND::replace_body`: [#1321](https://github.com/cryspen/hax/pull/1321)
 - `hax_lib::decreases`: [#1342](https://github.com/cryspen/hax/pull/1342)
 
-## 0.3.1 (2025-05-26)
-
-Changes to hax-lib:
-- Bug fix with PartialOrd in f* lib: [#1473](https://github.com/cryspen/hax/pull/1473)
-- Move `proof-libs` into `hax-lib` to allow dependencies using crates.io
-
 ## [Unreleased]
 
-## 0.4.0 (2024-01-20)
+## 0.1.0 (2024-01-20)
  - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 authors = ["hax Authors"]
 license = "Apache-2.0"
 homepage = "https://github.com/hacspec/hax"


### PR DESCRIPTION
PR #1514 introduced a change to the hax frontend that changes the generated code.

This requires a minor version change for downstream users. This PR aims to address this by incrementing the hax version to 0.3.2 and documenting the changes in this version.
