### PR TITLE
Rust Engine: allow multiple backends to implement the `Pretty` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +590,7 @@ dependencies = [
  "hax-frontend-exporter",
  "hax-rust-engine-macros",
  "hax-types",
+ "pretty",
  "schemars",
  "serde",
  "serde-jsonlines",
@@ -1069,6 +1076,17 @@ checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac98773b7109bc75f475ab5a134c9b64b87e59d776d31098d8f346922396a477"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1689,6 +1707,12 @@ dependencies = [
  "tracing-log 0.1.4",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = { workspace = true, features = ["unbounded_depth"] }
 schemars.workspace = true
 serde-jsonlines = "0.5.0"
 serde_stacker = "0.1.12"
+pretty = "0.12.4"

--- a/rust-engine/src/ast.rs
+++ b/rust-engine/src/ast.rs
@@ -1487,8 +1487,26 @@ pub mod traits {
         };
     }
 
-    derive_has_metadata!(Item, Expr, Pat);
-    derive_has_kind!(Item => ItemKind, Expr => ExprKind, Pat => PatKind);
+    derive_has_metadata!(
+        Item,
+        Expr,
+        Pat,
+        Guard,
+        Arm,
+        ImplItem,
+        TraitItem,
+        GenericParam
+    );
+    derive_has_kind!(
+        Item => ItemKind, Expr => ExprKind, Pat => PatKind, Guard => GuardKind,
+        GenericParam => GenericParamKind, ImplItem => ImplItemKind, TraitItem => TraitItemKind
+    );
+
+    impl HasSpan for Attribute {
+        fn span(&self) -> Span {
+            self.span.clone()
+        }
+    }
 
     impl Typed for Expr {
         fn ty(&self) -> &Ty {

--- a/rust-engine/src/lib.rs
+++ b/rust-engine/src/lib.rs
@@ -11,4 +11,5 @@
 pub mod ast;
 pub mod hax_io;
 pub mod ocaml_engine;
+pub mod printer;
 pub mod symbol;

--- a/rust-engine/src/printer.rs
+++ b/rust-engine/src/printer.rs
@@ -1,0 +1,4 @@
+//! This modules provides types and helper for the printers of hax.
+
+mod allocator;
+pub use allocator::Allocator;

--- a/rust-engine/src/printer/allocator.rs
+++ b/rust-engine/src/printer/allocator.rs
@@ -12,6 +12,16 @@ pub struct Allocator<Printer> {
     pub printer: Printer,
 }
 
+impl<Printer> Allocator<Printer> {
+    /// Creates a new allocator from a printer.
+    pub fn new(printer: Printer) -> Self {
+        Self {
+            allocator: BoxAllocator,
+            printer,
+        }
+    }
+}
+
 impl<'a, P, A: 'a> DocAllocator<'a, A> for Allocator<P> {
     type Doc = <BoxAllocator as DocAllocator<'a, A>>::Doc;
 

--- a/rust-engine/src/printer/allocator.rs
+++ b/rust-engine/src/printer/allocator.rs
@@ -1,0 +1,77 @@
+//! This module provides a custom [`pretty`] allocator, indexed by a printer,
+//! enabling multiple printers to cohexist and to implement the type `Pretty`.
+
+use crate::ast::span::Span;
+use pretty::*;
+
+/// A printer-specific [`pretty`] allocator.
+pub struct Allocator<Printer> {
+    /// The pretty allocator
+    allocator: BoxAllocator,
+    /// Extra printer-specific context
+    pub printer: Printer,
+}
+
+impl<'a, P, A: 'a> DocAllocator<'a, A> for Allocator<P> {
+    type Doc = <BoxAllocator as DocAllocator<'a, A>>::Doc;
+
+    fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
+        self.allocator.alloc(doc)
+    }
+
+    fn alloc_column_fn(
+        &'a self,
+        f: impl Fn(usize) -> Self::Doc + 'a,
+    ) -> <Self::Doc as DocPtr<'a, A>>::ColumnFn {
+        self.allocator.alloc_column_fn(f)
+    }
+
+    fn alloc_width_fn(
+        &'a self,
+        f: impl Fn(isize) -> Self::Doc + 'a,
+    ) -> <Self::Doc as DocPtr<'a, A>>::WidthFn {
+        self.allocator.alloc_width_fn(f)
+    }
+}
+
+/// A helper type used to manually implement `Pretty` for types that carry spans.
+///
+/// By default, we implement the `Pretty` trait for all span-carrying
+/// types. These implementations annotate spans in the generated document, allowing
+/// source spans to be produced during pretty-printing. However, this default behavior
+/// does not provide access to the underlying data, which is sometimes necessary
+/// for custom printing logic.
+///
+/// For example, when printing an item, it's often useful to access its attributes.
+/// To support this, the default `Pretty` implementations delegate to `Manual<Item>`,
+/// which allows printers to access the inner value directly.
+///
+/// In practice, calling `expr.pretty(..)` will internally use
+/// `Manual(expr).pretty(..)`, enabling more flexible control over printing behavior.
+struct Manual<T>(T);
+
+use crate::ast::*;
+macro_rules! impl_pretty_kind_meta {
+        ($($type:ty),*) => {
+            $(impl<'a, 'b, P> Pretty<'a, Allocator<P>, Span> for &'b $type
+            where
+                Manual<&'b $type>: Pretty<'a, Allocator<P>, Span>,
+            {
+                fn pretty(self, allocator: &'a Allocator<P>) -> DocBuilder<'a, Allocator<P>, Span> {
+                    let doc = Manual(self).pretty(allocator);
+                    doc.annotate(self.span())
+                }
+            })*
+        };
+    }
+impl_pretty_kind_meta!(
+    Item,
+    Expr,
+    Pat,
+    Guard,
+    Arm,
+    ImplItem,
+    TraitItem,
+    GenericParam,
+    Attribute
+);


### PR DESCRIPTION
This commit introduces a [`pretty`](https://docs.rs/pretty/latest/pretty/index.html) allocator indexed by a printer, enabling multiple printers to cohexist and to implement the type `Pretty`.

This solves the following issue. hax has multiple printer and each must implement the trait [`Pretty`](https://docs.rs/pretty/latest/pretty/trait.Pretty.html) for the types of our AST.

We would end up with overlapping implementations instances of the trait `Pretty` for our AST types.

The document allocator introduced by this commit is simply a wrapper with a type index `Printer`.
It contains a box allocator (given by `pretty`) and a printer.

This commit also introduces automatic span annotations, by defining implementations for all types carrying span informations.

In order to let the backend freely implement custom printing logic for (say `T`) such a span-carrying data structure, we also provide a type `Manual<T>`. The automatic instance for `T` of `Pretty` will delegate to the `Pretty` implementation of `Manual<T>`.

In practice, while e.g. `&Expr` have a automatic implementation for any printer, a printer must implement `Pretty` for `Manual<&Expr>`.