### PR TITLE
nix: Fix iconv linking for macos

### DIFF
--- a/cli/default.nix
+++ b/cli/default.nix
@@ -17,6 +17,7 @@ let
     };
     inherit buildInputs doCheck;
     doNotRemoveReferencesToRustToolchain = true;
+    RUSTFLAGS = lib.optionalString stdenv.isDarwin "-C link-arg=-L${libiconv}/lib";
   } // (if doCheck then {
     # [cargo test] builds independent workspaces. Each time another
     # workspace is added, it's corresponding lockfile should be added


### PR DESCRIPTION
I have been running into linker issues with `libiconv` with nix on macos (trying to run an example in this case):

```
$ nix run ../../.#hax -- into fstar
warning: Git tree '/projects/rust/hax' is dirty
   Compiling hax-lib-macros v0.3.1 (projects/rust/hax/hax-lib/macros)
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-Wl,-exported_symbols_list" "-Wl,/var/folders/9z/n7rz_6cj3bq__11k5kcrsvvm0000gn/T/rustcaH573y/list" "/var/folders/9z/n7rz_6cj3bq__11k5kcrsvvm0000gn/T/rustcaH573y/symbols.o" "<146 object files omitted>" [snip]
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: library not found for -liconv
          collect2: error: ld returned 1 exit status
```

I have been able to fix it with `RUSTFLAGS` but I am not a heavy user of nix, maybe there is a better way do this.