### PR TITLE
fix(nix): make `nix run` work on darwin

### DIFF
--- a/cli/default.nix
+++ b/cli/default.nix
@@ -82,10 +82,10 @@ in stdenv.mkDerivation {
     makeWrapper ${hax}/bin/cargo-hax $out/bin/cargo-hax \
       --prefix PATH : ${lib.makeBinPath binaries} \
       ${
-        if stdenv.hostPlatform.isDarwin then
-          "--suffix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libz rustc ]}"
-        else
-          ""
+        lib.optionalString stdenv.isDarwin ''
+          --prefix RUSTFLAGS : "-C link-arg=-L${libiconv}/lib" \
+          --suffix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libz rustc ]}
+        ''
       }
   '';
   meta.mainProgram = "cargo-hax";


### PR DESCRIPTION
This injects `libiconv` at runtime in the env var `DYLD_LIBRARY_PATH`, fixing `nix run .#` on MacOS.

Thanks to @fjahr that reported the issue and submitted a PR. This PR is very similar, but injects `libiconv` only on the end binary.