### PR TITLE
Add custom timeout in CI workflow

### DIFF
--- a/.github/workflows/extract_and_run_coq.yml
+++ b/.github/workflows/extract_and_run_coq.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 47 # equal to max + 3*std over the last 77 successful runs
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
### Change Summary
Added custom timeout for `build` job of the `Extract and Run - Coq` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 77 successful runs, the `build` job has a maximum runtime of 35 minutes (mean=12, std=4).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/cryspen/hax/actions/runs/15416330338/job/43380022866) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 30-May-2025 and the last one one on 03-Jun-2025 (see below for full list of urls), while more recent occurences are also possible because our dataset has a cutoff date around early June. With the proposed changes, a total of **31 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 47 minutes` where `max` and `std` (standard deviation) are derived from the history of 77 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.


<details>
  <summary>Click here to see all the recently timed-out runs.</summary>

  03-Jun-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15416330338/job/43380022866)
03-Jun-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15414960142/job/43375484896)
03-Jun-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15414455198/job/43373870277)
01-Jun-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15368601393/job/43258588876)
30-May-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15351866949/job/43201831789)
30-May-2025 => [timed-out run](https://github.com/cryspen/hax/actions/runs/15351862495/job/43201814986)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this and for your contribution to open-source software in general.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch