### PR TITLE
chore(ci/gh actions): `ubuntu-20.04` -> `ubuntu-22.04`

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-latest
           - macos-13
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/11101.