### PR TITLE
feat(ci): mlkem job: use specific libcrux revision

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -16,6 +16,24 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
+      - name: ⤵ Extract libcrux version from PR body
+        id: extract_version
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const body = context.payload.pull_request?.body || '';
+            const match = body.match(/libcrux-ref:\s*([a-zA-Z0-9._/-]+)/);
+            const ref = match ? match[1] : 'main';
+            core.notice(`Using libcrux ref: ${ref}`);
+            return ref;
+
+      - name: ⤵ Clone Libcrux repository
+        uses: actions/checkout@v4
+        with:
+          repository: cryspen/libcrux
+          path: libcrux
+          ref: ${{ steps.extract_version.outputs.result }}
       - name: ⤵ Clone Libcrux repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
When a change in hax requires a change in ML-KEM, and vice-versal, we currently just bypass CI.

With this commit, one can now write:
<img width="202" height="34" alt="Capture d’écran 2025-07-24 à 10 02 31" src="https://github.com/user-attachments/assets/71a1c999-ad59-47c0-84c5-d0e387342125" />

This will make the CI use libcrux at `some-git-ref` instead of `main`.

(note I'm putting a screenshot here, otherwise this will override the version for this PR as well)

libcrux-ref: some-git-ref