### PR TITLE
Upstream changes from evit up to June 11th 2025.

### DIFF
--- a/hax-lib/proof-libs/fstar/core/Core.Mem.Manually_drop.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Mem.Manually_drop.fsti
@@ -1,0 +1,78 @@
+module Core.Mem.Manually_drop
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_ManuallyDrop (v_T: Type0) = { f_value:v_T }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_6 (#v_T: Type0) {| i0: Core.Clone.t_Clone v_T |} : Core.Clone.t_Clone (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_5 (#v_T: Type0) {| i0: Core.Marker.t_Copy v_T |} : Core.Marker.t_Copy (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7 (#v_T: Type0) {| i0: Core.Fmt.t_Debug v_T |} : Core.Fmt.t_Debug (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8 (#v_T: Type0) {| i0: Core.Default.t_Default v_T |}
+    : Core.Default.t_Default (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9 (#v_T: Type0) : Core.Marker.t_StructuralPartialEq (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10 (#v_T: Type0) {| i0: Core.Cmp.t_PartialEq v_T v_T |}
+    : Core.Cmp.t_PartialEq (t_ManuallyDrop v_T) (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_11 (#v_T: Type0) {| i0: Core.Cmp.t_Eq v_T |} : Core.Cmp.t_Eq (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_12 (#v_T: Type0) {| i0: Core.Cmp.t_PartialOrd v_T v_T |}
+    : Core.Cmp.t_PartialOrd (t_ManuallyDrop v_T) (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_13 (#v_T: Type0) {| i0: Core.Cmp.t_Ord v_T |} : Core.Cmp.t_Ord (t_ManuallyDrop v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14 (#v_T: Type0) {| i0: Core.Hash.t_Hash v_T |} : Core.Hash.t_Hash (t_ManuallyDrop v_T)
+
+val impl__new (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (value: v_T)
+    : Prims.Pure (t_ManuallyDrop v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl__into_inner (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (slot: t_ManuallyDrop v_T)
+    : Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val impl__take (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (slot: t_ManuallyDrop v_T)
+    : Prims.Pure (t_ManuallyDrop v_T & v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl__take__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_1__drop (#v_T: Type0) (slot: t_ManuallyDrop v_T)
+    : Prims.Pure (t_ManuallyDrop v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_1__drop__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_2 (#v_T: Type0) : Core.Ops.Deref.t_Deref (t_ManuallyDrop v_T) =
+  {
+    f_Target = v_T;
+    f_deref_pre = (fun (self: t_ManuallyDrop v_T) -> true);
+    f_deref_post = (fun (self: t_ManuallyDrop v_T) (out: v_T) -> true);
+    f_deref = fun (self: t_ManuallyDrop v_T) -> () <: v_T
+  }
+
+val f_deref__impl_2__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_3 (#v_T: Type0) : Core.Ops.Deref.t_DerefMut (t_ManuallyDrop v_T)
+
+val f_deref_mut__impl_3__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_4 (#v_T: Type0) : Core.Ops.Deref.t_DerefPure (t_ManuallyDrop v_T)

--- a/hax-lib/proof-libs/fstar/core/Core.Mem.Maybe_uninit.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Mem.Maybe_uninit.fsti
@@ -1,0 +1,345 @@
+module Core.Mem.Maybe_uninit
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} {| i1: Core.Marker.t_Copy v_T |}
+    : Core.Clone.t_Clone (t_MaybeUninit v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} {| i1: Core.Marker.t_Copy v_T |}
+    : Core.Marker.t_Copy (t_MaybeUninit v_T)
+
+val f_clone__impl__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Fmt.t_Debug (t_MaybeUninit v_T)
+
+val f_fmt__impl_1__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__new (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (v_val: v_T)
+    : Prims.Pure (t_MaybeUninit v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__uninit: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure (t_MaybeUninit v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__zeroed: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure (t_MaybeUninit v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__write
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit v_T)
+      (v_val: v_T)
+    : Prims.Pure (t_MaybeUninit v_T & Rust_primitives.Hax.t_MutRef v_T)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__as_ptr (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (self: t_MaybeUninit v_T)
+    : Prims.Pure Rust_primitives.Hax.failure Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__as_mut_ptr (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (self: t_MaybeUninit v_T)
+    : Prims.Pure (t_MaybeUninit v_T & Rust_primitives.Hax.failure)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__assume_init (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (self: t_MaybeUninit v_T)
+    : Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__assume_init_read
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit v_T)
+    : Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__assume_init_drop
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit v_T)
+    : Prims.Pure (t_MaybeUninit v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__assume_init_ref
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit v_T)
+    : Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__assume_init_mut
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit v_T)
+    : Prims.Pure (t_MaybeUninit v_T & Rust_primitives.Hax.t_MutRef v_T)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__array_assume_init
+      (#v_T: Type0)
+      (v_N: usize)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (array: t_Array (t_MaybeUninit v_T) v_N)
+    : Prims.Pure (t_Array v_T v_N) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__as_bytes (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (self: t_MaybeUninit v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit u8)) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__as_bytes_mut (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (self: t_MaybeUninit v_T)
+    : Prims.Pure (t_MaybeUninit v_T & Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit u8)))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__slice_assume_init_ref
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (slice: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__slice_assume_init_mut
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (slice: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_ptr
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure Rust_primitives.Hax.failure Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_mut_ptr
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.failure)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__copy_from_slice
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i1: Core.Marker.t_Copy v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+      (src: t_Slice v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__clone_from_slice
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i2: Core.Clone.t_Clone v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+      (src: t_Slice v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__fill
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i2: Core.Clone.t_Clone v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+      (value: v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__fill_with
+      (#v_T #v_F: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i3: Core.Marker.t_Sized v_F |}
+      {| i4: Core.Ops.Function.t_FnMut v_F Prims.unit |}
+      (this: t_Slice (t_MaybeUninit v_T))
+      (f: v_F)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__fill_from
+      (#v_T #v_I: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i5: Core.Marker.t_Sized v_I |}
+      {| i6: Core.Iter.Traits.Collect.t_IntoIterator v_I |}
+      (this: t_Slice (t_MaybeUninit v_T))
+      (it: v_I)
+    : Prims.Pure
+      (t_Slice (t_MaybeUninit v_T) &
+        (Rust_primitives.Hax.t_MutRef (t_Slice v_T) &
+          Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit v_T))))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_bytes
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit u8)) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_bytes_mut
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (this: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure
+      (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit u8)))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_2__assume_init_drop__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__copy_from_slice__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__clone_from_slice__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__fill__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__fill_with__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__fill_from__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_bytes__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_2__slice_as_bytes_mut__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_3__write_copy_of_slice
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i1: Core.Marker.t_Copy v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+      (src: t_Slice v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__write_clone_of_slice
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i2: Core.Clone.t_Clone v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+      (src: t_Slice v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__write_filled
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i2: Core.Clone.t_Clone v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+      (value: v_T)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__write_with
+      (#v_T #v_F: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i3: Core.Marker.t_Sized v_F |}
+      {| i4: Core.Ops.Function.t_FnMut v_F usize |}
+      (self: t_Slice (t_MaybeUninit v_T))
+      (f: v_F)
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__write_iter
+      (#v_T #v_I: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i5: Core.Marker.t_Sized v_I |}
+      {| i6: Core.Iter.Traits.Collect.t_IntoIterator v_I |}
+      (self: t_Slice (t_MaybeUninit v_T))
+      (it: v_I)
+    : Prims.Pure
+      (t_Slice (t_MaybeUninit v_T) &
+        (Rust_primitives.Hax.t_MutRef (t_Slice v_T) &
+          Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit v_T))))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__as_bytes
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit u8)) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_3__as_bytes_mut
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure
+      (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit u8)))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_3__assume_init_drop
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T)) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_3__assume_init_ref
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_3__assume_init_mut
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Slice (t_MaybeUninit v_T))
+    : Prims.Pure (t_Slice (t_MaybeUninit v_T) & Rust_primitives.Hax.t_MutRef (t_Slice v_T))
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_4__transpose
+      (#v_T: Type0)
+      (v_N: usize)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_MaybeUninit (t_Array v_T v_N))
+    : Prims.Pure (t_Array (t_MaybeUninit v_T) v_N) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_5__transpose
+      (#v_T: Type0)
+      (v_N: usize)
+      {| i0: Core.Marker.t_Sized v_T |}
+      (self: t_Array (t_MaybeUninit v_T) v_N)
+    : Prims.Pure (t_MaybeUninit (t_Array v_T v_N)) Prims.l_True (fun _ -> Prims.l_True)
+
+type t_Guard (v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} = {
+  f_slice:Rust_primitives.Hax.t_MutRef (t_Slice (t_MaybeUninit v_T));
+  f_initialized:usize
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_6 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Ops.Drop.t_Drop (t_Guard v_T)
+
+val f_drop__impl_6__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+class t_SpecFill (v_Self: Type0) (v_T: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15671470021555116719:Core.Marker.t_Sized v_T;
+  f_spec_fill_pre:v_Self -> v_T -> Type0;
+  f_spec_fill_post:v_Self -> v_T -> v_Self -> Type0;
+  f_spec_fill:x0: v_Self -> x1: v_T
+    -> Prims.Pure v_Self (f_spec_fill_pre x0 x1) (fun result -> f_spec_fill_post x0 x1 result)
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} {| i1: Core.Clone.t_Clone v_T |}
+    : t_SpecFill (t_Slice (t_MaybeUninit v_T)) v_T
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} {| i1: Core.Marker.t_Copy v_T |}
+    : t_SpecFill (t_Slice (t_MaybeUninit v_T)) v_T

--- a/hax-lib/proof-libs/fstar/core/Core.Mem.Transmutability.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Mem.Transmutability.fsti
@@ -1,0 +1,81 @@
+module Core.Mem.Transmutability
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+
+val f_transmute__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+type t_Assume = {
+  f_alignment:bool;
+  f_lifetimes:bool;
+  f_safety:bool;
+  f_validity:bool
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_5:Core.Marker.t_StructuralPartialEq t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_6:Core.Cmp.t_PartialEq t_Assume t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7:Core.Cmp.t_Eq t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8:Core.Clone.t_Clone t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9:Core.Marker.t_Copy t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10:Core.Fmt.t_Debug t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core.Marker.t_UnsizedConstParamTy t_Assume
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl:Core.Marker.t_ConstParamTy_ t_Assume
+
+let impl_Assume__NOTHING: t_Assume = () <: t_Assume
+
+let impl_Assume__ALIGNMENT: t_Assume = () <: t_Assume
+
+let impl_Assume__LIFETIMES: t_Assume = () <: t_Assume
+
+let impl_Assume__SAFETY: t_Assume = () <: t_Assume
+
+let impl_Assume__VALIDITY: t_Assume = () <: t_Assume
+
+val impl_Assume__and (self other_assumptions: t_Assume)
+    : Prims.Pure t_Assume Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Assume__but_not (self other_assumptions: t_Assume)
+    : Prims.Pure t_Assume Prims.l_True (fun _ -> Prims.l_True)
+
+val f_add__impl_3__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_sub__impl_4__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3: Core.Ops.Arith.t_Add t_Assume t_Assume =
+  {
+    f_Output = t_Assume;
+    f_Output_11695847888444666345 = FStar.Tactics.Typeclasses.solve;
+    f_add_pre = (fun (self: t_Assume) (other_assumptions: t_Assume) -> true);
+    f_add_post = (fun (self: t_Assume) (other_assumptions: t_Assume) (out: t_Assume) -> true);
+    f_add = fun (self: t_Assume) (other_assumptions: t_Assume) -> () <: t_Assume
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_4: Core.Ops.Arith.t_Sub t_Assume t_Assume =
+  {
+    f_Output = t_Assume;
+    f_Output_9381071510542709353 = FStar.Tactics.Typeclasses.solve;
+    f_sub_pre = (fun (self: t_Assume) (other_assumptions: t_Assume) -> true);
+    f_sub_post = (fun (self: t_Assume) (other_assumptions: t_Assume) (out: t_Assume) -> true);
+    f_sub = fun (self: t_Assume) (other_assumptions: t_Assume) -> () <: t_Assume
+  }

--- a/hax-lib/proof-libs/fstar/core/Core.Mem.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Mem.fsti
@@ -1,8 +1,90 @@
 module Core.Mem
-open Rust_primitives
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
 
-// FIXME(unsafe!): remove default type (see #545)
-val size_of (#[FStar.Tactics.exact (`eqtype_as_type unit)]t:Type): unit -> usize
-val size_of_val (#t:Type) : t -> usize
+val forget (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (t: v_T)
+    : Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
 
-val drop (#t: Type) (x:t) : Prims.unit
+val forget_unsized (#v_T: Type0) (t: v_T)
+    : Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+
+val size_of: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val size_of_val (#v_T: Type0) (v_val: v_T) : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val min_align_of: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val min_align_of_val (#v_T: Type0) (v_val: v_T)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val align_of: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+val align_of_val (#v_T: Type0) (v_val: v_T) : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+
+val needs_drop: #v_T: Type0 -> Prims.unit -> Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val zeroed: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val uninitialized: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val swap (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (x y: v_T)
+    : Prims.Pure (v_T & v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val take
+      (#v_T: Type0)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i1: Core.Default.t_Default v_T |}
+      (dest: v_T)
+    : Prims.Pure (v_T & v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val replace (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (dest src: v_T)
+    : Prims.Pure (v_T & v_T) Prims.l_True (fun _ -> Prims.l_True)
+
+val drop (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (e_x: v_T)
+    : Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+
+val copy (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} {| i1: Core.Marker.t_Copy v_T |} (x: v_T)
+    : Prims.Pure v_T Prims.l_True (fun _ -> Prims.l_True)
+
+val transmute_copy
+      (#v_Src #v_Dst: Type0)
+      {| i0: Core.Marker.t_Sized v_Src |}
+      {| i1: Core.Marker.t_Sized v_Dst |}
+      (src: v_Src)
+    : Prims.Pure v_Dst Prims.l_True (fun _ -> Prims.l_True)
+
+(* type t_Discriminant (v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} =
+  | Discriminant : _ -> t_Discriminant v_T
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Clone.t_Clone (t_Discriminant v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Marker.t_Copy (t_Discriminant v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_2 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |}
+    : Core.Cmp.t_PartialEq (t_Discriminant v_T) (t_Discriminant v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_3 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Cmp.t_Eq (t_Discriminant v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_4 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Hash.t_Hash (t_Discriminant v_T)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_5 (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} : Core.Fmt.t_Debug (t_Discriminant v_T)
+
+val discriminant (#v_T: Type0) {| i0: Core.Marker.t_Sized v_T |} (v: v_T)
+    : Prims.Pure (t_Discriminant v_T) Prims.l_True (fun _ -> Prims.l_True) *)
+
+val variant_count: #v_T: Type0 -> {| i0: Core.Marker.t_Sized v_T |} -> Prims.unit
+  -> Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+

--- a/hax-lib/proof-libs/fstar/core/Core.Num.Niche_types.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Num.Niche_types.fsti
@@ -1,0 +1,753 @@
+module Core.Num.Niche_types
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_Nanoseconds = | Nanoseconds : u32 -> t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_13:Core.Clone.t_Clone t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core.Marker.t_Copy t_Nanoseconds
+
+val e_: Prims.unit 
+
+val impl_Nanoseconds__new (v_val: u32)
+    : Prims.Pure (Core.Option.t_Option t_Nanoseconds) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Nanoseconds__new_unchecked (v_val: u32)
+    : Prims.Pure t_Nanoseconds Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Nanoseconds__as_inner (self: t_Nanoseconds)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7:Core.Marker.t_StructuralPartialEq t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_8:Core.Cmp.t_PartialEq t_Nanoseconds t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_15:Core.Cmp.t_Eq t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10:Core.Cmp.t_PartialOrd t_Nanoseconds t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9:Core.Cmp.t_Ord t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_11:Core.Hash.t_Hash t_Nanoseconds
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_12:Core.Fmt.t_Debug t_Nanoseconds
+
+val impl_Nanoseconds__ZERO: t_Nanoseconds 
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_1:Core.Default.t_Default t_Nanoseconds
+
+val f_default__impl_1__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+type t_NonZeroU8Inner = | NonZeroU8Inner : u8 -> t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_86:Core.Clone.t_Clone t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_87:Core.Marker.t_Copy t_NonZeroU8Inner
+
+val e_ee_1: Prims.unit
+
+val impl_NonZeroU8Inner__new (v_val: u8)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroU8Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU8Inner__new_unchecked (v_val: u8)
+    : Prims.Pure t_NonZeroU8Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU8Inner__as_inner (self: t_NonZeroU8Inner)
+    : Prims.Pure u8 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core.Marker.t_StructuralPartialEq t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core.Cmp.t_PartialEq t_NonZeroU8Inner t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_88:Core.Cmp.t_Eq t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core.Cmp.t_PartialOrd t_NonZeroU8Inner t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core.Cmp.t_Ord t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core.Hash.t_Hash t_NonZeroU8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_22:Core.Fmt.t_Debug t_NonZeroU8Inner
+
+type t_NonZeroU16Inner = | NonZeroU16Inner : u16 -> t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_89:Core.Clone.t_Clone t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_90:Core.Marker.t_Copy t_NonZeroU16Inner
+
+val e_ee_2: Prims.unit
+
+val impl_NonZeroU16Inner__new (v_val: u16)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroU16Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU16Inner__new_unchecked (v_val: u16)
+    : Prims.Pure t_NonZeroU16Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU16Inner__as_inner (self: t_NonZeroU16Inner)
+    : Prims.Pure u16 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_24:Core.Marker.t_StructuralPartialEq t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_25:Core.Cmp.t_PartialEq t_NonZeroU16Inner t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_91:Core.Cmp.t_Eq t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_27:Core.Cmp.t_PartialOrd t_NonZeroU16Inner t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_26:Core.Cmp.t_Ord t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_28:Core.Hash.t_Hash t_NonZeroU16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_29:Core.Fmt.t_Debug t_NonZeroU16Inner
+
+type t_NonZeroU32Inner = | NonZeroU32Inner : u32 -> t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_92:Core.Clone.t_Clone t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_93:Core.Marker.t_Copy t_NonZeroU32Inner
+
+val e_ee_3: Prims.unit
+
+val impl_NonZeroU32Inner__new (v_val: u32)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroU32Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU32Inner__new_unchecked (v_val: u32)
+    : Prims.Pure t_NonZeroU32Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU32Inner__as_inner (self: t_NonZeroU32Inner)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_31:Core.Marker.t_StructuralPartialEq t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_32:Core.Cmp.t_PartialEq t_NonZeroU32Inner t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_94:Core.Cmp.t_Eq t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_34:Core.Cmp.t_PartialOrd t_NonZeroU32Inner t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_33:Core.Cmp.t_Ord t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_35:Core.Hash.t_Hash t_NonZeroU32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_36:Core.Fmt.t_Debug t_NonZeroU32Inner
+
+type t_NonZeroU64Inner = | NonZeroU64Inner : u64 -> t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_95:Core.Clone.t_Clone t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_96:Core.Marker.t_Copy t_NonZeroU64Inner
+
+val e_ee_4: Prims.unit
+
+val impl_NonZeroU64Inner__new (v_val: u64)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroU64Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU64Inner__new_unchecked (v_val: u64)
+    : Prims.Pure t_NonZeroU64Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU64Inner__as_inner (self: t_NonZeroU64Inner)
+    : Prims.Pure u64 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_38:Core.Marker.t_StructuralPartialEq t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_39:Core.Cmp.t_PartialEq t_NonZeroU64Inner t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_97:Core.Cmp.t_Eq t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_41:Core.Cmp.t_PartialOrd t_NonZeroU64Inner t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_40:Core.Cmp.t_Ord t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_42:Core.Hash.t_Hash t_NonZeroU64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_43:Core.Fmt.t_Debug t_NonZeroU64Inner
+
+type t_NonZeroU128Inner = | NonZeroU128Inner : u128 -> t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_98:Core.Clone.t_Clone t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_99:Core.Marker.t_Copy t_NonZeroU128Inner
+
+val e_ee_5: Prims.unit
+
+val impl_NonZeroU128Inner__new (v_val: u128)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroU128Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU128Inner__new_unchecked (v_val: u128)
+    : Prims.Pure t_NonZeroU128Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroU128Inner__as_inner (self: t_NonZeroU128Inner)
+    : Prims.Pure u128 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_45:Core.Marker.t_StructuralPartialEq t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_46:Core.Cmp.t_PartialEq t_NonZeroU128Inner t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_100:Core.Cmp.t_Eq t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_48:Core.Cmp.t_PartialOrd t_NonZeroU128Inner t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_47:Core.Cmp.t_Ord t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_49:Core.Hash.t_Hash t_NonZeroU128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_50:Core.Fmt.t_Debug t_NonZeroU128Inner
+
+type t_NonZeroI8Inner = | NonZeroI8Inner : i8 -> t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_101:Core.Clone.t_Clone t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_102:Core.Marker.t_Copy t_NonZeroI8Inner
+
+val e_ee_6: Prims.unit
+
+val impl_NonZeroI8Inner__new (v_val: i8)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroI8Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI8Inner__new_unchecked (v_val: i8)
+    : Prims.Pure t_NonZeroI8Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI8Inner__as_inner (self: t_NonZeroI8Inner)
+    : Prims.Pure i8 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_52:Core.Marker.t_StructuralPartialEq t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_53:Core.Cmp.t_PartialEq t_NonZeroI8Inner t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_103:Core.Cmp.t_Eq t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_55:Core.Cmp.t_PartialOrd t_NonZeroI8Inner t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_54:Core.Cmp.t_Ord t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_56:Core.Hash.t_Hash t_NonZeroI8Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_57:Core.Fmt.t_Debug t_NonZeroI8Inner
+
+type t_NonZeroI16Inner = | NonZeroI16Inner : i16 -> t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_104:Core.Clone.t_Clone t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_105:Core.Marker.t_Copy t_NonZeroI16Inner
+
+val e_ee_7: Prims.unit
+
+val impl_NonZeroI16Inner__new (v_val: i16)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroI16Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI16Inner__new_unchecked (v_val: i16)
+    : Prims.Pure t_NonZeroI16Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI16Inner__as_inner (self: t_NonZeroI16Inner)
+    : Prims.Pure i16 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_59:Core.Marker.t_StructuralPartialEq t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_60:Core.Cmp.t_PartialEq t_NonZeroI16Inner t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_106:Core.Cmp.t_Eq t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_62:Core.Cmp.t_PartialOrd t_NonZeroI16Inner t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_61:Core.Cmp.t_Ord t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_63:Core.Hash.t_Hash t_NonZeroI16Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_64:Core.Fmt.t_Debug t_NonZeroI16Inner
+
+type t_NonZeroI32Inner = | NonZeroI32Inner : i32 -> t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_107:Core.Clone.t_Clone t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_108:Core.Marker.t_Copy t_NonZeroI32Inner
+
+val e_ee_8: Prims.unit
+
+val impl_NonZeroI32Inner__new (v_val: i32)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroI32Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI32Inner__new_unchecked (v_val: i32)
+    : Prims.Pure t_NonZeroI32Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI32Inner__as_inner (self: t_NonZeroI32Inner)
+    : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_66:Core.Marker.t_StructuralPartialEq t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_67:Core.Cmp.t_PartialEq t_NonZeroI32Inner t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_109:Core.Cmp.t_Eq t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_69:Core.Cmp.t_PartialOrd t_NonZeroI32Inner t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_68:Core.Cmp.t_Ord t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_70:Core.Hash.t_Hash t_NonZeroI32Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_71:Core.Fmt.t_Debug t_NonZeroI32Inner
+
+type t_NonZeroI64Inner = | NonZeroI64Inner : i64 -> t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_110:Core.Clone.t_Clone t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_111:Core.Marker.t_Copy t_NonZeroI64Inner
+
+val e_ee_9: Prims.unit
+
+val impl_NonZeroI64Inner__new (v_val: i64)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroI64Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI64Inner__new_unchecked (v_val: i64)
+    : Prims.Pure t_NonZeroI64Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI64Inner__as_inner (self: t_NonZeroI64Inner)
+    : Prims.Pure i64 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_73:Core.Marker.t_StructuralPartialEq t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_74:Core.Cmp.t_PartialEq t_NonZeroI64Inner t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_112:Core.Cmp.t_Eq t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_76:Core.Cmp.t_PartialOrd t_NonZeroI64Inner t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_75:Core.Cmp.t_Ord t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_77:Core.Hash.t_Hash t_NonZeroI64Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_78:Core.Fmt.t_Debug t_NonZeroI64Inner
+
+type t_NonZeroI128Inner = | NonZeroI128Inner : i128 -> t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_113:Core.Clone.t_Clone t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_114:Core.Marker.t_Copy t_NonZeroI128Inner
+
+val e_ee_10: Prims.unit
+
+val impl_NonZeroI128Inner__new (v_val: i128)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroI128Inner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI128Inner__new_unchecked (v_val: i128)
+    : Prims.Pure t_NonZeroI128Inner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroI128Inner__as_inner (self: t_NonZeroI128Inner)
+    : Prims.Pure i128 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_80:Core.Marker.t_StructuralPartialEq t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_81:Core.Cmp.t_PartialEq t_NonZeroI128Inner t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_115:Core.Cmp.t_Eq t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_83:Core.Cmp.t_PartialOrd t_NonZeroI128Inner t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_82:Core.Cmp.t_Ord t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_84:Core.Hash.t_Hash t_NonZeroI128Inner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_85:Core.Fmt.t_Debug t_NonZeroI128Inner
+
+type t_UsizeNoHighBit = | UsizeNoHighBit : usize -> t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_137:Core.Clone.t_Clone t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_138:Core.Marker.t_Copy t_UsizeNoHighBit
+
+val e_ee_11: Prims.unit
+
+val impl_UsizeNoHighBit__new (v_val: usize)
+    : Prims.Pure (Core.Option.t_Option t_UsizeNoHighBit) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_UsizeNoHighBit__new_unchecked (v_val: usize)
+    : Prims.Pure t_UsizeNoHighBit Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_UsizeNoHighBit__as_inner (self: t_UsizeNoHighBit)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_117:Core.Marker.t_StructuralPartialEq t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_118:Core.Cmp.t_PartialEq t_UsizeNoHighBit t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_139:Core.Cmp.t_Eq t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_120:Core.Cmp.t_PartialOrd t_UsizeNoHighBit t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_119:Core.Cmp.t_Ord t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_121:Core.Hash.t_Hash t_UsizeNoHighBit
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_122:Core.Fmt.t_Debug t_UsizeNoHighBit
+
+type t_NonZeroUsizeInner = | NonZeroUsizeInner : usize -> t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_140:Core.Clone.t_Clone t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_141:Core.Marker.t_Copy t_NonZeroUsizeInner
+
+val e_ee_12: Prims.unit
+
+val impl_NonZeroUsizeInner__new (v_val: usize)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroUsizeInner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroUsizeInner__new_unchecked (v_val: usize)
+    : Prims.Pure t_NonZeroUsizeInner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroUsizeInner__as_inner (self: t_NonZeroUsizeInner)
+    : Prims.Pure usize Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_124:Core.Marker.t_StructuralPartialEq t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_125:Core.Cmp.t_PartialEq t_NonZeroUsizeInner t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_142:Core.Cmp.t_Eq t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_127:Core.Cmp.t_PartialOrd t_NonZeroUsizeInner t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_126:Core.Cmp.t_Ord t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_128:Core.Hash.t_Hash t_NonZeroUsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_129:Core.Fmt.t_Debug t_NonZeroUsizeInner
+
+type t_NonZeroIsizeInner = | NonZeroIsizeInner : isize -> t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_143:Core.Clone.t_Clone t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_144:Core.Marker.t_Copy t_NonZeroIsizeInner
+
+val e_ee_13: Prims.unit
+
+val impl_NonZeroIsizeInner__new (v_val: isize)
+    : Prims.Pure (Core.Option.t_Option t_NonZeroIsizeInner) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroIsizeInner__new_unchecked (v_val: isize)
+    : Prims.Pure t_NonZeroIsizeInner Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_NonZeroIsizeInner__as_inner (self: t_NonZeroIsizeInner)
+    : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_131:Core.Marker.t_StructuralPartialEq t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_132:Core.Cmp.t_PartialEq t_NonZeroIsizeInner t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_145:Core.Cmp.t_Eq t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_134:Core.Cmp.t_PartialOrd t_NonZeroIsizeInner t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_133:Core.Cmp.t_Ord t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_135:Core.Hash.t_Hash t_NonZeroIsizeInner
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_136:Core.Fmt.t_Debug t_NonZeroIsizeInner
+
+type t_U32NotAllOnes = | U32NotAllOnes : u32 -> t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_174:Core.Clone.t_Clone t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_175:Core.Marker.t_Copy t_U32NotAllOnes
+
+val e_ee_14: Prims.unit
+
+val impl_U32NotAllOnes__new (v_val: u32)
+    : Prims.Pure (Core.Option.t_Option t_U32NotAllOnes) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_U32NotAllOnes__new_unchecked (v_val: u32)
+    : Prims.Pure t_U32NotAllOnes Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_U32NotAllOnes__as_inner (self: t_U32NotAllOnes)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_147:Core.Marker.t_StructuralPartialEq t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_148:Core.Cmp.t_PartialEq t_U32NotAllOnes t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_176:Core.Cmp.t_Eq t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_150:Core.Cmp.t_PartialOrd t_U32NotAllOnes t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_149:Core.Cmp.t_Ord t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_151:Core.Hash.t_Hash t_U32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_152:Core.Fmt.t_Debug t_U32NotAllOnes
+
+type t_I32NotAllOnes = | I32NotAllOnes : i32 -> t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_177:Core.Clone.t_Clone t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_178:Core.Marker.t_Copy t_I32NotAllOnes
+
+val e_ee_15: Prims.unit
+
+val impl_I32NotAllOnes__new (v_val: i32)
+    : Prims.Pure (Core.Option.t_Option t_I32NotAllOnes) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_I32NotAllOnes__new_unchecked (v_val: i32)
+    : Prims.Pure t_I32NotAllOnes Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_I32NotAllOnes__as_inner (self: t_I32NotAllOnes)
+    : Prims.Pure i32 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_154:Core.Marker.t_StructuralPartialEq t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_155:Core.Cmp.t_PartialEq t_I32NotAllOnes t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_179:Core.Cmp.t_Eq t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_157:Core.Cmp.t_PartialOrd t_I32NotAllOnes t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_156:Core.Cmp.t_Ord t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_158:Core.Hash.t_Hash t_I32NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_159:Core.Fmt.t_Debug t_I32NotAllOnes
+
+type t_U64NotAllOnes = | U64NotAllOnes : u64 -> t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_180:Core.Clone.t_Clone t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_181:Core.Marker.t_Copy t_U64NotAllOnes
+
+val e_ee_16: Prims.unit
+
+val impl_U64NotAllOnes__new (v_val: u64)
+    : Prims.Pure (Core.Option.t_Option t_U64NotAllOnes) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_U64NotAllOnes__new_unchecked (v_val: u64)
+    : Prims.Pure t_U64NotAllOnes Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_U64NotAllOnes__as_inner (self: t_U64NotAllOnes)
+    : Prims.Pure u64 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_161:Core.Marker.t_StructuralPartialEq t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_162:Core.Cmp.t_PartialEq t_U64NotAllOnes t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_182:Core.Cmp.t_Eq t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_164:Core.Cmp.t_PartialOrd t_U64NotAllOnes t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_163:Core.Cmp.t_Ord t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_165:Core.Hash.t_Hash t_U64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_166:Core.Fmt.t_Debug t_U64NotAllOnes
+
+type t_I64NotAllOnes = | I64NotAllOnes : i64 -> t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_183:Core.Clone.t_Clone t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_184:Core.Marker.t_Copy t_I64NotAllOnes
+
+val e_ee_17: Prims.unit
+
+val impl_I64NotAllOnes__new (v_val: i64)
+    : Prims.Pure (Core.Option.t_Option t_I64NotAllOnes) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_I64NotAllOnes__new_unchecked (v_val: i64)
+    : Prims.Pure t_I64NotAllOnes Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_I64NotAllOnes__as_inner (self: t_I64NotAllOnes)
+    : Prims.Pure i64 Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_168:Core.Marker.t_StructuralPartialEq t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_169:Core.Cmp.t_PartialEq t_I64NotAllOnes t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_185:Core.Cmp.t_Eq t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_171:Core.Cmp.t_PartialOrd t_I64NotAllOnes t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_170:Core.Cmp.t_Ord t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_172:Core.Hash.t_Hash t_I64NotAllOnes
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_173:Core.Fmt.t_Debug t_I64NotAllOnes
+
+class t_NotAllOnesHelper (v_Self: Type0) = {
+  f_Type:Type0;
+  f_Type_659097508213326199:Core.Marker.t_Sized f_Type
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_NotAllOnesHelper_for_u32: t_NotAllOnesHelper u32 =
+  { f_Type = t_U32NotAllOnes; f_Type_659097508213326199 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_NotAllOnesHelper_for_i32: t_NotAllOnesHelper i32 =
+  { f_Type = t_I32NotAllOnes; f_Type_659097508213326199 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_NotAllOnesHelper_for_u64: t_NotAllOnesHelper u64 =
+  { f_Type = t_U64NotAllOnes; f_Type_659097508213326199 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_NotAllOnesHelper_for_i64: t_NotAllOnesHelper i64 =
+  { f_Type = t_I64NotAllOnes; f_Type_659097508213326199 = FStar.Tactics.Typeclasses.solve }

--- a/hax-lib/proof-libs/fstar/core/Core.Time.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core.Time.fsti
@@ -1,0 +1,366 @@
+module Core.Time
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val v_NANOS_PER_SEC: u32
+
+val v_NANOS_PER_MILLI: u32
+
+val v_NANOS_PER_MICRO: u32
+
+val v_MILLIS_PER_SEC: u64
+
+val v_MICROS_PER_SEC: u64
+
+val v_SECS_PER_MINUTE: u64
+
+val v_MINS_PER_HOUR: u64
+
+val v_HOURS_PER_DAY: u64
+
+val v_DAYS_PER_WEEK: u64
+
+type t_Duration = {
+  f_secs:u64;
+  f_nanos:Core.Num.Niche_types.t_Nanoseconds
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_16:Core.Clone.t_Clone t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_17:Core.Marker.t_Copy t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_18:Core.Marker.t_StructuralPartialEq t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_19:Core.Cmp.t_PartialEq t_Duration t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_20:Core.Cmp.t_Eq t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_21:Core.Cmp.t_PartialOrd t_Duration t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_22:Core.Cmp.t_Ord t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_23:Core.Hash.t_Hash t_Duration
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_24:Core.Default.t_Default t_Duration
+
+val impl_Duration__SECOND: t_Duration
+
+val impl_Duration__MILLISECOND: t_Duration
+
+val impl_Duration__MICROSECOND: t_Duration
+
+val impl_Duration__NANOSECOND: t_Duration
+
+val impl_Duration__ZERO: t_Duration
+
+val impl_Duration__MAX: t_Duration
+
+val impl_Duration__new (secs: u64) (nanos: u32)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_secs (secs: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_millis (millis: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_micros (micros: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_nanos (nanos: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_weeks (weeks: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_days (days: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_hours (hours: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_mins (mins: u64)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__is_zero (self: t_Duration) : Prims.Pure bool Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_secs (self: t_Duration) : Prims.Pure u64 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__subsec_millis (self: t_Duration)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__subsec_micros (self: t_Duration)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__subsec_nanos (self: t_Duration)
+    : Prims.Pure u32 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_millis (self: t_Duration)
+    : Prims.Pure u128 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_micros (self: t_Duration)
+    : Prims.Pure u128 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_nanos (self: t_Duration)
+    : Prims.Pure u128 Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__abs_diff (self other: t_Duration)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__checked_add (self rhs: t_Duration)
+    : Prims.Pure (Core.Option.t_Option t_Duration) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__saturating_add (self rhs: t_Duration)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__checked_sub (self rhs: t_Duration)
+    : Prims.Pure (Core.Option.t_Option t_Duration) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__saturating_sub (self rhs: t_Duration)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__checked_mul (self: t_Duration) (rhs: u32)
+    : Prims.Pure (Core.Option.t_Option t_Duration) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__saturating_mul (self: t_Duration) (rhs: u32)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__checked_div (self: t_Duration) (rhs: u32)
+    : Prims.Pure (Core.Option.t_Option t_Duration) Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_secs_f64 (self: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_secs_f32 (self: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_millis_f64 (self: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__as_millis_f32 (self: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_secs_f64 (secs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_secs_f32 (secs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__mul_f64 (self: t_Duration) (rhs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__mul_f32 (self: t_Duration) (rhs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_f64 (self: t_Duration) (rhs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_f32 (self: t_Duration) (rhs: float)
+    : Prims.Pure t_Duration Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_duration_f64 (self rhs: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_duration_f32 (self rhs: t_Duration)
+    : Prims.Pure float Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_nanos__v_NANOS_PER_SEC: u64
+
+val impl_Duration__from_secs_f64__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__from_secs_f32__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__mul_f64__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__mul_f32__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_f64__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__div_f32__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_add__impl_1__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_2:Core.Ops.Arith.t_AddAssign t_Duration t_Duration
+
+val f_add_assign__impl_2__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_sub__impl_3__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_4:Core.Ops.Arith.t_SubAssign t_Duration t_Duration
+
+val f_sub_assign__impl_4__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_mul__impl_5__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_mul__impl_6__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_7:Core.Ops.Arith.t_MulAssign t_Duration u32
+
+val f_mul_assign__impl_7__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_div__impl_8__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_9:Core.Ops.Arith.t_DivAssign t_Duration u32
+
+val f_div_assign__impl_9__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+(* [@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_10:Core.Iter.Traits.Accum.t_Sum t_Duration t_Duration *)
+
+val f_sum__impl_10__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+(* [@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_11:Core.Iter.Traits.Accum.t_Sum t_Duration t_Duration *)
+
+val f_sum__impl_11__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_12:Core.Fmt.t_Debug t_Duration
+
+val f_fmt__impl_12__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val f_fmt__impl_14__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+type t_TryFromFloatSecsErrorKind =
+  | TryFromFloatSecsErrorKind_Negative : t_TryFromFloatSecsErrorKind
+  | TryFromFloatSecsErrorKind_OverflowOrNan : t_TryFromFloatSecsErrorKind
+
+type t_TryFromFloatSecsError = { f_kind:t_TryFromFloatSecsErrorKind }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_25:Core.Fmt.t_Debug t_TryFromFloatSecsError
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_26:Core.Clone.t_Clone t_TryFromFloatSecsError
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_27:Core.Marker.t_StructuralPartialEq t_TryFromFloatSecsError
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_28:Core.Cmp.t_PartialEq t_TryFromFloatSecsError t_TryFromFloatSecsError
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_29:Core.Cmp.t_Eq t_TryFromFloatSecsError
+
+val impl_TryFromFloatSecsError__description (self: t_TryFromFloatSecsError)
+    : Prims.Pure string Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_14:Core.Fmt.t_Display t_TryFromFloatSecsError
+
+val t_TryFromFloatSecsErrorKind_cast_to_repr (x: t_TryFromFloatSecsErrorKind)
+    : Prims.Pure isize Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_30:Core.Fmt.t_Debug t_TryFromFloatSecsErrorKind
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_31:Core.Clone.t_Clone t_TryFromFloatSecsErrorKind
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_32:Core.Marker.t_StructuralPartialEq t_TryFromFloatSecsErrorKind
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_33:Core.Cmp.t_PartialEq t_TryFromFloatSecsErrorKind t_TryFromFloatSecsErrorKind
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+val impl_34:Core.Cmp.t_Eq t_TryFromFloatSecsErrorKind
+
+val impl_Duration__try_from_secs_f32 (secs: float)
+    : Prims.Pure (Core.Result.t_Result t_Duration t_TryFromFloatSecsError)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_Duration__try_from_secs_f64 (secs: float)
+    : Prims.Pure (Core.Result.t_Result t_Duration t_TryFromFloatSecsError)
+      Prims.l_True
+      (fun _ -> Prims.l_True)
+
+val impl_Duration__try_from_secs_f32__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+val impl_Duration__try_from_secs_f64__panic_cold_explicit: Prims.unit
+  -> Prims.Pure Rust_primitives.Hax.t_Never Prims.l_True (fun _ -> Prims.l_True)
+
+(* [@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core.Ops.Arith.t_Add t_Duration t_Duration =
+  {
+    f_Output = t_Duration;
+    f_Output_11695847888444666345 = FStar.Tactics.Typeclasses.solve;
+    f_add_pre = (fun (self: t_Duration) (rhs: t_Duration) -> true);
+    f_add_post = (fun (self: t_Duration) (rhs: t_Duration) (out: t_Duration) -> true);
+    f_add = fun (self: t_Duration) (rhs: t_Duration) -> () <: t_Duration
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3: Core.Ops.Arith.t_Sub t_Duration t_Duration =
+  {
+    f_Output = t_Duration;
+    f_Output_9381071510542709353 = FStar.Tactics.Typeclasses.solve;
+    f_sub_pre = (fun (self: t_Duration) (rhs: t_Duration) -> true);
+    f_sub_post = (fun (self: t_Duration) (rhs: t_Duration) (out: t_Duration) -> true);
+    f_sub = fun (self: t_Duration) (rhs: t_Duration) -> () <: t_Duration
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_5: Core.Ops.Arith.t_Mul t_Duration u32 =
+  {
+    f_Output = t_Duration;
+    f_Output_11167888388700478202 = FStar.Tactics.Typeclasses.solve;
+    f_mul_pre = (fun (self: t_Duration) (rhs: u32) -> true);
+    f_mul_post = (fun (self: t_Duration) (rhs: u32) (out: t_Duration) -> true);
+    f_mul = fun (self: t_Duration) (rhs: u32) -> () <: t_Duration
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_6: Core.Ops.Arith.t_Mul u32 t_Duration =
+  {
+    f_Output = t_Duration;
+    f_Output_11167888388700478202 = FStar.Tactics.Typeclasses.solve;
+    f_mul_pre = (fun (self: u32) (rhs: t_Duration) -> true);
+    f_mul_post = (fun (self: u32) (rhs: t_Duration) (out: t_Duration) -> true);
+    f_mul = fun (self: u32) (rhs: t_Duration) -> () <: t_Duration
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_8: Core.Ops.Arith.t_Div t_Duration u32 =
+  {
+    f_Output = t_Duration;
+    f_Output_10117503193521621741 = FStar.Tactics.Typeclasses.solve;
+    f_div_pre = (fun (self: t_Duration) (rhs: u32) -> true);
+    f_div_post = (fun (self: t_Duration) (rhs: u32) (out: t_Duration) -> true);
+    f_div = fun (self: t_Duration) (rhs: u32) -> () <: t_Duration
+  } *)


### PR DESCRIPTION
This PR contains the changes from hax-evit up to June 11th. We add interfaces to the f* proof libs that were extracted using hax from the actual definitions in Rust core.