### PR TITLE
Rust Engine: improve debug utility `show-json`

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,10 @@ expand *FLAGS:
     $([[ "$(cargo --version)" == *nightly* ]] || echo "+nigthly") \
     expand {{FLAGS}}
 
+# Show debug JSON emitted by the Rust engine
+@show-json N: (_ensure_command_in_path "jless" "jless (https://jless.io/)") (_ensure_command_in_path "jq" "jq (https://jqlang.github.io/jq/)")
+  cat /tmp/hax-ast-debug.json | jq -s '.[{{N}}]' | jless
+
 # Show the generated module `concrete_ident_generated.ml`, that contains all the Rust names the engine knows about. Those names are declared in the `./engine/names` crate.
 @list-names:
   hax-engine-names-extract | sed '/include .val/,$d' | just _pager

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -78,7 +78,7 @@ impl<T: serde::Serialize> Display for DebugJSON<T> {
         }
 
         /// Drop the file at `PATH` when we first write
-        fn cleanup() {
+        fn clean_up() {
             static DID_RUN: AtomicBool = AtomicBool::new(false);
             use std::sync::atomic::{AtomicBool, Ordering};
             if DID_RUN

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -58,6 +58,11 @@ use resugared::*;
 pub struct DebugJSON<T: serde::Serialize>(pub T);
 
 impl<T: serde::Serialize> Display for DebugJSON<T> {
+    #[cfg(not(unix))]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<unknown, DebugJSON supported on unix plateforms only>")
+    }
+    #[cfg(unix)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         const PATH: &str = "/tmp/hax-ast-debug.json";
         /// Write a new JSON as a line at the end of `PATH`

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -59,11 +59,14 @@ pub struct DebugJSON<T: serde::Serialize>(pub T);
 
 impl<T: serde::Serialize> Display for DebugJSON<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const PATH: &str = "/tmp/hax-ast-debug.json";
+        /// Write a new JSON as a line at the end of `PATH`
         fn append_line_json(path: &str, value: &serde_json::Value) -> std::io::Result<usize> {
             use std::{
                 fs::OpenOptions,
                 io::{BufRead, BufReader, Write},
             };
+            cleanup();
             let file = OpenOptions::new()
                 .read(true)
                 .append(true)
@@ -74,7 +77,18 @@ impl<T: serde::Serialize> Display for DebugJSON<T> {
             Ok(count)
         }
 
-        const PATH: &str = "/tmp/hax-ast-debug.json";
+        /// Drop the file at `PATH` when we first write
+        fn cleanup() {
+            static DID_RUN: AtomicBool = AtomicBool::new(false);
+            use std::sync::atomic::{AtomicBool, Ordering};
+            if DID_RUN
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                let _ignored = std::fs::remove_file(PATH);
+            }
+        }
+
         let id = append_line_json(PATH, &serde_json::to_value(&self.0).unwrap()).unwrap();
         write!(f, "`just debug-json {id}`")
     }

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -91,8 +91,11 @@ impl<T: serde::Serialize> Display for DebugJSON<T> {
             }
         }
 
-        let id = append_line_json(&serde_json::to_value(&self.0).unwrap()).unwrap();
-        write!(f, "`just debug-json {id}`")
+        if let Ok(id) = append_line_json(&serde_json::to_value(&self.0).unwrap()) {
+            write!(f, "`just debug-json {id}`")
+        } else {
+            write!(f, "<DebugJSON failed>")
+        }
     }
 }
 

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -61,24 +61,21 @@ impl<T: serde::Serialize> Display for DebugJSON<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         const PATH: &str = "/tmp/hax-ast-debug.json";
         /// Write a new JSON as a line at the end of `PATH`
-        fn append_line_json(path: &str, value: &serde_json::Value) -> std::io::Result<usize> {
-            use std::{
-                fs::OpenOptions,
-                io::{BufRead, BufReader, Write},
-            };
+        fn append_line_json(value: &serde_json::Value) -> std::io::Result<usize> {
+            use std::io::{BufRead, BufReader, Write};
             cleanup();
-            let file = OpenOptions::new()
+            let file = std::fs::OpenOptions::new()
                 .read(true)
                 .append(true)
                 .create(true)
-                .open(path)?;
+                .open(PATH)?;
             let count = BufReader::new(&file).lines().count();
             writeln!(&file, "{value}")?;
             Ok(count)
         }
 
         /// Drop the file at `PATH` when we first write
-        fn clean_up() {
+        fn cleanup() {
             static DID_RUN: AtomicBool = AtomicBool::new(false);
             use std::sync::atomic::{AtomicBool, Ordering};
             if DID_RUN
@@ -89,7 +86,7 @@ impl<T: serde::Serialize> Display for DebugJSON<T> {
             }
         }
 
-        let id = append_line_json(PATH, &serde_json::to_value(&self.0).unwrap()).unwrap();
+        let id = append_line_json(&serde_json::to_value(&self.0).unwrap()).unwrap();
         write!(f, "`just debug-json {id}`")
     }
 }


### PR DESCRIPTION
This PR adds a command `show-json` to our `justfile`.
I forgot to commit it.

This PR also makes sure to clean up the temporary file created by `show-json`: whenever we first write to that temp file, we try to drop it.

Thanks @clementblaudeau, who saw the command was missing in the justfile