### PR TITLE
feat(nix/ci): run examples outside of the sandbox

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -39,7 +39,9 @@ jobs:
         
     - name: Test the examples
       run: |
-        nix build .#check-examples -L
+        cd examples
+        nix develop ..#ci-examples --command make clean
+        nix develop ..#ci-examples --command make
 
     - name: Try to extract Rust By Examples
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -57,9 +57,11 @@
         '';
         ocamlPackages = pkgs.ocamlPackages;
         ocamlformat = ocamlPackages.ocamlformat_0_27_0;
+        proverif = pkgs.proverif.overrideDerivation
+          (_: { patches = [ examples/proverif-psk/pv_div_by_zero_fix.diff ]; });
       in rec {
         packages = {
-          inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs;
+          inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs proverif;
           docs = pkgs.python312Packages.callPackage ./docs {
             hax-frontend-docs = packages.hax-rust-frontend.docs;
             hax-engine-docs = packages.hax-engine.docs;
@@ -170,7 +172,6 @@
             })
             packages.docs
           ];
-        in let
           utils = pkgs.stdenv.mkDerivation {
             name = "hax-dev-scripts";
             phases = [ "installPhase" ];
@@ -179,7 +180,7 @@
               cp ${./.utils/rebuild.sh} $out/bin/rebuild
             '';
           };
-          packages = [
+          defaultPackages = [
             ocamlformat
             ocamlPackages.ocaml-lsp
             ocamlPackages.ocamlformat-rpc-lib
@@ -210,12 +211,26 @@
               export HAX_PROOF_LIBS_HOME="$HAX_ROOT/proof-libs/fstar"
               export HAX_LIBS_HOME="$HAX_ROOT/hax-lib"
             '';
-            packages = packages ++ [ fstar pkgs.proverif ];
+            packages = defaultPackages ++ [ fstar pkgs.proverif ];
+          };
+          ci-examples = pkgs.mkShell {
+            shellHook = ''
+              eval $(hax-env)
+              export CACHE_DIR=$(mktemp -d)
+              export HINT_DIR=$(mktemp -d)
+              export SHELL=${pkgs.bash}/bin/bash
+            '';
+            packages = [
+              packages.hax
+              packages.hax-env
+              packages.fstar
+              packages.proverif
+              pkgs.jq
+            ];
           };
           default = pkgs.mkShell {
-            inherit packages inputsFrom LIBCLANG_PATH DYLD_LIBRARY_PATH;
-            shellHook = ''
-              echo "Commands available: $(ls ${utils}/bin | tr '\n' ' ')" 1>&2'';
+            inherit inputsFrom LIBCLANG_PATH DYLD_LIBRARY_PATH;
+            packages = defaultPackages;
           };
         };
       });


### PR DESCRIPTION
This PR makes the CI run the `examples` test cases outside of the Nix sandbox.
Nix enforce reproducability, thus disable network.
For Lean, @clementblaudeau needs to adds example that have a third party dependency: putting the burden of packaging examples with nix so that they can be in the CI is unpleasant and not useful.
Thus, this PR now uses nix to build the binary dependencies of the examples, but then the examples are run outside of the sandbox.

@clementblaudeau if the PR is green, you can rebase yours onto this one!

EDIT: leaving it as draft, let's wait for CI to be happy