### PR TITLE
misc(rengine): stop pinning `derive-generic-visitor` with a git branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,16 +361,18 @@ dependencies = [
 
 [[package]]
 name = "derive_generic_visitor"
-version = "0.2.0"
-source = "git+https://github.com/W95Psp/derive-generic-visitor.git?branch=visitable-group-add-attrs#fc4fb41661e59deb48feec66d06b579a1236d5f3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8307b157ef1ca852032be5723dd87063a30a58bc373d663eb327cfbf71f198da"
 dependencies = [
  "derive_generic_visitor_macros",
 ]
 
 [[package]]
 name = "derive_generic_visitor_macros"
-version = "0.2.0"
-source = "git+https://github.com/W95Psp/derive-generic-visitor.git?branch=visitable-group-add-attrs#fc4fb41661e59deb48feec66d06b579a1236d5f3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20916a23e6247d36d3526a9dce953303a6a83091eaae6d96f08fb3d976ab257"
 dependencies = [
  "convert_case",
  "darling",

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -19,5 +19,5 @@ serde-jsonlines = "0.5.0"
 serde_stacker = "0.1.12"
 pretty = "0.12"
 itertools.workspace = true
-derive_generic_visitor = { git = "https://github.com/W95Psp/derive-generic-visitor.git", branch = "visitable-group-add-attrs" }
+derive_generic_visitor = "0.3.0"
 pastey = "0.1.0"


### PR DESCRIPTION
Fixes https://github.com/cryspen/hax/issues/1598.

Thanks @nadrieril, who merged https://github.com/Nadrieril/derive-generic-visitor/pull/2 and published a new version of that crate :)