### PR TITLE
ci(rengine): clippy: deny lints

### DIFF
--- a/.github/workflows/clippy_rust_engine.yml
+++ b/.github/workflows/clippy_rust_engine.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run clippy
       run: |
-        cargo clippy -p hax-rust-engine -- --no-deps
+        cargo clippy -p hax-rust-engine -- -D warnings --no-deps


### PR DESCRIPTION
This PR makes clippy deny lints in CI.

Our CI job was just emitting warnings, doing nothing in practice.

cc @franziskuskiefer  