### PR TITLE
fix(rengine): drop `unused`

### DIFF
--- a/rust-engine/src/backends.rs
+++ b/rust-engine/src/backends.rs
@@ -104,7 +104,6 @@ pub fn apply_backend<B: Backend + 'static>(backend: B, mut items: Vec<Item>) -> 
         .collect()
 }
 
-#[allow(unused)]
 mod prelude {
     //! Small "bring-into-scope" set used by backend modules.
     //!


### PR DESCRIPTION
Fixes https://github.com/cryspen/hax/issues/1615.