### PR TITLE
Rust-engine / Lean backend: pass include flag from the ocaml engine to the rust engine.

### DIFF
--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -277,7 +277,9 @@ let driver_for_rust_engine () : unit =
        `ocaml_engine.rs`. This is a temporary flag that applies some phases while
        importing THIR. In the future (when #1550 is merged), we will be able to
        import THIR and then apply phases. *)
-      let imported_items = import_thir_items [] input in
+      let imported_items =
+        import_thir_items query.translation_options.include_namespaces input
+      in
       let rust_ast_items =
         if apply_phases then
           let imported_items = Lean_backend.apply_phases imported_items in

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
             input: value.input,
             apply_phases: !matches!(&value.backend.backend, Backend::GenerateRustEngineNames),
         },
+        translation_options: value.backend.translation_options,
     };
 
     let Some(Response::ImportThir { output: items }) = query.execute() else {

--- a/rust-engine/src/ocaml_engine.rs
+++ b/rust-engine/src/ocaml_engine.rs
@@ -23,6 +23,8 @@ pub struct Query {
     )>,
     /// The kind of query we want to send to the engine
     pub kind: QueryKind,
+    /// Translation options which contains include clauses (items filtering)
+    pub translation_options: hax_types::cli_options::TranslationOptions,
 }
 
 /// The payload of the query. [`Response`] below mirrors this enum to represent


### PR DESCRIPTION
This PR allows to use the `-i` flag with the lean backend.