### PR TITLE
Lean backend - Run rustc coverage tests for lean.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ proof-libs/fstar/rust_primitives/#*#
 !**/proofs/*/extraction/*.diff
 !**/proofs/fstar/extraction/*.fst
 !**/proofs/coq/extraction/*.v
+!**/proofs/lean/extraction/lakefile.toml

--- a/rustc-coverage-tests/Cargo.toml
+++ b/rustc-coverage-tests/Cargo.toml
@@ -11,4 +11,5 @@ fstar = []
 fstar-lax = []
 coq = []
 json = []
+lean = []
 

--- a/rustc-coverage-tests/README.md
+++ b/rustc-coverage-tests/README.md
@@ -5,6 +5,8 @@ The following test target are available:
 - `fstar` to test that extraction to F* succeeds
 - `fstar-lax` to test that extraction to F* and lax-checking succeed
 - `coq` to test that extraction to coq succeeds
+- `lean` to test that extraction to Lean succeeds
+- `lean-tc` to test that extraction to Lean succeeds and type checks
 
 ## Running
 

--- a/rustc-coverage-tests/proofs/lean/extraction/lakefile.toml
+++ b/rustc-coverage-tests/proofs/lean/extraction/lakefile.toml
@@ -1,0 +1,10 @@
+name = "coverage"
+version = "0.1.0"
+defaultTargets = ["coverage"]
+
+[[lean_lib]]
+name = "coverage"
+
+[[require]]
+name = "Hax"
+path = "../../../../hax-lib/proof-libs/lean"

--- a/rustc-coverage-tests/proofs/lean/extraction/lakefile.toml
+++ b/rustc-coverage-tests/proofs/lean/extraction/lakefile.toml
@@ -1,9 +1,9 @@
-name = "coverage"
+name = "Coverage"
 version = "0.1.0"
-defaultTargets = ["coverage"]
+defaultTargets = ["Coverage"]
 
 [[lean_lib]]
-name = "coverage"
+name = "Coverage"
 
 [[require]]
 name = "Hax"

--- a/rustc-coverage-tests/snapshots/fstar/Coverage.Attr.Trait_impl_inherit.fst
+++ b/rustc-coverage-tests/snapshots/fstar/Coverage.Attr.Trait_impl_inherit.fst
@@ -6,8 +6,8 @@ open FStar.Mul
 (* item error backend: (reject_TraitItemDefault) ExplicitRejection { reason: "a node of kind [Trait_item_default] have been found in the AST" }
 Last available AST for this item:
 
-#[<cfg>(any(feature = "json"))]#[feature(coverage_attribute)]#[<cfg>(any(feature = "json", feature = "fstar", feature = "fstar-lax", feature =
-"coq"))]#[feature(coverage_attribute)]#[allow(unused_attributes)]#[allow(dead_code)]#[allow(unreachable_code)]#[feature(register_tool)]#[register_tool(_hax)]trait t_T<Self_>{fn f_f((self: Self)) -> tuple0{{let _: tuple0 = {std::io::stdio::e_print(core::fmt::rt::impl_1__new_const::<generic_value!(todo)>(["default\n"]))};{let _: tuple0 = {Tuple0};Tuple0}}}}
+#[<cfg>(any(feature = "json"))]#[feature(coverage_attribute)]#[<cfg>(any(feature = "json", feature = "lean", feature = "fstar", feature =
+"fstar-lax", feature = "coq"))]#[feature(coverage_attribute)]#[allow(unused_attributes)]#[allow(dead_code)]#[allow(unreachable_code)]#[feature(register_tool)]#[register_tool(_hax)]trait t_T<Self_>{fn f_f((self: Self)) -> tuple0{{let _: tuple0 = {std::io::stdio::e_print(core::fmt::rt::impl_1__new_const::<generic_value!(todo)>(["default\n"]))};{let _: tuple0 = {Tuple0};Tuple0}}}}
 
 Last AST:
 /** print_rust: pitem: not implemented  (item: { Concrete_ident.T.def_id =

--- a/rustc-coverage-tests/snapshots/fstar/Coverage.Inner_items.fst
+++ b/rustc-coverage-tests/snapshots/fstar/Coverage.Inner_items.fst
@@ -38,7 +38,7 @@ let main__v_IN_CONST: u32 = mk_u32 1234
 (* item error backend: (reject_TraitItemDefault) ExplicitRejection { reason: "a node of kind [Trait_item_default] have been found in the AST" }
 Last available AST for this item:
 
-#[<cfg>(any(feature = "json"))]#[allow(unused_assignments, unused_variables, dead_code)]#[feature(coverage_attribute)]#[allow(unused_attributes)]#[allow(dead_code)]#[allow(unreachable_code)]#[feature(register_tool)]#[register_tool(_hax)]trait main__t_InTrait<Self_>{#[_hax::json("\"TraitMethodNoPrePost\"")]fn main__f_trait_func_pre(_: Self,_: int) -> bool;
+#[<cfg>(any(feature = "json", feature = "lean"))]#[allow(unused_assignments, unused_variables, dead_code)]#[feature(coverage_attribute)]#[allow(unused_attributes)]#[allow(dead_code)]#[allow(unreachable_code)]#[feature(register_tool)]#[register_tool(_hax)]trait main__t_InTrait<Self_>{#[_hax::json("\"TraitMethodNoPrePost\"")]fn main__f_trait_func_pre(_: Self,_: int) -> bool;
 #[_hax::json("\"TraitMethodNoPrePost\"")]fn main__f_trait_func_post(_: Self,_: int,_: Self) -> bool;
 fn main__f_trait_func(_: Self,_: int) -> Self;
 fn main__f_default_trait_func((self: Self)) -> Self{{let _: tuple0 = {coverage::inner_items::main__in_func(coverage::inner_items::main__v_IN_CONST)};{let self: Self = {coverage::inner_items::main__f_trait_func(self,coverage::inner_items::main__v_IN_CONST)};self}}}}

--- a/rustc-coverage-tests/src/lib.rs
+++ b/rustc-coverage-tests/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unreachable_code)]
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -11,6 +12,7 @@
 mod attr;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -19,12 +21,23 @@ mod auxiliary;
 /* Modules that are commented out are not used by any test target.
 They are kept in case they need to be added to a target in the future. */
 // mod branch;
-#[cfg(any(feature = "json", feature = "fstar", feature = "fstar-lax"))]
+#[cfg(any(
+    feature = "json",
+    feature = "lean",
+    feature = "fstar",
+    feature = "fstar-lax"
+))]
 mod abort;
-#[cfg(any(feature = "json", feature = "fstar", feature = "fstar-lax"))]
+#[cfg(any(
+    feature = "json",
+    feature = "lean",
+    feature = "fstar",
+    feature = "fstar-lax"
+))]
 mod assert;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -33,6 +46,7 @@ mod assert;
 mod assert_ne;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -40,6 +54,7 @@ mod assert_ne;
 mod assert_not;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -55,28 +70,29 @@ mod mcdc;
 // mod bench;
 // mod closure_bug;
 // mod closure_macro_async;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod closure_macro;
 // mod closure;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod closure_unit_return;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod color;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod conditions;
-#[cfg(any(feature = "json", feature = "fstar"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar"))]
 #[path = "continue.rs"]
 mod continue_;
 // mod coroutine;
 // mod coverage_attr_closure;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod dead_code;
 // #[path = "discard-all-issue-133606.rs"]
 // mod discard_all_issue_133606;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod drop_trait;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -87,15 +103,16 @@ mod generics;
 // #[path = "generic-unused-impl.rs"]
 // mod generic_unused_impl;
 // mod holes;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 #[path = "if.rs"]
 mod if_;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod if_else;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod if_not;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -103,21 +120,23 @@ mod if_not;
 mod ignore_map;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
 ))]
 mod ignore_run;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 #[path = "inline-dead.rs"]
 mod inline_dead;
 // mod inline_mixed;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod inline;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod inner_items;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -130,44 +149,47 @@ mod issue_83601;
 // mod issue_85461;
 // #[path = "issue-93054.rs"]
 // mod issue_93054;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod lazy_boolean;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod let_else_loop;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
 ))]
 mod long_and_wide;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 #[path = "loop-break.rs"]
 mod loop_break;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod loop_break_value;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod loops_branches;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
 ))]
 mod macro_in_closure;
 // mod macro_name_span;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod match_or_pattern;
-#[cfg(any(feature = "json", feature = "fstar"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar"))]
 mod nested_loops;
 // #[path = "no-core.rs"]
 // mod no_core;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod no_cov_crate;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod no_spans;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -175,41 +197,49 @@ mod no_spans;
 mod no_spans_if_not;
 #[cfg(any(feature = "json", feature = "fstar"))]
 mod overflow;
-#[cfg(any(feature = "json", feature = "fstar", feature = "fstar-lax"))]
+#[cfg(any(
+    feature = "json",
+    feature = "lean",
+    feature = "fstar",
+    feature = "fstar-lax"
+))]
 mod panic_unwind;
 #[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
 mod partial_eq;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod simple_loop;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod simple_match;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod sort_groups;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
 ))]
 mod test_harness;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 mod tight_inf_loop;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
 ))]
 mod trivial;
-#[cfg(any(feature = "json", feature = "fstar", feature = "coq"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar", feature = "coq"))]
 mod try_error_result;
 #[cfg(any(feature = "json"))]
 mod unicode;
 // mod unreachable;
-#[cfg(any(feature = "json", feature = "fstar"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar"))]
 mod unused;
 #[cfg(any(
     feature = "json",
+    feature = "lean",
     feature = "fstar",
     feature = "fstar-lax",
     feature = "coq"
@@ -217,9 +247,9 @@ mod unused;
 mod unused_mod;
 // mod uses_crate;
 // mod uses_inline_crate;
-#[cfg(any(feature = "json"))]
+#[cfg(any(feature = "json", feature = "lean"))]
 #[path = "while.rs"]
 mod while_;
-#[cfg(any(feature = "json", feature = "fstar"))]
+#[cfg(any(feature = "json", feature = "lean", feature = "fstar"))]
 mod while_early_ret;
 // mod r#yield;

--- a/rustc-coverage-tests/test_config.yaml
+++ b/rustc-coverage-tests/test_config.yaml
@@ -2,108 +2,134 @@ tests:
   attr::impl_:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   attr::module:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   attr::off_on_sandwich:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   attr::trait_impl_inherit:
     - json
+    - lean
   auxiliary::discard_all_helper:
     - json
     - coq
+    - lean
+    - lean-tc
     - fstar
     - fstar-lax
   auxiliary::used_crate:
     - json
     - coq
     - fstar
+    - lean
   auxiliary::used_inline_crate:
     - json
     - coq
     - fstar
+    - lean
   condition::conditions:
     - json
     - coq
     - fstar 
     - fstar-lax
+    - lean
   mcdc::condition_limit:
     - json
+    - lean
   mcdc::if_:
     - json
     - coq
     - fstar 
     - fstar-lax
+    - lean
   mcdc::inlined_expressions:
     - json
     - coq
     - fstar 
     - fstar-lax
+    - lean
   mcdc::nested_if:
     - json
     - coq
     - fstar 
     - fstar-lax
+    - lean
   mcdc::non_control_flow:
     - json
     - coq
     - fstar 
     - fstar-lax
+    - lean
   abort:
     - json
+    - lean
     - fstar
     - fstar-lax
   assert:
     - json
+    - lean
     - fstar
     - fstar-lax
   assert_ne:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   assert_not:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   closure_macro:
     - json
     - coq
     - fstar
+    - lean
   closure_unit_return:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   color:
     - json
+    - lean
   conditions:
     - json
     - coq
     - fstar
+    - lean
   continue_:
     - json
     - fstar
+    - lean
   dead_code:
     - json
     - coq
     - fstar
+    - lean
   drop_trait:
     - json
     - coq
     - fstar
     - fstar-lax
+    - lean
   fn_sig_into_try:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   generics:
@@ -114,83 +140,104 @@ tests:
     - json
     - coq
     - fstar
+    - lean
   if_else:
     - json
     - coq
     - fstar
+    - lean
   if_not:
     - json
+    - lean
   ignore_map:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   ignore_run:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   inline_dead:
     - json
     - coq
     - fstar
+    - lean
   inline:
     - json
+    - lean
   inner_items:
     - json
+    - lean
   issue_83601:
     - json
     - coq
+    - lean
     - fstar
     - fstar-lax
   lazy_boolean:
     - json
     - coq
     - fstar
+    - lean
   let_else_loop:
     - json
+    - lean
   long_and_wide:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
 
   loop_break:
     - json
+    - lean
 
   loop_break_value:
     - json
+    - lean
 
   loops_branches:
     - json
+    - lean
 
   macro_in_closure:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
 
   match_or_pattern:
     - json
+    - lean
     - fstar
     - coq
 
   nested_loops:
     - json
     - fstar
+    - lean
 
   no_cov_crate:
     - json
+    - lean
     - fstar
     - coq
 
   no_spans:
     - json
+    - lean
     - fstar
     - coq
 
   no_spans_if_not:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
@@ -202,6 +249,7 @@ tests:
 
   panic_unwind:
     - json
+    - lean
     - fstar
     - fstar-lax
 
@@ -213,32 +261,39 @@ tests:
 
   simple_loop:
     - json
+    - lean
 
   simple_match:
     - json
+    - lean
 
   sort_groups:
     - json
+    - lean
     - fstar
     - coq
 
   test_harness:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
 
   tight_inf_loop:
     - json
+    - lean
 
   trivial:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
 
   try_error_result:
     - json
+    - lean
     - fstar
     - coq
 
@@ -248,16 +303,20 @@ tests:
   unused:
     - json
     - fstar
+    - lean
 
   unused_mod:
     - json
+    - lean
     - fstar
     - fstar-lax
     - coq
 
   while_:
     - json
+    - lean
   
   while_early_ret:
     - json
     - fstar
+    - lean

--- a/rustc-coverage-tests/test_config.yaml
+++ b/rustc-coverage-tests/test_config.yaml
@@ -247,6 +247,7 @@ tests:
     - json
     - fstar
     - fstar-lax
+    - lean
 
   panic_unwind:
     - json

--- a/rustc-coverage-tests/test_config.yaml
+++ b/rustc-coverage-tests/test_config.yaml
@@ -136,6 +136,7 @@ tests:
     - json
     - coq
     - fstar
+    - lean
   if_:
     - json
     - coq
@@ -258,6 +259,7 @@ tests:
     - fstar
     - coq
     - fstar-lax
+    - lean
 
   simple_loop:
     - json


### PR DESCRIPTION
This PR extends the existing infrastructure to run rustc coverage tests with lean extraction (and type checking). Currently all tests fail type checking, a lot of it seems to be because they return unit and there is a bug with that (should be fixed by https://github.com/cryspen/hax/pull/1629)

[skip changelog]
libcrux-ref: frontend-upgrades-hash-fixes