### PR TITLE
Rust engine: Optimize communication with hax driver and Ocaml engine.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,6 @@ dependencies = [
  "pretty",
  "schemars",
  "serde",
- "serde-jsonlines",
  "serde_json",
  "serde_stacker",
 ]

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -264,9 +264,7 @@ module ExportLeanAst = Export_ast.Make (Lean_backend.InputLanguage)
 (** Entry point for interacting with the Rust hax engine *)
 let driver_for_rust_engine () : unit =
   let query : Rust_engine_types.query =
-    (* TODO: support for table *)
-    (* let json = load_table ~check_version:false in *)
-    let json = Hax_io.read_json () |> Option.value_exn in
+    let json = load_table ~check_version:false in
     [%of_yojson: Rust_engine_types.query] json
   in
   Concrete_ident.ImplInfoStore.init

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -15,7 +15,6 @@ hax-rust-engine-macros = { path = "macros" }
 hax-types.workspace = true
 serde_json = { workspace = true, features = ["unbounded_depth"] }
 schemars.workspace = true
-serde-jsonlines = "0.5.0"
 serde_stacker = "0.1.12"
 pretty = "0.12"
 itertools.workspace = true

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     let ExtendedToEngine::Query(input) = hax_rust_engine::hax_io::read() else {
         panic!()
     };
-    let (value, _map) = input.destruct();
+    let (value, table) = input.destruct();
 
     let query = hax_rust_engine::ocaml_engine::Query {
         hax_version: value.hax_version,
@@ -20,7 +20,7 @@ fn main() {
         },
     };
 
-    let Some(Response::ImportThir { output: items }) = query.execute() else {
+    let Some(Response::ImportThir { output: items }) = query.execute(table) else {
         panic!()
     };
 

--- a/rust-engine/src/ocaml_engine.rs
+++ b/rust-engine/src/ocaml_engine.rs
@@ -4,7 +4,10 @@
 
 use std::io::BufRead;
 
-use hax_frontend_exporter::ThirBody;
+use hax_frontend_exporter::{
+    ThirBody,
+    id_table::{Table, WithTable},
+};
 use hax_types::engine_api::{
     EngineOptions,
     protocol::{FromEngine, ToEngine},
@@ -57,7 +60,7 @@ pub enum ExtendedToEngine {
     /// A standard `ToEngine` message
     ToEngine(ToEngine),
     /// A `Query`
-    Query(Box<hax_frontend_exporter::id_table::WithTable<EngineOptions>>),
+    Query(Box<WithTable<EngineOptions>>),
 }
 
 /// Extends the common `FromEngine` messages with one extra case: `Response`.
@@ -72,7 +75,7 @@ pub enum ExtendedFromEngine {
 
 impl Query {
     /// Execute the query synchronously.
-    pub fn execute(&self) -> Option<Response> {
+    pub fn execute(&self, table: Table) -> Option<Response> {
         use std::io::Write;
         use std::process::Command;
 
@@ -98,8 +101,9 @@ impl Query {
                 .expect("Could not write on stdin"),
         );
 
-        // TODO: send a table here (see https://github.com/cryspen/hax/issues/1536)
-        send!(stdin, self);
+        WithTable::run(table, self, |with_table| {
+            send!(stdin, with_table);
+        });
 
         let mut response = None;
         let stdout = std::io::BufReader::new(engine_subprocess.stdout.take().unwrap());


### PR DESCRIPTION
Fixes #1536. In addition to the use of tables for the Rust engine -> Ocaml engine communication, this PR disables serde recursion limits for the deserialization at message reception in the communication hax driver -> Rust engine. Together, these two changes allow to fix crashes when using the Rust engine (and lean backend) on large crates.