### PR TITLE
fix(rengine): missed case `Static` in name rendering

### DIFF
--- a/rust-engine/src/ast/identifiers/global_id/view.rs
+++ b/rust-engine/src/ast/identifiers/global_id/view.rs
@@ -652,6 +652,7 @@ impl PathSegment {
             DefKind::Mod => AnyKind::Mod,
             DefKind::Fn => AnyKind::Fn,
             DefKind::Const => AnyKind::Const,
+            DefKind::Static { .. } => AnyKind::Static,
             DefKind::Use => AnyKind::Use,
             DefKind::TyAlias => AnyKind::TyAlias,
             DefKind::TraitAlias => AnyKind::TraitAlias,

--- a/rust-engine/src/ast/identifiers/global_id/view.rs
+++ b/rust-engine/src/ast/identifiers/global_id/view.rs
@@ -445,7 +445,11 @@ impl PathSegmentPayload {
             | DefKind::Closure => Self::from_unnamed(def_id)
                 .unwrap_or_else(|message| error_dummy_value(message, def_id)),
 
-            _ => error_dummy_value(
+            DefKind::TyParam
+            | DefKind::ConstParam
+            | DefKind::PromotedConst
+            | DefKind::LifetimeParam
+            | DefKind::SyntheticCoroutineBody => error_dummy_value(
                 "PathSegmentPayload::from_def_id, kinds should never appear",
                 def_id,
             ),


### PR DESCRIPTION
This fixes a bug you had @clementblaudeau.