### PR TITLE
CONTRIBUTING.md: change and clarify the meaning of assignee

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ The processes described here is not to pester you but to increase and maintain c
 ## Working with this repository
 
 We use issues to organise and prioritise work items.
-If you start working on an issue, assign it to yourself so everyone knows it's being worked on.
-Unassign yourself if you stop working on it and leave a comment why you stopped.
+
+**Assignee meaning in issues:** The assignee is the person responsible for addressing the issue and is typically the one actively working on it.
 
 After picking up an issue create a branch.
 There can be any number of branches and pull request for one issue.


### PR DESCRIPTION
After chatting with @karthikbhargavan, @clementblaudeau and @maximebuyse, we decided to change the semantics of the assignee field on this repository.

The assignee of an issue or a PR is the person responsible for the issue or PR. The notion of assignee is thus now decorelated to "this item is being worked on actively by person X".

To everyone: feel free to suggest different wording if you think this is still unclear!

[skip changelog]