### PR TITLE
Rust engine: errors resugaring.

### DIFF
--- a/rust-engine/src/ast/identifiers/global_id.rs
+++ b/rust-engine/src/ast/identifiers/global_id.rs
@@ -196,6 +196,17 @@ impl ConcreteId {
     pub fn into_concrete(self) -> GlobalId {
         GlobalId::Concrete(self)
     }
+
+    pub fn from_def_id(def_id: DefId) -> ConcreteId {
+        ConcreteId {
+            def_id: ExplicitDefId {
+                is_constructor: false,
+                def_id,
+            },
+            moved: None,
+            suffix: None,
+        }
+    }
 }
 
 impl PartialEq<DefId> for GlobalId {

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -19,16 +19,19 @@ impl_doc_allocator_for!(LeanPrinter);
 
 impl Printer for LeanPrinter {
     fn resugaring_phases() -> Vec<Box<dyn Resugaring>> {
-        vec![Box::new(BinOp::new(&[
-            binops::add(),
-            binops::sub(),
-            binops::mul(),
-            binops::rem(),
-            binops::div(),
-            binops::shr(),
-            binops::logical_op_and(),
-            binops::logical_op_or(),
-        ]))]
+        vec![
+            Box::new(BinOp::new(&[
+                binops::add(),
+                binops::sub(),
+                binops::mul(),
+                binops::rem(),
+                binops::div(),
+                binops::shr(),
+                binops::logical_op_and(),
+                binops::logical_op_or(),
+            ])),
+            Box::new(crate::resugarings::Errors),
+        ]
     }
 
     const NAME: &str = "Lean";


### PR DESCRIPTION
The Error nodes in patterns, type, expression, etc. should be converted into “fake” patterns, “fake” types and “fake” expressions.

E.g., `ExprKind::Error(err)` should be translated in the application `hax_error(formatted err)`