### PR TITLE
Temporarily remove ocaml doc build because of odoc issue.

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, setuptools, wheel, mkdocs
 , mkdocs-material, fetchFromGitHub, natsort, wcmatch, hax-frontend-docs
-, hax-engine-docs, mkdocs-awesome-nav }:
+, mkdocs-awesome-nav }:
 let
   mkdocs-glightbox = buildPythonPackage rec {
     pname = "mkdocs-glightbox";
@@ -47,6 +47,5 @@ in stdenv.mkDerivation {
   installPhase = ''
     mv site $out
     cp -rf ${hax-frontend-docs}/share/doc/ $out/frontend/docs
-    cp -rf ${hax-engine-docs} $out/engine/docs
   '';
 }

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -47,5 +47,6 @@ in stdenv.mkDerivation {
   installPhase = ''
     mv site $out
     cp -rf ${hax-frontend-docs}/share/doc/ $out/frontend/docs
+    echo 'Sorry, this page is temporarily unavailable (see <a href="https://github.com/cryspen/hax/issues/1675">issue</a>)' > $out/engine/docs/hax-engine/index.html
   '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs proverif;
           docs = pkgs.python312Packages.callPackage ./docs {
             hax-frontend-docs = packages.hax-rust-frontend.docs;
-            hax-engine-docs = packages.hax-engine.docs;
+            #hax-engine-docs = packages.hax-engine.docs;
           };
           hax-engine = pkgs.callPackage ./engine {
             hax-rust-frontend = packages.hax-rust-frontend.unwrapped;

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,6 @@
           inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs proverif;
           docs = pkgs.python312Packages.callPackage ./docs {
             hax-frontend-docs = packages.hax-rust-frontend.docs;
-            #hax-engine-docs = packages.hax-engine.docs;
           };
           hax-engine = pkgs.callPackage ./engine {
             hax-rust-frontend = packages.hax-rust-frontend.unwrapped;


### PR DESCRIPTION
Fixes #1638, `odoc` causes issues which require time to debug. This is a temporary fix to remove the step that builds Ocaml documentation. I opened https://github.com/cryspen/hax/issues/1675 to reactivate later.

[skip changelog]
libcrux-ref: frontend-upgrades-hash-fixes