### PR TITLE
fix(engine): add rewrite local self as a proper phase

### DIFF
--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -1086,6 +1086,7 @@ open Phase_utils
 module TransformToInputLanguage =
   [%functor_application
   Phases.Reject.Unsafe(Features.Rust)
+  |> Phases.Rewrite_local_self
   |> Phases.Reject.RawOrMutPointer
   |> Phases.And_mut_defsite
   |> Phases.Reconstruct_asserts

--- a/engine/backends/coq/ssprove/ssprove_backend.ml
+++ b/engine/backends/coq/ssprove/ssprove_backend.ml
@@ -555,6 +555,7 @@ open Phase_utils
 module TransformToInputLanguage =
   [%functor_application
     Phases.Reject.Unsafe(Features.Rust)
+    |> Phases.Rewrite_local_self
     |> Phases.Reject.RawOrMutPointer
     |> Phases.And_mut_defsite
     |> Phases.Reconstruct_asserts

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1943,6 +1943,7 @@ module DepGraphR = Dependencies.Make (Features.Rust)
 module TransformToInputLanguage =
   [%functor_application
     Phases.Reject.RawOrMutPointer(Features.Rust)
+  |> Phases.Rewrite_local_self
   |> Phases.Transform_hax_lib_inline
   |> Phases.Specialize
   |> Phases.Drop_sized_trait
@@ -2003,42 +2004,6 @@ let unsize_as_identity =
   in
   visitor#visit_item ()
 
-(** Rewrites, in trait, local bounds refereing to `Self` into the impl expr of
-    kind `Self`. *)
-let local_self_bound_as_self (i : AST.item) : AST.item =
-  match i.v with
-  | Trait { name; generics; _ } ->
-      let generic_eq (param : generic_param) (value : generic_value) =
-        (let* id =
-           match (param.kind, value) with
-           | GPConst _, GConst { e = LocalVar id } -> Some id
-           | GPType, GType (TParam id) -> Some id
-           | GPLifetime _, GLifetime _ -> Some param.ident
-           | _ -> None
-         in
-         Some ([%eq: local_ident] id param.ident))
-        |> Option.value ~default:false
-      in
-      let generics_eq params values =
-        match List.for_all2 ~f:generic_eq params values with
-        | List.Or_unequal_lengths.Ok v -> v
-        | List.Or_unequal_lengths.Unequal_lengths -> false
-      in
-      (object
-         inherit [_] U.Visitors.map as super
-
-         method! visit_impl_expr () ie =
-           match ie with
-           | { kind = LocalBound _; goal = { args; trait } }
-             when [%eq: concrete_ident] trait name
-                  && generics_eq generics.params args ->
-               { ie with kind = Self }
-           | _ -> ie
-      end)
-        #visit_item
-        () i
-  | _ -> i
-
 let apply_phases (bo : BackendOptions.t) (items : Ast.Rust.item list) :
     AST.item list =
   let items =
@@ -2058,7 +2023,6 @@ let apply_phases (bo : BackendOptions.t) (items : Ast.Rust.item list) :
     TransformToInputLanguage.ditems items
     |> List.map ~f:unsize_as_identity
     |> List.map ~f:unsize_as_identity
-    |> List.map ~f:local_self_bound_as_self
     |> List.map ~f:U.Mappers.add_typ_ascription
   in
   items

--- a/engine/backends/lean/lean_backend.ml
+++ b/engine/backends/lean/lean_backend.ml
@@ -93,6 +93,7 @@ module DepGraphR = Dependencies.Make (Features.Rust)
 module TransformToInputLanguage =
   [%functor_application
     Phases.Reject.RawOrMutPointer(Features.Rust)
+  |> Phases.Rewrite_local_self
   |> Phases.Transform_hax_lib_inline
   |> Phases.Specialize
   |> Phases.Drop_sized_trait

--- a/engine/lib/phases/phase_rewrite_local_self.ml
+++ b/engine/lib/phases/phase_rewrite_local_self.ml
@@ -1,0 +1,51 @@
+open! Prelude
+
+module Make (F : Features.T) =
+  Phase_utils.MakeMonomorphicPhase
+    (F)
+    (struct
+      let phase_id = [%auto_phase_name auto]
+
+      open Ast.Make (F)
+      module U = Ast_utils.Make (F)
+
+      module Error = Phase_utils.MakeError (struct
+        let ctx = Diagnostics.Context.Phase phase_id
+      end)
+
+      let ditem i =
+        match i.v with
+        | Trait { name; generics; _ } ->
+            let generic_eq (param : generic_param) (value : generic_value) =
+              (let* id =
+                 match (param.kind, value) with
+                 | GPConst _, GConst { e = LocalVar id; _ } -> Some id
+                 | GPType, GType (TParam id) -> Some id
+                 | GPLifetime _, GLifetime _ -> Some param.ident
+                 | _ -> None
+               in
+               Some ([%eq: Ast.local_ident] id param.ident))
+              |> Option.value ~default:false
+            in
+            let generics_eq params values =
+              match List.for_all2 ~f:generic_eq params values with
+              | List.Or_unequal_lengths.Ok v -> v
+              | List.Or_unequal_lengths.Unequal_lengths -> false
+            in
+            (object
+               inherit [_] U.Visitors.map as super
+
+               method! visit_impl_expr () ie =
+                 match super#visit_impl_expr () ie with
+                 | { kind = LocalBound _; goal = { args; trait } }
+                   when [%eq: Ast.concrete_ident] trait name
+                        && generics_eq generics.params args ->
+                     { ie with kind = Self }
+                 | ie -> ie
+            end)
+              #visit_item
+              () i
+        | _ -> i
+
+      let ditems = List.map ~f:ditem
+    end)

--- a/engine/lib/phases/phase_rewrite_local_self.mli
+++ b/engine/lib/phases/phase_rewrite_local_self.mli
@@ -1,0 +1,4 @@
+(** Rewrites, in traits and impls, local bounds refereing to `Self` into the
+    impl expr of kind `Self`. *)
+
+module Make : Phase_utils.UNCONSTRAINTED_MONOMORPHIC_PHASE


### PR DESCRIPTION
Moves the function `local_self_bound_as_self` out of the F* backend to a proper phase `Rewrite_local_self`. Add `Rewrite_local_self` to the phases of the F*, Lean, Coq and SSProve backends.

[skip changelog]
libcrux-ref: frontend-upgrades-hash-fixes