### PR TITLE
Fix libcrux-ref for the merge queue.

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -29,12 +29,12 @@ jobs:
               core.notice(`Using libcrux ref: ${resolved}`);
               return resolved;
             } else if (context.eventName === 'merge_group') {
-              const mergeGroupPRs = context.payload.merge_group?.pull_requests || [];
-              for (const prInfo of mergeGroupPRs) {
-                const pull_number = prInfo.number;
-                const pr = await github.rest.pulls.get({...context.repo, pull_number}).data;
+              const query = 'query {repository(owner:"cryspen", name:"hax") {mergeQueue {entries(first:100) {nodes {pullRequest {body, number}}}}}}';
+              const result = await github.graphql(query);
+              const mergeQueuePRs = result.repository.mergeQueue.entries.nodes;
+              for (const pr of mergeQueuePRs) {
                 const ref = extractLibcruxRef(pr.body);
-                ref && refMap.set(pull_number, ref);
+                ref && refMap.set(pr.number, ref);
               }
               if (refMap.size === 0) {
                 core.notice('No libcrux-ref specified, defaulting to "main"');


### PR DESCRIPTION
This PR should fix the extraction of `libcrux-ref` from PR descriptions when they are in the merge queue.

[skip changelog]
libcrux-ref: frontend-upgrades-hash-fixes