### PR TITLE
Allow hax_lib::include to override -i flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 debug/
 target/
 **/*.rs.bk
+**/*.profraw
 node_modules
 TODO.org
 .direnv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Changes to the frontend:
 - Many improvements to `FullDef` (#1559)
 - Add infrastructure to get a monomorphized `FullDef`; this is used in charon to monomorphize a crate graph (#1559)
 
+Changes to hax-lib:
+- New behavior for`hax_lib::include`: it now forces inclusion when in contradiction with `-i` flag.
+
 Miscellaneous:
  - A lean tutorial has been added to the hax website.
 

--- a/docs/manual/faq/include-flags.md
+++ b/docs/manual/faq/include-flags.md
@@ -104,6 +104,28 @@ cargo hax into -i '-** +~mycrate::interesting_function' <BACKEND>
 cargo hax into -i '+:mycrate::not_extracting_function' <BACKEND>
 ```
 
+#### **6. Including anonymous items using `hax_lib::include`**
+Some items like trait impls, or inherent impls have no name so it is impossible to target them specifically using the `-i` flag.
+In this case, one can use `hax_lib::include` to extract these items, and override the default behavior for the rest of the module.
+```rust
+struct S;
+
+#[hax_lib::include]
+impl S {
+    fn f() {}
+}
+
+impl S {
+    #[hax_lib::include]
+    fn g() {}
+    fn h () {}
+}
+```
+To include only `S::f` and `S::g` in the example above, the `hax_lib::include` annotations does the trick, together with the following extraction command:
+```bash
+cargo hax into -i '-**' <BACKEND>
+```
+
 - **Explanation**:
   - `+:mycrate::not_extracting_function`: Includes only the type signature of `mycrate::not_extracting_function` (e.g., as an assumed or axiomatized symbol).
 - **Extracted Items**:

--- a/docs/manual/faq/include-flags.md
+++ b/docs/manual/faq/include-flags.md
@@ -104,9 +104,16 @@ cargo hax into -i '-** +~mycrate::interesting_function' <BACKEND>
 cargo hax into -i '+:mycrate::not_extracting_function' <BACKEND>
 ```
 
+- **Explanation**:
+  - `+:mycrate::not_extracting_function`: Includes only the type signature of `mycrate::not_extracting_function` (e.g., as an assumed or axiomatized symbol).
+- **Extracted Items**:
+  - The type signature of `mycrate::not_extracting_function`, without its body or dependencies.
+
+
+
 #### **6. Including anonymous items using `hax_lib::include`**
-Some items like trait impls, or inherent impls have no name so it is impossible to target them specifically using the `-i` flag.
-In this case, one can use `hax_lib::include` to extract these items, and override the default behavior for the rest of the module.
+Some items like [trait impls](https://doc.rust-lang.org/reference/items/implementations.html#r-items.impl.trait), or [inherent impls](https://doc.rust-lang.org/reference/items/implementations.html#r-items.impl.inherent) have no name so it is impossible to target them specifically using the `-i` flag.
+In this case, one can use [`hax_lib::include`](https://docs.rs/hax-lib/latest/hax_lib/attr.include.html) to extract these items, and override the default behavior for the rest of the module.
 ```rust
 struct S;
 
@@ -125,11 +132,6 @@ To include only `S::f` and `S::g` in the example above, the `hax_lib::include` a
 ```bash
 cargo hax into -i '-**' <BACKEND>
 ```
-
-- **Explanation**:
-  - `+:mycrate::not_extracting_function`: Includes only the type signature of `mycrate::not_extracting_function` (e.g., as an assumed or axiomatized symbol).
-- **Extracted Items**:
-  - The type signature of `mycrate::not_extracting_function`, without its body or dependencies.
 
 ### **Summary**
 The `-i` flag offers powerful control over extraction, allowing fine-grained inclusion and exclusion of items with various dependency handling strategies. Use it to:

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -449,7 +449,7 @@ module Make (F : Features.T) = struct
                    it.attrs ))
              items)
       in
-      Hashtbl.find_exn id_to_include
+      Hashtbl.find id_to_include >> Option.join
     in
 
     let items_drop_body = Hash_set.create (module Concrete_ident) in

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -437,6 +437,21 @@ module Make (F : Features.T) = struct
         |> String.concat ~sep:"::")
       ^ "]"
     in
+    let hax_lib_include =
+      let id_to_include =
+        Hashtbl.of_alist_exn
+          (module Concrete_ident)
+          (List.map
+             ~f:(fun it ->
+               ( it.ident,
+                 Attrs.find_unique_attr
+                   ~f:(function Types.ItemStatus is -> Some is | _ -> None)
+                   it.attrs ))
+             items)
+      in
+      Hashtbl.find_exn id_to_include
+    in
+
     let items_drop_body = Hash_set.create (module Concrete_ident) in
     let apply_clause selection' (clause : Types.inclusion_clause) =
       let matches = Concrete_ident.matches_namespace clause.Types.namespace in
@@ -464,7 +479,15 @@ module Make (F : Features.T) = struct
         | Excluded -> Set.diff
       in
       let result = set_op selection' matched in
-      result
+      let forced_include =
+        selection'
+        |> Set.filter
+             ~f:
+               (hax_lib_include
+               >> [%eq: Types.ha_item_status option]
+                    (Some (Included { late_skip = false })))
+      in
+      Set.union forced_include result
     in
     let selection = List.fold ~init:selection ~f:apply_clause clauses in
     Logs.info (fun m ->

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -174,7 +174,7 @@ pub fn fstar_postprocess_with(attr: pm::TokenStream, item: pm::TokenStream) -> p
     quote! {#[::hax_lib::fstar::before(#payload)] #item}.into()
 }
 
-/// Include this item in the Hax translation.
+/// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn include(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {


### PR DESCRIPTION
We already have the `hax_lib::include` macro but it doesn't have any effect. With this PR, when computing the set of items to extract based on include flag clauses, we force items that have `hax_lib::include` to be always extracted.

libcrux-ref: frontend-upgrades-hash-fixes