### PR TITLE
Docs: hide RFCs tab and add toolchain structure page.

### DIFF
--- a/docs/RFCs/.nav.yml
+++ b/docs/RFCs/.nav.yml
@@ -1,0 +1,1 @@
+hide: true

--- a/docs/engine/toolchain_structure/index.md
+++ b/docs/engine/toolchain_structure/index.md
@@ -1,0 +1,7 @@
+# Toolchain structure
+
+Hax is composed of three main parts:
+
+* The frontend, which interfaces with rustc to extract Rust intermediary representation ASTs (for MIR or THIR) out of Rust code.
+* The engine, which imports the Rust THIR AST to the internal hax AST, and defines a set of transformation phases on this internal AST.
+* The backends, which make use of a set of phases from the engine, and print it to a target verification framework or language. A backend also usually needs to provide a proof library and some more utilities.


### PR DESCRIPTION
This PR makes minor documentation updates:
- Hide the RFCs tab which has never been used
- Add a page under the engine docs, to describe the toolchain structure

[skip changelog]
libcrux-ref: frontend-upgrades-hash-fixes