### PR TITLE
Show Lean backend when doing `cargo hax into --help`

### DIFF
--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -174,6 +174,8 @@ pub struct FStarOptions<E: Extension> {
 pub enum Backend<E: Extension> {
     /// Use the F* backend
     Fstar(FStarOptions<E>),
+    /// Use the Lean backend (warning: experimental)
+    Lean,
     /// Use the Coq backend
     Coq,
     /// Use the SSProve backend
@@ -182,9 +184,6 @@ pub enum Backend<E: Extension> {
     Easycrypt,
     /// Use the ProVerif backend (warning: work in progress!)
     ProVerif(ProVerifOptions),
-    /// Use the Lean backend (warning: work in progress!)
-    #[clap(hide = true)]
-    Lean,
     /// Use the Rust backend (warning: work in progress!)
     #[clap(hide = true)]
     Rust,


### PR DESCRIPTION
This PR make the Lean option visible (it was hidden before). `cargo hax into --help` gives : 
```sh 
Translate to a backend. The translated modules will be written under the directory `<PKG>/proofs/<BACKEND>/extraction`, where `<PKG>` is the translated cargo package name and `<BACKEND>` the name of the backend

Usage: hax into [OPTIONS] <COMMAND>

Commands:
  fstar      Use the F* backend
  lean       Use the Lean backend (warning: experimental)
  coq        Use the Coq backend
  ssprove    Use the SSProve backend
  easycrypt  Use the EasyCrypt backend (warning: work in progress!)
  pro-verif  Use the ProVerif backend (warning: work in progress!)
  help       Print this message or the help of the given subcommand(s)
 
...
```

[skip changelog]