### PR TITLE
fix(ci): cache hax entirely on Cachix

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -58,6 +58,5 @@ jobs:
       env:
         CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       run: |
-        nix build .# .#fstar --json \
-          | jq -r '.[].outputs | to_entries[].value' \
+        nix-store -qR --include-outputs $(nix build .# --json | jq -r '.[].outputs | to_entries[].value') \
           | cachix push hax


### PR DESCRIPTION
The previous job was only caching the superficial layer of hax (a few kb only!).

This PR pushes to cachix the transitive closure of the nix recipe, not just the first derivation.

Should fix https://github.com/hacspec/hax-actions/issues/6.