### PR TITLE
[Lean Backend] Proper error messages

### DIFF
--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -418,7 +418,7 @@ set_option linter.unusedVariables false
                 GenericParamKind::Type => docs![&generic_param.ident, reflow!(" : Type")]
                     .parens()
                     .group(),
-                GenericParamKind::Lifetime => unreachable!(),
+                GenericParamKind::Lifetime => unreachable_by_invariant!(Drop_references),
                 GenericParamKind::Const { .. } => {
                     todo!("-- Unsupported const param")
                 }
@@ -448,8 +448,7 @@ set_option linter.unusedVariables false
                         .parens()
                         .group()
                     } else {
-                        // The Hax engine should ensure that there is always an else branch
-                        unreachable!()
+                        unreachable_by_invariant!(Local_mutation)
                     }
                 }
                 ExprKind::App {
@@ -633,7 +632,7 @@ set_option linter.unusedVariables false
 
         fn arm(&'a self, arm: &'b Arm) -> DocBuilder<'a, Self, A> {
             if let Some(_guard) = &arm.guard {
-                todo!()
+                unreachable_by_invariant!(Drop_match_guards)
             } else {
                 docs![
                     reflow!("| "),
@@ -904,8 +903,9 @@ set_option linter.unusedVariables false
                     if *is_struct {
                         // Structures
                         let Some(variant) = variants.first() else {
-                            // Structures always have a constructor (even empty ones)
-                            unreachable!()
+                            unreachable!(
+                                "Structures should always have a constructor (even empty ones)"
+                            )
                         };
                         let args = if !variant.is_record {
                             // Tuple-like structure, using positional arguments
@@ -1162,5 +1162,27 @@ set_option linter.unusedVariables false
             .group()
             .nest(INDENT)
         }
+
+        fn lhs(&'a self, _lhs: &'b Lhs) -> DocBuilder<'a, Self, A> {
+            unreachable_by_invariant!(Local_mutation)
+        }
+
+
+        fn binding_mode(&'a self, _binding_mode: &'b BindingMode) -> DocBuilder<'a, Self, A> {
+            unreachable!("This backend handle binding modes directly inside patterns")
+        }
+
+        fn region(&'a self, _region: &'b Region) -> DocBuilder<'a, Self, A> {
+            unreachable_by_invariant!(Drop_references)
+        }
+
+        fn borrow_kind(&'a self, _borrow_kind: &'b BorrowKind) -> DocBuilder<'a, Self, A> {
+            unreachable_by_invariant!(Drop_references)
+        }
+
+        fn guard(&'a self, _guard: &'b Guard) -> DocBuilder<'a, Self, A> {
+            unreachable_by_invariant!(Drop_match_guards)
+        }
+
     }
 };

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -864,15 +864,8 @@ set_option linter.unusedVariables false
             self.pat_typed(&param.pat)
         }
 
-        fn item(
-            &'a self,
-            Item {
-                ident,
-                kind,
-                meta: _,
-            }: &'b Item,
-        ) -> DocBuilder<'a, Self, A> {
-            match kind {
+        fn item(&'a self, Item { ident, kind, meta }: &'b Item) -> DocBuilder<'a, Self, A> {
+            let body = match kind {
                 ItemKind::Fn {
                     name,
                     generics,
@@ -1060,7 +1053,8 @@ set_option linter.unusedVariables false
                     emit_error!(issue 1658, "Unsupported alias item")
                 }
                 ItemKind::Error(e) => docs![e],
-            }
+            };
+            docs![meta, body]
         }
 
         fn trait_item(
@@ -1161,10 +1155,11 @@ set_option linter.unusedVariables false
                 name,
                 arguments,
                 is_record,
-                attributes: _,
+                attributes,
             }: &'b Variant,
         ) -> DocBuilder<'a, Self, A> {
             docs![
+                concat!(attributes),
                 self.render_last(name),
                 softline!(),
                 // args
@@ -1212,7 +1207,7 @@ set_option linter.unusedVariables false
                 attributes,
             }: &'b Metadata,
         ) -> DocBuilder<'a, Self, A> {
-            zip_right!(attributes, hardline!())
+            concat!(attributes)
         }
 
         fn lhs(&'a self, _lhs: &'b Lhs) -> DocBuilder<'a, Self, A> {
@@ -1244,13 +1239,13 @@ set_option linter.unusedVariables false
             Attribute { kind, span: _ }: &'b Attribute,
         ) -> DocBuilder<'a, Self, A> {
             match kind {
-                AttributeKind::Tool { path, tokens: _ } => {
-                    comment!(format!("Rust attribute {}", path))
+                AttributeKind::Tool { .. } => {
+                    nil!()
                 }
                 AttributeKind::DocComment {
                     kind: DocCommentKind::Line,
                     body,
-                } => comment!(body.clone()),
+                } => comment!(body.clone()).append(hardline!()),
                 AttributeKind::DocComment {
                     kind: DocCommentKind::Block,
                     body,
@@ -1262,7 +1257,8 @@ set_option linter.unusedVariables false
                     "-/"
                 ]
                 .nest(INDENT)
-                .group(),
+                .group()
+                .append(hardline!()),
             }
         }
 

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -641,4 +641,27 @@ def Lean_tests.Ite.test2 (b : Bool) : Result i32 := do
     (← (← z +? y) +? x)
   else do
     let z : i32 ← (pure (← y -? x));
-    (← (← z +? y) +? x))'''
+    (← (← z +? y) +? x))
+
+--  Single line doc comment
+def Lean_tests.Comments.f
+  (_ : Rust_primitives.Hax.Tuple0)
+  : Result Rust_primitives.Hax.Tuple0
+  := do
+  Rust_primitives.Hax.Tuple0.mk
+
+/--
+   Block doc-comment : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rutrum
+  orci ac tellus ullamcorper sollicitudin. Sed fringilla mi id arcu suscipit rhoncus. Pellentesque et
+  metus a ante feugiat lobortis. Nam a mauris eget nisl congue egestas. Duis et gravida
+  nulla. Curabitur mattis leo vel molestie posuere. Etiam malesuada et augue eget
+  varius. Pellentesque quis tincidunt erat. Vestibulum id consectetur turpis. Cras elementum magna id
+  urna volutpat fermentum. In vel erat quis nunc rhoncus porta. Aliquam sed pellentesque
+  tellus. Quisque odio diam, mollis ut venenatis non, scelerisque at nulla. Nunc urna ante, tristique
+  quis nisi quis, congue maximus nisl. Curabitur non efficitur odio. 
+  -/
+def Lean_tests.Comments.heavily_documented
+  (_ : Rust_primitives.Hax.Tuple0)
+  : Result u32
+  := do
+  (4 : u32)'''

--- a/tests/lean-tests/src/comments.rs
+++ b/tests/lean-tests/src/comments.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+/// Single line doc comment
+fn f() {}
+
+/** Block doc-comment : Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rutrum
+orci ac tellus ullamcorper sollicitudin. Sed fringilla mi id arcu suscipit rhoncus. Pellentesque et
+metus a ante feugiat lobortis. Nam a mauris eget nisl congue egestas. Duis et gravida
+nulla. Curabitur mattis leo vel molestie posuere. Etiam malesuada et augue eget
+varius. Pellentesque quis tincidunt erat. Vestibulum id consectetur turpis. Cras elementum magna id
+urna volutpat fermentum. In vel erat quis nunc rhoncus porta. Aliquam sed pellentesque
+tellus. Quisque odio diam, mollis ut venenatis non, scelerisque at nulla. Nunc urna ante, tristique
+quis nisi quis, congue maximus nisl. Curabitur non efficitur odio. */
+fn heavily_documented() -> u32 {
+    4
+}

--- a/tests/lean-tests/src/lib.rs
+++ b/tests/lean-tests/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
+pub mod comments;
 pub mod enums;
 pub mod ite;
 pub mod loops;


### PR DESCRIPTION
This PR is a cleanup of the Lean backend. It: 
1. turns every `todo!` , `panic!` and `unreachable!` of the Lean backend into either `emit_error` (that prints a proper diagnostic refering to a github issue), or `unreachable_by_invariant` (that justifies the unreachability by pointing to the specific phase in the Hax engine that removed the node in the AST).  
2. makes pattern-matching explicit (removing default cases `_ => ... ` to print a correct error for each case)
2. adds support for some easy missing nodes (quotes, comments, attributes )