### PR TITLE
fix(engine): fix owner_id

### DIFF
--- a/engine/lib/span.ml
+++ b/engine/lib/span.ml
@@ -100,7 +100,7 @@ let owner_id_list = ref []
 let owner_id_list_len = ref 0
 
 let fresh_owner_id (owner : Types.def_id) : owner_id =
-  let next_id = OwnerId (List.length !owner_id_list) in
+  let next_id = OwnerId !owner_id_list_len in
   owner_id_list := owner :: !owner_id_list;
   owner_id_list_len := !owner_id_list_len + 1;
   next_id

--- a/engine/lib/span.ml
+++ b/engine/lib/span.ml
@@ -97,10 +97,12 @@ type owner_id = OwnerId of int
 [@@deriving show, yojson, sexp, compare, eq, hash]
 
 let owner_id_list = ref []
+let owner_id_list_len = ref 0
 
 let fresh_owner_id (owner : Types.def_id) : owner_id =
   let next_id = OwnerId (List.length !owner_id_list) in
   owner_id_list := owner :: !owner_id_list;
+  owner_id_list_len := !owner_id_list_len + 1;
   next_id
 
 (** This state changes the behavior of `of_thir`: the hint placed into this
@@ -151,7 +153,8 @@ let default = { id = 0; data = []; owner_hint = None }
 let owner_hint span =
   span.owner_hint
   |> Option.map ~f:(fun (OwnerId id) ->
-         Option.value_exn (List.nth !owner_id_list id))
+         Option.value_exn
+           (List.nth !owner_id_list (!owner_id_list_len - id - 1)))
 
 let to_span2 span : Types.span2 =
   {


### PR DESCRIPTION
Drive by PR while looking at tests.
The engine had a bug where the IDs of the owner hints were reversed.

[skip changelog]