### PR TITLE
refactor(rengine): revisit printer traits

### DIFF
--- a/rust-engine/macros/src/struct_fields.rs
+++ b/rust-engine/macros/src/struct_fields.rs
@@ -1,0 +1,142 @@
+use crate::utils::*;
+use proc_macro::TokenStream;
+use proc_macro2::{Group, Ident, Span};
+use quote::{ToTokens, quote};
+use syn::{
+    Field, FieldsUnnamed, Token, parse_macro_input, parse_quote, punctuated::Punctuated,
+    token::Paren,
+};
+
+/// Adds a new field `extra_field_name` of type `extra_field_type` to an existing `struct` type definition.
+/// `extra_field_name` is just a name hint, if a field with this name exists already, a different name will be picked.
+/// Returns the actual name or `_N` (in the case of a tuple struct).
+fn add_field_to_item_struct(
+    item: &mut syn::ItemStruct,
+    extra_field_name: &str,
+    extra_field_type: syn::Type,
+) -> proc_macro2::TokenStream {
+    // Deal with the case of unit structs.
+    if let fields @ syn::Fields::Unit = &mut item.fields {
+        let span = Group::new(proc_macro2::Delimiter::Brace, fields.to_token_stream()).delim_span();
+        *fields = syn::Fields::Unnamed(FieldsUnnamed {
+            paren_token: Paren { span },
+            unnamed: Punctuated::default(),
+        })
+    }
+    /// Computes a fresh identifier given a list of existing identifiers.
+    fn fresh_ident(base: &str, existing: &[Ident]) -> Ident {
+        let existing: std::collections::HashSet<_> =
+            existing.iter().map(|id| id.to_string()).collect();
+
+        (0..)
+            .map(|i| {
+                if i == 0 {
+                    base.to_string()
+                } else {
+                    format!("{}{}", base, i)
+                }
+            })
+            .find(|name| !existing.contains(name))
+            .map(|name| Ident::new(&name, Span::call_site()))
+            .expect("should always find a fresh identifier")
+    }
+    // Collect fields, disregarding their kind (are they named or not)
+    let (fields, named) = match &mut item.fields {
+        syn::Fields::Named(fields_named) => (&mut fields_named.named, true),
+        syn::Fields::Unnamed(fields_unnamed) => (&mut fields_unnamed.unnamed, false),
+        syn::Fields::Unit => unreachable!("Unit structs were dealt with."),
+    };
+
+    let existing_names = fields
+        .iter()
+        .flat_map(|f| &f.ident)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let (extra_field_ident, extra_field_ident_ts) = if named {
+        let ident = fresh_ident(extra_field_name, &existing_names);
+        (Some(ident.clone()), ident.to_token_stream())
+    } else {
+        (
+            None,
+            syn::LitInt::new(&format!("{}", fields.len()), Span::call_site()).to_token_stream(),
+        )
+    };
+
+    fields.push(Field {
+        attrs: vec![],
+        vis: syn::Visibility::Inherited,
+        mutability: syn::FieldMutability::None,
+        ident: extra_field_ident,
+        colon_token: named.then_some(Token![:](Span::call_site())),
+        ty: extra_field_type,
+    });
+
+    extra_field_ident_ts
+}
+
+/// Adds a new field with a fresh name to an existing `struct` type definition.
+/// The new field contains error handling and span information to be used with a
+/// visitor. This macro will also derive implementations of
+/// [`hax_rust_engine::ast::visitors::wrappers::VisitorWithErrors`] and
+/// [`hax_rust_engine::ast::HasSpan`] for the struct.
+pub(crate) fn setup_error_handling_struct(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut item: syn::ItemStruct = parse_macro_input!(item);
+    let krate = krate();
+    let extra_field_ident_ts = add_field_to_item_struct(
+        &mut item,
+        "error_handling_state",
+        parse_quote! {#krate::ast::visitors::wrappers::ErrorHandlingState},
+    );
+
+    let struct_name = &item.ident;
+    let generics = &item.generics;
+    quote! {
+        #item
+        impl #generics #krate::ast::HasSpan for #struct_name #generics {
+            fn span(&self) -> #krate::ast::span::Span {
+                self.#extra_field_ident_ts.0.clone()
+            }
+            fn span_mut(&mut self) -> &mut #krate::ast::span::Span {
+                &mut self.#extra_field_ident_ts.0
+            }
+        }
+        impl #generics #krate::ast::visitors::wrappers::VisitorWithErrors for #struct_name #generics {
+            fn error_vault(&mut self) -> &mut #krate::ast::visitors::wrappers::ErrorVault {
+                &mut self.#extra_field_ident_ts.1
+            }
+        }
+    }
+    .into()
+}
+
+/// Adds a new field with a fresh name to an existing `struct` type definition.
+/// The new field contains span information to be used with a
+/// printer. This macro will also derive implementations of
+/// [`hax_rust_engine::ast::HasSpan`] for the struct.
+pub(crate) fn setup_span_handling_struct(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut item: syn::ItemStruct = parse_macro_input!(item);
+    let krate = krate();
+    let extra_field_ident_ts = add_field_to_item_struct(
+        &mut item,
+        "contextual_span",
+        parse_quote! {Option<#krate::ast::span::Span>},
+    );
+
+    let struct_name = &item.ident;
+    let generics = &item.generics;
+    quote! {
+        #item
+        impl #generics #krate::printer::pretty_ast::HasContextualSpan for #struct_name #generics {
+            fn span(&self) -> Option<#krate::ast::span::Span> {
+                self.#extra_field_ident_ts.clone()
+            }
+            fn with_span(&self, span: #krate::ast::span::Span) -> Self {
+                let mut printer = self.clone();
+                printer.#extra_field_ident_ts = Some(span);
+                printer
+            }
+        }
+    }
+    .into()
+}

--- a/rust-engine/src/backends.rs
+++ b/rust-engine/src/backends.rs
@@ -118,7 +118,6 @@ mod prelude {
         identifiers::{global_id::view::AnyKind, *},
         literals::*,
         resugared::*,
-        span::*,
         *,
     };
     pub use crate::printer::{
@@ -128,5 +127,7 @@ mod prelude {
     };
     pub use crate::resugarings::*;
     pub use crate::symbol::Symbol;
-    pub use hax_rust_engine_macros::prepend_associated_functions_with;
+    pub use hax_rust_engine_macros::{
+        prepend_associated_functions_with, setup_span_handling_struct,
+    };
 }

--- a/rust-engine/src/backends.rs
+++ b/rust-engine/src/backends.rs
@@ -108,24 +108,25 @@ pub fn apply_backend<B: Backend + 'static>(backend: B, mut items: Vec<Item>) -> 
         .collect()
 }
 
-#[allow(unused)]
 mod prelude {
     //! Small "bring-into-scope" set used by backend modules.
     //!
     //! Importing this prelude saves repetitive `use` lists in per-backend
     //! modules without forcing these names on downstream users.
     pub use super::Backend;
-    pub use crate::ast::identifiers::global_id::view::AnyKind;
-    pub use crate::ast::identifiers::*;
-    pub use crate::ast::literals::*;
-    pub use crate::ast::resugared::*;
-    pub use crate::ast::*;
-    pub use crate::printer::render_view::*;
-    pub use crate::printer::*;
+    pub use crate::ast::{
+        identifiers::{global_id::view::AnyKind, *},
+        literals::*,
+        resugared::*,
+        span::*,
+        *,
+    };
+    pub use crate::printer::{
+        pretty_ast::{DocBuilder, PrettyAst, ToDocument, install_pretty_helpers},
+        render_view::*,
+        *,
+    };
+    pub use crate::resugarings::*;
     pub use crate::symbol::Symbol;
     pub use hax_rust_engine_macros::prepend_associated_functions_with;
-    pub use pretty::DocAllocator;
-    pub use pretty::DocBuilder;
-    pub use pretty::Pretty;
-    pub use pretty_ast::install_pretty_helpers;
 }

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -17,10 +17,9 @@ mod binops {
 }
 
 /// The Lean printer
+#[setup_span_handling_struct]
 #[derive(Default, Clone)]
-pub struct LeanPrinter {
-    span: Option<Span>,
-}
+pub struct LeanPrinter;
 
 const INDENT: isize = 2;
 
@@ -308,13 +307,6 @@ const _: () = {
 
     impl<A: 'static + Clone> PrettyAst<A> for LeanPrinter {
         const NAME: &'static str = "Lean";
-
-        fn with_span(&self, span: Span) -> Self {
-            Self { span: Some(span) }
-        }
-        fn span(&self) -> Option<Span> {
-            self.span.clone()
-        }
 
         /// Produce a non-panicking placeholder document. In general, prefer the use of the helper macro [`todo_document!`].
         fn todo_document(&self, message: &str, issue_id: Option<u32>) -> DocBuilder<A> {

--- a/rust-engine/src/backends/rust.rs
+++ b/rust-engine/src/backends/rust.rs
@@ -4,7 +4,8 @@
 use super::prelude::*;
 
 /// The Rust printer.
-#[derive(Default, Clone, Copy)]
+#[setup_span_handling_struct]
+#[derive(Default, Clone)]
 pub struct RustPrinter;
 
 impl Printer for RustPrinter {

--- a/rust-engine/src/backends/rust.rs
+++ b/rust-engine/src/backends/rust.rs
@@ -4,9 +4,8 @@
 use super::prelude::*;
 
 /// The Rust printer.
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct RustPrinter;
-impl_doc_allocator_for!(RustPrinter);
 
 impl Printer for RustPrinter {
     fn resugaring_phases() -> Vec<Box<dyn Resugaring>> {
@@ -40,16 +39,16 @@ const _: () = {
     #[allow(unused)]
     macro_rules! concat {($($tt:tt)*) => {disambiguated_concat!($($tt)*)};}
 
-    impl<'a, 'b, A: 'a + Clone> PrettyAst<'a, 'b, A> for RustPrinter {
+    impl<A: 'static + Clone> PrettyAst<A> for RustPrinter {
         const NAME: &'static str = "Rust";
 
-        fn module(&'a self, module: &'b Module) -> DocBuilder<'a, Self, A> {
+        fn module(&self, module: &Module) -> DocBuilder<A> {
             intersperse!(&module.items, docs![hardline!(), hardline!()])
         }
-        fn item(&'a self, item: &'b Item) -> DocBuilder<'a, Self, A> {
+        fn item(&self, item: &Item) -> DocBuilder<A> {
             docs![&item.meta, item.kind()]
         }
-        fn item_kind(&'a self, item_kind: &'b ItemKind) -> DocBuilder<'a, Self, A> {
+        fn item_kind(&self, item_kind: &ItemKind) -> DocBuilder<A> {
             match item_kind {
                 ItemKind::Fn {
                     name,

--- a/rust-engine/src/printer.rs
+++ b/rust-engine/src/printer.rs
@@ -11,50 +11,16 @@
 
 use std::ops::Deref;
 
-use crate::ast::{self, span::Span};
+use crate::{
+    ast::{self, span::Span},
+    printer::pretty_ast::ToDocument,
+};
 use ast::visitors::dyn_compatible;
-use pretty::Pretty;
 
 pub mod pretty_ast;
 pub use pretty_ast::PrettyAst;
 
 pub mod render_view;
-
-/// Implements `pretty::DocAllocator<'a, A>` for a local types
-/// that already implement `HasAllocator<'a, A>`.
-///
-/// Usage:
-///   impl_doc_allocator_for!(MyType);
-///
-/// Notes:
-/// - Types must be local to your crate (orphan rule).
-#[macro_export]
-macro_rules! impl_doc_allocator_for {
-    ($ty:ty) => {
-        impl<'a, A: 'a> ::pretty::DocAllocator<'a, A> for $ty {
-            type Doc = pretty::BoxDoc<'a, A>;
-
-            fn alloc(&'a self, doc: ::pretty::Doc<'a, Self::Doc, A>) -> Self::Doc {
-                pretty::BoxAllocator.alloc(doc)
-            }
-
-            fn alloc_column_fn(
-                &'a self,
-                f: impl Fn(usize) -> Self::Doc + 'a,
-            ) -> <Self::Doc as ::pretty::DocPtr<'a, A>>::ColumnFn {
-                pretty::BoxAllocator.alloc_column_fn(f)
-            }
-
-            fn alloc_width_fn(
-                &'a self,
-                f: impl Fn(isize) -> Self::Doc + 'a,
-            ) -> <Self::Doc as ::pretty::DocPtr<'a, A>>::WidthFn {
-                pretty::BoxAllocator.alloc_width_fn(f)
-            }
-        }
-    };
-}
-pub use impl_doc_allocator_for;
 
 /// A resugaring is an erased mapper visitor with a name.
 /// A resugaring is a *local* transformation on the AST that produces exclusively `ast::resugared` nodes.
@@ -74,11 +40,11 @@ pub trait Resugaring: for<'a> dyn_compatible::AstVisitorMut<'a> {
 }
 
 /// A printer defines a list of resugaring phases.
-pub trait Printer: Sized + for<'a, 'b> PrettyAst<'a, 'b, Span> + Default {
+pub trait Printer: Sized + PrettyAst<Span> + Default {
     /// A list of resugaring phases.
     fn resugaring_phases() -> Vec<Box<dyn Resugaring>>;
     /// The name of the printer
-    const NAME: &'static str = <Self as PrettyAst<'static, 'static, Span>>::NAME;
+    const NAME: &'static str = <Self as PrettyAst<Span>>::NAME;
 }
 
 /// Placeholder type for sourcemaps.
@@ -87,16 +53,16 @@ pub struct SourceMap;
 /// Helper trait to print AST fragments.
 pub trait Print<T>: Printer {
     /// Print a single AST fragment using this backend.
-    fn print(&self, mut fragment: T) -> (String, SourceMap)
+    fn print(&mut self, mut fragment: T) -> (String, SourceMap)
     where
-        for<'a, 'b> &'b T: Pretty<'a, Self, Span>,
+        T: ToDocument<Self, Span>,
         // The following node is equivalent to "T is an AST node"
         for<'a> dyn Resugaring: dyn_compatible::AstVisitableMut<'a, T>,
     {
         for mut reguaring_phase in Self::resugaring_phases() {
             reguaring_phase.visit(&mut fragment)
         }
-        let doc_builder = fragment.pretty(self).into_doc();
+        let doc_builder = fragment.to_document(self).into_doc();
         (doc_builder.deref().pretty(80).to_string(), SourceMap)
     }
 }

--- a/rust-engine/src/printer/pretty_ast.rs
+++ b/rust-engine/src/printer/pretty_ast.rs
@@ -1,111 +1,31 @@
 //! Pretty-printing support for the hax AST.
 //!
 //! This module defines the trait [`PrettyAst`], which is the **primary trait a printer should
-//! implement**. It also exposes a handful of ergonomic helper macros that wire the
-//! [`pretty`](https://docs.rs/pretty/) crate's allocator into concise printing code, while
-//! taking care of annotations/spans for you.
+//! implement**.
 //!
 //! # Quickstart
 //! In most printers you:
 //! 1. Implement [`Printer`] for your allocator/type,
 //! 2. Implement [`PrettyAst`] for that allocator,
-//! 3. Call `x.pretty(&allocator)` on AST values.
+//! 3. Call `ast_value.to_document(&print)` on AST values.
 //!
-//! See [`super::backends`] for backend and printer examples.
-//!
-//! # Lifetimes and Parameters
-//! - `'a`: lifetime tied to the **document allocator** (from `pretty::DocAllocator`).
-//! - `'b`: lifetime of the **borrowed AST** node(s) being printed.
-//! - `A`: the **annotation** type carried in documents (e.g., spans for source maps).
-//!   `PrettyAst` is generic over `A`.
+//! See [`crate::backends`] for backend and printer examples.
 
-use std::fmt::Display;
+use std::{borrow::Cow, fmt::Display};
 
 use super::*;
 use crate::ast::*;
-use pretty::{DocAllocator, DocBuilder};
+use pretty::BoxAllocator;
 
 use crate::symbol::Symbol;
 use identifiers::*;
 use literals::*;
 use resugared::*;
 
-/// This type is primarily useful inside printer implementations when you want a
-/// low-friction way to inspect an AST fragment.
-///
-/// # What it does
-/// - Appends a JSON representation of the wrapped value to
-///   `"/tmp/hax-ast-debug.json"` (one JSON document per line).
-/// - Implements [`std::fmt::Display`] to print a `just` invocation you can paste in a shell
-///   to re-open that same JSON by line number:
-///   `just debug-json <line-id>`
-///
-/// # Example
-/// ```rust
-/// # use hax_rust_engine::printer::pretty_ast::DebugJSON;
-/// # #[derive(serde::Serialize)]
-/// # struct Small { x: u32 }
-/// let s = Small { x: 42 };
-/// // Prints something like: `just debug-json 17`.
-/// println!("{}", DebugJSON(&s));
-/// // Running `just debug-json 17` will print `{"x":42}`
-/// ```
-///
-/// # Notes
-/// - This is a **debugging convenience** and intentionally has a side-effect (file write).
-///   Avoid keeping it in user-facing output paths.
-/// - The file grows over time; occasionally delete it if you no longer need historical entries.
-pub struct DebugJSON<T: serde::Serialize>(pub T);
-
-impl<T: serde::Serialize> Display for DebugJSON<T> {
-    #[cfg(not(unix))]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "<unknown, DebugJSON supported on unix plateforms only>")
-    }
-    #[cfg(unix)]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const PATH: &str = "/tmp/hax-ast-debug.json";
-        /// Write a new JSON as a line at the end of `PATH`
-        fn append_line_json(value: &serde_json::Value) -> std::io::Result<usize> {
-            use std::io::{BufRead, BufReader, Write};
-            cleanup();
-            let file = std::fs::OpenOptions::new()
-                .read(true)
-                .append(true)
-                .create(true)
-                .open(PATH)?;
-            let count = BufReader::new(&file).lines().count();
-            writeln!(&file, "{value}")?;
-            Ok(count)
-        }
-
-        /// Drop the file at `PATH` when we first write
-        fn cleanup() {
-            static DID_RUN: AtomicBool = AtomicBool::new(false);
-            use std::sync::atomic::{AtomicBool, Ordering};
-            if DID_RUN
-                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-            {
-                let _ignored = std::fs::remove_file(PATH);
-            }
-        }
-
-        if let Ok(id) = append_line_json(&serde_json::to_value(&self.0).unwrap()) {
-            write!(f, "`just debug-json {id}`")
-        } else {
-            write!(f, "<DebugJSON failed>")
-        }
-    }
-}
-
-impl<'a, 'b, A: 'a + Clone, P: PrettyAst<'a, 'b, A>, T: 'b + serde::Serialize> Pretty<'a, P, A>
-    for DebugJSON<T>
-{
-    fn pretty(self, allocator: &'a P) -> DocBuilder<'a, P, A> {
-        allocator.as_string(format!("{self}"))
-    }
-}
+mod debug_json;
+mod to_document;
+pub use debug_json::*;
+pub use to_document::*;
 
 #[macro_export]
 /// Similar to [`std::todo`], but returns a document instead of panicking with a message.
@@ -138,6 +58,41 @@ macro_rules! todo_document {
 }
 pub use todo_document;
 
+/// Expand a list of values into documents and concatenate them in order.
+///
+/// This helper mirrors [`pretty::docs!`] but automatically calls
+/// [`ToDocumentOwned::to_document_owned`] on each argument before appending it
+/// to the accumulator that starts as [`PrettyAstExt::nil`].
+#[macro_export]
+macro_rules! pretty_ast_docs {
+    ($printer: expr, $docs:expr) => {{
+        use $crate::printer::pretty_ast::{ToDocumentOwned};
+        $docs.to_document_owned($printer)
+    }};
+    ($printer: expr, $($docs:expr),*$(,)?) => {{
+        use $crate::printer::pretty_ast::{ToDocumentOwned};
+        nil!()
+        $(.append($docs.to_document_owned($printer)))*
+    }};
+}
+pub use pretty_ast_docs;
+
+/// Convert a collection of values into documents separated by another
+/// document.
+///
+/// It forwards to [`PrettyAstExt::intersperse`] after materialising the
+/// separator. The macro exists so call sites can stay concise while still
+/// benefiting from the allocator captured by [`install_pretty_helpers!`].
+#[macro_export]
+macro_rules! pretty_ast_intersperse {
+    ($printer: expr, $docs:expr, $sep: expr$(,)?) => {{
+        let docs = $docs;
+        let sep = $sep;
+        crate::printer::pretty_ast::PrettyAstExt::intersperse($printer, docs, sep)
+    }};
+}
+pub use pretty_ast_intersperse;
+
 #[macro_export]
 /// Install pretty-printing helpers partially applied with a given local
 /// allocator.
@@ -158,14 +113,14 @@ pub use todo_document;
 ///
 /// # What gets installed
 /// - macro shorthands for common allocator methods:
-///   [`pretty::DocAllocator::nil`], [`pretty::DocAllocator::fail`],
-///   [`pretty::DocAllocator::hardline`], [`pretty::DocAllocator::space`],
-///   [`pretty::DocAllocator::line`], [`pretty::DocAllocator::line_`],
-///   [`pretty::DocAllocator::softline`], [`pretty::DocAllocator::softline_`],
-///   [`pretty::DocAllocator::as_string`], [`pretty::DocAllocator::text`],
-///   [`pretty::DocAllocator::concat`], [`pretty::DocAllocator::intersperse`],
-///   [`pretty::DocAllocator::column`], [`pretty::DocAllocator::nesting`],
-///   [`pretty::DocAllocator::reflow`].
+///   [`PrettyAstExt::nil`], [`PrettyAstExt::fail`],
+///   [`PrettyAstExt::hardline`], [`PrettyAstExt::space`],
+///   [`PrettyAstExt::line`], [`PrettyAstExt::line_`],
+///   [`PrettyAstExt::softline`], [`PrettyAstExt::softline_`],
+///   [`PrettyAstExt::as_string`], [`PrettyAstExt::text`],
+///   [`PrettyAstExt::concat`], [`PrettyAstExt::intersperse`],
+///   [`PrettyAstExt::column`], [`PrettyAstExt::nesting`],
+///   [`PrettyAstExt::reflow`].
 /// - a partially applied version of [`pretty::docs!`].
 /// - [`todo_document!`]: produce a placeholder document (that does not panic).
 macro_rules! install_pretty_helpers {
@@ -176,37 +131,38 @@ macro_rules! install_pretty_helpers {
             #[doc = ::std::concat!(r#"Example: `disambiguated_todo!("Error message")` or `disambiguated_todo!(issue #123, "Error message with issue attached")`."#)]
             disambiguated_todo{$crate::printer::pretty_ast::todo_document!},
             #[doc = ::std::concat!("Proxy macro for [`pretty::docs`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            docs{pretty::docs!},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::nil`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            nil{<$allocator_type as ::pretty::DocAllocator<'_, _>>::nil},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::fail`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            fail{<$allocator_type as ::pretty::DocAllocator<'_, _>>::fail},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::hardline`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            hardline{<$allocator_type as ::pretty::DocAllocator<'_, _>>::hardline},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::space`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            space{<$allocator_type as ::pretty::DocAllocator<'_, _>>::space},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::line`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            disambiguated_line{<$allocator_type as ::pretty::DocAllocator<'_, _>>::line},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::line_`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            line_{<$allocator_type as ::pretty::DocAllocator<'_, _>>::line_},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::softline`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            softline{<$allocator_type as ::pretty::DocAllocator<'_, _>>::softline},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::softline_`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            softline_{<$allocator_type as ::pretty::DocAllocator<'_, _>>::softline_},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::as_string`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            as_string{<$allocator_type as ::pretty::DocAllocator<'_, _>>::as_string},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::text`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            text{<$allocator_type as ::pretty::DocAllocator<'_, _>>::text},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::concat`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            disambiguated_concat{<$allocator_type as ::pretty::DocAllocator<'_, _>>::concat},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::intersperse`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            intersperse{<$allocator_type as ::pretty::DocAllocator<'_, _>>::intersperse},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::column`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            column{<$allocator_type as ::pretty::DocAllocator<'_, _>>::column},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::nesting`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            nesting{<$allocator_type as ::pretty::DocAllocator<'_, _>>::nesting},
-            #[doc = ::std::concat!("Proxy macro for [`pretty::DocAllocator::reflow`] that automatically uses `", stringify!($allocator),"` as allocator.")]
-            reflow{<$allocator_type as ::pretty::DocAllocator<'_, _>>::reflow}
+            docs{$crate::printer::pretty_ast::pretty_ast_docs!},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::nil`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            nil{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::nil},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::fail`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            fail{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::fail},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::hardline`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            hardline{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::hardline},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::space`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            space{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::space},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::line`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            disambiguated_line{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::line},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::line_`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            line_{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::line_},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::softline`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            softline{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::softline},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::softline_`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            softline_{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::softline_},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::as_string`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            as_string{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::as_string},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::text`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            text{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::text},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::concat`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            disambiguated_concat{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::concat},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::intersperse`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            intersperse{$crate::printer::pretty_ast::pretty_ast_intersperse!},
+            // intersperse{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::intersperse},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::column`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            column{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::column},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::nesting`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            nesting{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::nesting},
+            #[doc = ::std::concat!("Proxy macro for [`PrettyAstExt::reflow`] that automatically uses `", stringify!($allocator),"` as allocator.")]
+            reflow{<$allocator_type as crate::printer::pretty_ast::PrettyAstExt<_>>::reflow}
         );
     };
     (@$allocator:ident, $($(#[$($attrs:tt)*])*$name:ident{$($callable:tt)*}),*) => {
@@ -220,51 +176,172 @@ macro_rules! install_pretty_helpers {
 }
 pub use install_pretty_helpers;
 
-// This module tracks a span information via a global mutex, because our
-// printers cannot really carry information in a nice way. See issue
-// https://github.com/cryspen/hax/issues/1667. Once addressed this can go away.
-mod default_global_span_context {
-    use super::Span;
-
-    use std::sync::{LazyLock, Mutex};
-    static STATE: LazyLock<Mutex<Option<Span>>> = LazyLock::new(|| Mutex::new(None));
-
-    pub(super) fn with_span<T>(span: Span, action: impl Fn() -> T) -> T {
-        let previous_span = STATE.lock().unwrap().clone();
-        *STATE.lock().unwrap() = Some(span);
-        let result = action();
-        *STATE.lock().unwrap() = previous_span;
-        result
+/// `PrettyAstExt` exposes `DocAllocator`-style constructors for printers.
+///
+/// Every method simply forwards to the global [`pretty::BoxAllocator`] so that printers
+/// implementing [`PrettyAst`] can build documents without juggling allocator plumbing.
+pub trait PrettyAstExt<A: 'static>: Sized {
+    /// Returns an empty document.
+    /// Mirrors [`pretty::DocAllocator::nil`].
+    fn nil(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::nil(&BoxAllocator)
     }
 
-    pub(super) fn get_ambiant_span() -> Option<Span> {
-        STATE.lock().unwrap().clone()
+    /// Produces a document that fails rendering immediately.
+    /// Mirrors [`pretty::DocAllocator::fail`].
+    ///
+    /// This is typically used to abort rendering inside the left side of a [`pretty::Doc::Union`].
+    fn fail(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::fail(&BoxAllocator)
+    }
+
+    /// Inserts a mandatory line break.
+    /// Mirrors [`pretty::DocAllocator::hardline`].
+    fn hardline(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::hardline(&BoxAllocator)
+    }
+
+    /// Inserts a single space that disappears when groups flatten.
+    /// Mirrors [`pretty::DocAllocator::space`].
+    fn space(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::space(&BoxAllocator)
+    }
+
+    /// Acts like a `\n` but behaves like `space` once grouped onto a single line.
+    /// Mirrors [`pretty::DocAllocator::line`].
+    fn line(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::line(&BoxAllocator)
+    }
+
+    /// Acts like `line` but collapses to `nil` if grouped on a single line.
+    /// Mirrors [`pretty::DocAllocator::line_`].
+    fn line_(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::line_(&BoxAllocator)
+    }
+
+    /// Acts like `space` when the document fits the page, otherwise behaves like `line`.
+    /// Mirrors [`pretty::DocAllocator::softline`].
+    fn softline(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::softline(&BoxAllocator)
+    }
+
+    /// Acts like `nil` when the document fits the page, otherwise behaves like `line_`.
+    /// Mirrors [`pretty::DocAllocator::softline_`].
+    fn softline_(&self) -> DocBuilder<A> {
+        pretty::DocAllocator::softline_(&BoxAllocator)
+    }
+
+    /// Renders `data` via its [`Display`] implementation.
+    /// Mirrors [`pretty::DocAllocator::as_string`].
+    ///
+    /// The resulting document must not contain explicit line breaks.
+    fn as_string<U: Display>(&self, data: U) -> DocBuilder<A> {
+        pretty::DocAllocator::as_string(&BoxAllocator, data)
+    }
+
+    /// Renders the provided text verbatim.
+    /// Mirrors [`pretty::DocAllocator::text`].
+    ///
+    /// The supplied string must not contain line breaks.
+    fn text<'a>(&self, data: impl Into<Cow<'a, str>>) -> DocBuilder<A> {
+        self.as_string(data.into())
+    }
+
+    /// Concatenates the given values after turning each into a document.
+    /// Mirrors [`pretty::DocAllocator::concat`].
+    fn concat<I>(&self, docs: I) -> DocBuilder<A>
+    where
+        I::Item: ToDocumentOwned<Self, A>,
+        I: IntoIterator,
+    {
+        pretty::DocAllocator::concat(
+            &BoxAllocator,
+            docs.into_iter().map(|doc| doc.to_document_owned(self)),
+        )
+    }
+
+    /// Concatenates documents while interspersing `separator` between every pair.
+    /// Mirrors [`pretty::DocAllocator::intersperse`].
+    ///
+    /// `separator` may need to be cloned; consider cheap pointer documents like `RefDoc` or `RcDoc`.
+    fn intersperse<I, S>(&self, docs: I, separator: S) -> DocBuilder<A>
+    where
+        I::Item: ToDocumentOwned<Self, A>,
+        I: IntoIterator,
+        S: ToDocumentOwned<Self, A> + Clone,
+        A: Clone,
+    {
+        let separator = separator.to_document_owned(self);
+        pretty::DocAllocator::intersperse(
+            &BoxAllocator,
+            docs.into_iter().map(|doc| doc.to_document_owned(self)),
+            separator,
+        )
+    }
+
+    /// Reflows `text`, inserting `softline` wherever whitespace appears.
+    /// Mirrors [`pretty::DocAllocator::reflow`].
+    fn reflow(&self, text: &'static str) -> DocBuilder<A>
+    where
+        A: Clone,
+    {
+        pretty::DocAllocator::reflow(&BoxAllocator, text)
     }
 }
 
+impl<A: 'static + Clone, P: PrettyAst<A>> PrettyAstExt<A> for P {}
+
+/// Generate a dispatcher macro that forwards a token to specialised macros.
+macro_rules! make_cases_macro {
+    (
+        $macro_name:ident,
+        $(
+            $($idents:ident)|* => $target:ident,
+        )*
+        _ => $fallback:ident $(,)?
+    ) => {
+        macro_rules! $macro_name {
+            $(
+                $(
+                    ($idents $tt:tt) => { $target!($tt); };
+                )*
+            )*
+            ($anything:ident $tt:tt) => { $fallback!($tt); };
+        }
+    };
+}
+
+/// Helper macro used to ignore a matched arm in `make_cases_macro!`.
+macro_rules! skip {
+    ($tt:tt) => {};
+}
+/// Helper macro used to keep the body for specific matches in
+/// `make_cases_macro!`.
+macro_rules! keep {
+    ({$($tt:tt)*}) => { $($tt)* };
+}
+
+make_cases_macro!(method_deny_list,
+    ExprKind | PatKind | TyKind | GuardKind | ImplExprKind | ImplItemKind | TraitItemKind | AttributeKind | DocCommentKind => skip,
+    Signedness  | IntSize => skip,
+    ItemQuoteOrigin | ItemQuoteOriginKind | ItemQuoteOriginPosition => skip,
+    ControlFlowKind | LoopState | LoopKind => skip,
+    _ => keep
+);
+
+make_cases_macro!(span_handling,
+    Item | Expr | Pat | Guard | Arm | ImplItem | TraitItem | GenericParam | Attribute | Attribute => keep,
+    _ => skip
+);
+
+/// Declare the `PrettyAst` trait and wiring for deriving `ToDocument` for AST
+/// nodes.
 macro_rules! mk {
     ($($ty:ident),*) => {
         pastey::paste! {
             /// A trait that defines a print method per type in the AST.
             ///
-            /// This is the main trait a printer should implement. It ties
-            /// together:
-            /// - the [`pretty::DocAllocator`] implementation that builds
-            ///   documents,
-            /// - the [`Printer`] behavior (syntax highlighting, punctuation
-            ///   helpers, …),
-            /// - and annotation plumbing (`A`) used for source maps.
-            ///
-            /// ## Lifetimes and Type Parameters
-            /// - `'a`: the allocator/document lifetime.
-            /// - `'b`: the lifetime of borrowed AST values being printed.
-            /// - `A`: the annotation type carried by documents (must be
-            ///   `Clone`).
-            ///
-            /// ## Implementing `PrettyAst`
-            /// ```rust,ignore
-            /// impl<'a, 'b, A: 'a + Clone> PrettyAst<'a, 'b, A> for MyPrinter { }
-            /// ```
+            /// This is the main trait a printer should implement.
             ///
             /// You then implement the actual formatting logic in the generated
             /// per-type methods. These methods are intentionally marked
@@ -275,15 +352,15 @@ macro_rules! mk {
             /// Note that using `install_pretty_helpers!` will produce macro
             /// that implicitely use `self` as allocator. Take a look at a
             /// printer in the [`backends`] module for an example.
-            pub trait PrettyAst<'a, 'b, A: 'a + Clone>: DocAllocator<'a, A> + Sized {
+            pub trait PrettyAst<A: 'static + Clone>: Sized + Clone {
                 /// A name for this instance of `PrettyAst`.
                 /// Useful for diagnostics and debugging.
                 const NAME: &'static str;
 
                 /// Emit a diagnostic with proper context and span.
-                fn emit_diagnostic(&'a self, kind: hax_types::diagnostics::Kind) {
-                    let span = default_global_span_context::get_ambiant_span().unwrap_or_else(|| Span::dummy());
-                    use crate::printer::pretty_ast::diagnostics::{DiagnosticInfo, Context};
+                fn emit_diagnostic(&self, kind: hax_types::diagnostics::Kind) {
+                    let span = self.span().unwrap_or_else(|| Span::dummy());
+                    use crate::ast::diagnostics::{DiagnosticInfo, Context};
                     (DiagnosticInfo {
                         context: Context::Printer(Self::NAME.to_string()),
                         span,
@@ -292,17 +369,32 @@ macro_rules! mk {
                 }
 
                 /// Produce a non-panicking placeholder document. In general, prefer the use of the helper macro [`todo_document!`].
-                fn todo_document(&'a self, message: &str, issue_id: Option<u32>) -> DocBuilder<'a, Self, A> {
+                fn todo_document(&self, message: &str, issue_id: Option<u32>) -> DocBuilder<A> {
                     self.emit_diagnostic(hax_types::diagnostics::Kind::Unimplemented {
                         issue_id,
                         details: Some(message.into()),
                     });
                     self.as_string(message)
                 }
-                /// Execute an action with a span hint. Useful for errors.
-                fn with_span<T>(&self, span: Span, action: impl Fn(&Self) -> T) -> T {
-                    default_global_span_context::with_span(span, || action(self))
+
+                /// Clone the printer, adding a span hint. Useful for errors.
+                ///
+                /// Backends that track source locations should override this so diagnostics
+                /// emitted through [`PrettyAst::emit_diagnostic`] can highlight the right span.
+                ///
+                /// The default implementation just clones, and drops the span.
+                fn with_span(&self, _span: Span) -> Self {
+                    self.clone()
                 }
+
+                /// Returns the span currently associated with the printer, if any.
+                ///
+                /// Backends that track source locations should override this so diagnostics
+                /// emitted through [`PrettyAst::emit_diagnostic`] can highlight the right span.
+                fn span(&self) -> Option<Span> {
+                    None
+                }
+
                 /// Produce a structured error document for an unimplemented
                 /// method.
                 ///
@@ -311,7 +403,7 @@ macro_rules! mk {
                 /// locations). The default produces a small, debuggable piece
                 /// of text that includes the method name and a JSON handle for
                 /// the AST fragment (via [`DebugJSON`]).
-                fn unimplemented_method(&'a self, method: &str, ast: ast::fragment::FragmentRef<'_>) -> DocBuilder<'a, Self, A> {
+                fn unimplemented_method(&self, method: &str, ast: ast::fragment::FragmentRef<'_>) -> DocBuilder<A> {
                     let debug_json = DebugJSON(ast).to_string();
                     self.emit_diagnostic(hax_types::diagnostics::Kind::Unimplemented {
                         issue_id: None,
@@ -319,36 +411,48 @@ macro_rules! mk {
                     });
                     self.text(format!("`{method}` unimpl, {debug_json}", )).parens()
                 }
+
                 $(
-                    #[doc = "Define how the printer formats a value of this AST type."]
-                    #[doc = "Do not call this method directly. Use [`pretty::Pretty::pretty`] instead, so annotations/spans are preserved correctly."]
-                    #[deprecated = "Do not call this method directly. Use [`pretty::Pretty::pretty`] instead, so annotations/spans are preserved correctly."]
-                    fn [<$ty:snake>](&'a self, [<$ty:snake>]: &'b $ty) -> DocBuilder<'a, Self, A> {
-                        mk!(@method_body $ty [<$ty:snake>] self [<$ty:snake>])
-                    }
+                    method_deny_list!($ty{
+                        #[doc = "Define how the printer formats a value of this AST type."]
+                        #[doc = "Do not call this method directly. Use [`pretty::Pretty::pretty`] instead, so annotations/spans are preserved correctly."]
+                        #[deprecated = "Do not call this method directly. Use [`pretty::Pretty::pretty`] instead, so annotations/spans are preserved correctly."]
+                        fn [<$ty:snake>](&self, [<$ty:snake>]: &$ty) -> DocBuilder<A> {
+                            mk!(@method_body $ty [<$ty:snake>] self [<$ty:snake>])
+                        }
+                    });
                 )*
             }
 
             $(
-                impl<'a, 'b, A: 'a + Clone, P: PrettyAst<'a, 'b, A>> Pretty<'a, P, A> for &'b $ty {
-                    fn pretty(self, allocator: &'a P) -> DocBuilder<'a, P, A> {
-                        // Note about deprecation:
-                        //   Here is the only place where calling the deprecated methods from the trait `PrettyAst` is fine.
-                        //   Here is the place we (will) take care of spans, etc.
-                        #[allow(deprecated)]
-                        let print = <P as PrettyAst<'_, '_, _>>::[<$ty:snake>];
-                        print(allocator, self)
+                method_deny_list!($ty{
+                    impl<A: 'static + Clone, P: PrettyAst<A>> ToDocument<P, A> for $ty {
+                        fn to_document(&self, printer: &P) -> DocBuilder<A> {
+                            span_handling!($ty{
+                                let printer = &(printer.with_span(self.span()));
+                            });
+                            // Note about deprecation:
+                            //   Here is the only place where calling the deprecated methods from the trait `PrettyAst` is fine.
+                            //   Here is the place we (will) take care of spans, etc.
+                            #[allow(deprecated)]
+                            let print = <P as PrettyAst<A>>::[<$ty:snake>];
+                            print(printer, self)
+                        }
                     }
-                }
+                });
             )*
         }
     };
+
     // Special default implementation for specific types
     (@method_body Symbol $meth:ident $self:ident $value:ident) => {
-        $self.text($value.to_string())
+        $self.as_string($value.to_string())
     };
     (@method_body LocalId $meth:ident $self:ident $value:ident) => {
-        ::pretty::docs![$self, &$value.0]
+        $value.0.to_document($self)
+    };
+    (@method_body SpannedTy $meth:ident $self:ident $value:ident) => {
+        $value.ty.to_document($self)
     };
     (@method_body $ty:ident $meth:ident $self:ident $value:ident) => {
         $self.unimplemented_method(stringify!($meth), ast::fragment::FragmentRef::from($meth))

--- a/rust-engine/src/printer/pretty_ast/debug_json.rs
+++ b/rust-engine/src/printer/pretty_ast/debug_json.rs
@@ -1,0 +1,81 @@
+use std::fmt::{Debug, Display};
+
+use crate::printer::pretty_ast::ToDocument;
+
+/// This type is primarily useful inside printer implementations when you want a
+/// low-friction way to inspect an AST fragment.
+///
+/// # What it does
+/// - Appends a JSON representation of the wrapped value to
+///   `"/tmp/hax-ast-debug.json"` (one JSON document per line).
+/// - Implements [`std::fmt::Display`] to print a `just` invocation you can paste in a shell
+///   to re-open that same JSON by line number:
+///   `just debug-json <line-id>`
+///
+/// # Example
+/// ```rust
+/// # use hax_rust_engine::printer::pretty_ast::DebugJSON;
+/// # #[derive(serde::Serialize)]
+/// # struct Small { x: u32 }
+/// let s = Small { x: 42 };
+/// // Prints something like: `just debug-json 17`.
+/// println!("{}", DebugJSON(&s));
+/// // Running `just debug-json 17` will print `{"x":42}`
+/// ```
+///
+/// # Notes
+/// - This is a **debugging convenience** and intentionally has a side-effect (file write).
+///   Avoid keeping it in user-facing output paths.
+/// - The file grows over time; occasionally delete it if you no longer need historical entries.
+pub struct DebugJSON<T: serde::Serialize>(pub T);
+
+impl<T: serde::Serialize> Display for DebugJSON<T> {
+    #[cfg(not(unix))]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<unknown, DebugJSON supported on unix plateforms only>")
+    }
+    #[cfg(unix)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const PATH: &str = "/tmp/hax-ast-debug.json";
+        /// Write a new JSON as a line at the end of `PATH`
+        fn append_line_json(value: &serde_json::Value) -> std::io::Result<usize> {
+            use std::io::{BufRead, BufReader, Write};
+            cleanup();
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .append(true)
+                .create(true)
+                .open(PATH)?;
+            let count = BufReader::new(&file).lines().count();
+            writeln!(&file, "{value}")?;
+            Ok(count)
+        }
+
+        /// Drop the file at `PATH` when we first write
+        fn cleanup() {
+            static DID_RUN: AtomicBool = AtomicBool::new(false);
+            use std::sync::atomic::{AtomicBool, Ordering};
+            if DID_RUN
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                let _ignored = std::fs::remove_file(PATH);
+            }
+        }
+
+        if let Ok(id) = append_line_json(&serde_json::to_value(&self.0).unwrap()) {
+            write!(f, "`just debug-json {id}`")
+        } else {
+            write!(f, "<DebugJSON failed>")
+        }
+    }
+}
+
+impl<A: 'static + Clone, P, T: serde::Serialize + Debug> ToDocument<P, A> for DebugJSON<T> {
+    fn to_document(&self, _: &P) -> super::DocBuilder<A> {
+        pretty::DocAllocator::as_string(
+            &pretty::BoxAllocator,
+            &serde_json::to_string_pretty(&self.0).unwrap_or_else(|_| format!("{:#?}", &self.0)),
+        )
+    }
+}

--- a/rust-engine/src/printer/pretty_ast/to_document.rs
+++ b/rust-engine/src/printer/pretty_ast/to_document.rs
@@ -1,0 +1,87 @@
+use pretty::{BoxAllocator, DocAllocator};
+use std::ops::Deref as _;
+
+/// A convenience alias tying the document builder to the global
+/// [`pretty::BoxAllocator`].
+pub type DocBuilder<A> = pretty::DocBuilder<'static, BoxAllocator, A>;
+
+/// Convert a value into a document by-value.
+///
+/// Implementations typically delegate to [`ToDocument`] after adjusting the
+/// input ownership (e.g., cloning or borrowing). It allows helpers to accept
+/// either borrowed or owned values transparently.
+pub trait ToDocumentOwned<P, A> {
+    /// Produce a document using the provided printer.
+    fn to_document_owned(self, printer: &P) -> DocBuilder<A>;
+}
+
+impl<'a, P, A, T: ToDocument<P, A>> ToDocumentOwned<P, A> for &'a T {
+    fn to_document_owned(self, printer: &P) -> DocBuilder<A> {
+        self.to_document(printer)
+    }
+}
+
+impl<P, A> ToDocumentOwned<P, A> for DocBuilder<A> {
+    fn to_document_owned(self, _printer: &P) -> DocBuilder<A> {
+        self
+    }
+}
+impl<P, A> ToDocumentOwned<P, A> for &str {
+    fn to_document_owned(self, _printer: &P) -> DocBuilder<A> {
+        DocAllocator::as_string(&BoxAllocator, self)
+    }
+}
+impl<P, A> ToDocumentOwned<P, A> for String {
+    fn to_document_owned(self, _printer: &P) -> DocBuilder<A> {
+        DocAllocator::as_string(&BoxAllocator, self)
+    }
+}
+impl<P, A> ToDocumentOwned<P, A> for Option<&str> {
+    fn to_document_owned(self, printer: &P) -> DocBuilder<A> {
+        self.map(|s| s.to_document_owned(printer))
+            .unwrap_or_else(|| DocAllocator::nil(&BoxAllocator))
+    }
+}
+
+/// Convert a value into a document using the supplied printer.
+///
+/// This is the primary trait invoked throughout the pretty-printing pipeline;
+/// it mirrors [`pretty::Pretty::pretty`] while giving access to printer-specific
+/// context.
+pub trait ToDocument<P, A> {
+    /// Produce a document using the provided printer reference.
+    fn to_document(&self, printer: &P) -> DocBuilder<A>;
+}
+
+impl<A, P, T: ToDocument<P, A>> ToDocument<P, A> for Box<T> {
+    fn to_document(&self, printer: &P) -> DocBuilder<A> {
+        self.deref().to_document(printer)
+    }
+}
+impl<A, P, T: ToDocument<P, A>> ToDocument<P, A> for Option<T> {
+    fn to_document(&self, printer: &P) -> DocBuilder<A> {
+        self.as_ref()
+            .map(|value| value.to_document(printer))
+            .unwrap_or_else(|| DocAllocator::nil(&BoxAllocator))
+    }
+}
+impl<A, P> ToDocument<P, A> for String {
+    fn to_document(&self, _printer: &P) -> DocBuilder<A> {
+        DocAllocator::as_string(&BoxAllocator, self)
+    }
+}
+impl<A: Clone, P> ToDocument<P, A> for DocBuilder<A> {
+    #[inline(always)]
+    fn to_document(&self, _printer: &P) -> DocBuilder<A> {
+        self.clone()
+    }
+}
+impl<'a, A: Clone, P, T> ToDocument<P, A> for &'a T
+where
+    T: ToDocument<P, A>,
+{
+    #[inline(always)]
+    fn to_document(&self, printer: &P) -> DocBuilder<A> {
+        (*self).to_document(printer)
+    }
+}


### PR DESCRIPTION
This PR revisits and refactors a bit the traits supporting our printing infrastructure in the Rust engine.

We now always return static Pretty `doc`s:
 - all the strings in the AST are `Symbol`s
 - `Symbol`s will soon be interned: we'll be able to get a `&'static str` out of a symbol
 - the vast majority of strings we want to print is either a literal (thus a static str), or a symbol (that we will be able to deref to a static str)
 - this leads to the conclusion that having Pretty documents with a lifetime different from `'static` isn't useful

The methods on the printer now always return values of type `pretty_ast::DocBuilder<A>`, which is a type alias for static boxed documents.
The lifetimes are thus greatly simplified.
Since lifetimes are only on input position, we can now create new printers in the middle of a pretty-printing job: this is very useful to carry contextual information such as `Span`s.

This PR also kills methods from `PrettyAst` that made no special sense, for the following types:
```rust
  ExprKind        | PatKind      | TyKind | GuardKind
| ImplExprKind    | ImplItemKind | TraitItemKind
| AttributeKind   | DocCommentKind
| Signedness      | IntSize
| ItemQuoteOrigin | ItemQuoteOriginKind | ItemQuoteOriginPosition
| ControlFlowKind | LoopState           | LoopKind
```

This PR also adds full support for span tracking; it adds a macro `setup_span_handling_struct` that each printer should use on their printer type. That macro adds a field `contextual_span` and implements the correct trait so that the printer infrastructure can keep contextual span information to produce nicely spanned errors.