### PR TITLE
fix(lean): display generic parameters of type aliases

### DIFF
--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -898,11 +898,17 @@ set_option linter.unusedVariables false
                 ]
                 .group()
                 .nest(INDENT),
-                ItemKind::TyAlias {
+                ItemKind::TyAlias { name, generics, ty } => docs![
+                    "abbrev ",
                     name,
-                    generics: _,
-                    ty,
-                } => docs!["abbrev ", name, reflow!(" := "), ty].group(),
+                    line!(),
+                    generics,
+                    reflow!(": Type :="),
+                    line!(),
+                    ty
+                ]
+                .nest(INDENT)
+                .group(),
                 ItemKind::Use {
                     path: _,
                     is_external: _,

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -800,6 +800,26 @@ def Lean_tests.binop_resugarings (x : u32) : RustM u32 := do
   let lshift : u32 ← (div <<<? x);
   (pure x)
 
+abbrev Lean_tests.Types.UsizeAlias : Type := usize
+
+abbrev Lean_tests.Types.MyOption (A : Type) : Type := (Core.Option.Option A)
+
+abbrev Lean_tests.Types.MyResult
+  (A : Type) (B : Type) : Type :=
+  (Core.Result.Result (Core.Option.Option A) B)
+
+abbrev Lean_tests.Types.ErrorMonad
+  (A : Type) (E : Type) : Type :=
+  (Core.Result.Result A E)
+
+abbrev Lean_tests.Types.StateMonad
+  (A : Type) (S : Type) : Type :=
+  (Rust_primitives.Hax.Tuple2 A S)
+
+abbrev Lean_tests.Types.ESMonad
+  (A : Type) (S : Type) (E : Type) : Type :=
+  (Rust_primitives.Hax.Tuple2 (Core.Result.Result A E) S)
+
 def Lean_tests.Reject_do_dsl.rejected
   (_ : Rust_primitives.Hax.Tuple0)
   : RustM Rust_primitives.Hax.Tuple0

--- a/tests/lean-tests/src/lib.rs
+++ b/tests/lean-tests/src/lib.rs
@@ -12,6 +12,7 @@ pub mod monadic;
 pub mod reject_do_dsl;
 pub mod structs;
 pub mod traits;
+pub mod types;
 
 const FORTYTWO: usize = 42;
 const MINUS_FORTYTWO: isize = -42;

--- a/tests/lean-tests/src/types.rs
+++ b/tests/lean-tests/src/types.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+// Tests on type aliases
+
+type UsizeAlias = usize;
+type MyOption<A> = Option<A>;
+type MyResult<A, B> = Result<Option<A>, B>;
+
+type ErrorMonad<A, E> = Result<A, E>;
+type StateMonad<A, S> = (A, S);
+type ESMonad<A, S, E> = StateMonad<ErrorMonad<A, E>, S>;


### PR DESCRIPTION
This PR fixes a bug : generic parameters of type aliases were ignored. Now they are displayed as parameters.

```rust
type UsizeAlias = usize;
type MyOption<A> = Option<A>;
type MyResult<A, B> = Result<Option<A>, B>;
```

```lean
abbrev UsizeAlias : Type := usize
abbrev MyOption (A : Type) : Type := (Core.Option.Option A)
abbrev MyResult (A : Type) (B : Type) : Type := (Core.Result.Result (Core.Option.Option A) B)
```

[Open this code snippet in the playground](https://hax-playground.cryspen.com/#lean/7a98965019/gist=1296c64717cc7914e66ef7ba71350048)

[skip changelog]