### PR TITLE
feat(lean): base specs on mathematical integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes to hax-lib:
  - F* lib: improved while loops support, additions of some specific arithmetic operations and fixed `TryInto` for integer types (#1742)
  - Lean lib: use macros for int operations (#1795)
  - Lean lib: add new setup for `bv_decide` (#1828)
+ - Lean lib: base specs on mathematical integers (#1829)
 
 Changes to the Lean backend:
  - Support for constants with arbitrary computation (#1738)

--- a/examples/lean_chacha20/src/hacspec_helper.rs
+++ b/examples/lean_chacha20/src/hacspec_helper.rs
@@ -79,8 +79,6 @@ theorem Lean_chacha20.Hacspec_helper.u32s_to_le_bytes_spec (state : (Vector u32 
   intros
   mvcgen [Lean_chacha20.Hacspec_helper.u32s_to_le_bytes, Core.Num.Impl_8.to_le_bytes]
     <;> try grind (splits := 14)
-  · rw [USize.umulOverflow_iff]
-    grind
 "
 )]
 pub(super) fn u32s_to_le_bytes(state: &[u32; 16]) -> [u8; 64] {

--- a/examples/lean_chacha20/src/lib.rs
+++ b/examples/lean_chacha20/src/lib.rs
@@ -234,6 +234,7 @@ pub fn chacha20_encrypt_last(st0: State, ctr: u32, plain: &[u8]) -> Vec<u8> {
 theorem System.Platform.numBits_ne_zero : ¬ System.Platform.numBits = 0 :=
 by cases (System.Platform.numBits_eq) <;> grind
 
+set_option maxHeartbeats 1200000 in
 @[spec]
 theorem Lean_chacha20.chacha20_update_spec (st0 : (Vector u32 16)) (m : (Array u8)) :
   m.size ≤ USize.size →
@@ -252,12 +253,14 @@ by
   <;> simp [
       USize.size,
       USize.eq_iff_toBitVec_eq,
+      USize.mulOverflow,
+      USize.addOverflow,
+      BitVec.uaddOverflow,
+      BitVec.umulOverflow
       ] at *
-  <;> (try omega)
-  <;> (try (intro h ; injections ; simp_all ; done))
-  <;> (rcases System.Platform.numBits_eq with h_size | h_size <;> try rw [h_size])
-  <;> (try bv_decide)
-  <;> try (simp [USize.lt_iff_toNat_lt, h_size ] at * <;> omega )
+  <;> (rcases System.Platform.numBits_eq with h_size | h_size)
+  <;> try rw [h_size]
+  all_goals (simp_all only [USize.le_iff_toNat_le, USize.toNat_ofNat'] <;> grind)
 "
 )]
 pub fn chacha20_update(st0: State, m: &[u8]) -> Vec<u8> {

--- a/hax-lib/proof-libs/lean/Hax/Integers/Ops.lean
+++ b/hax-lib/proof-libs/lean/Hax/Integers/Ops.lean
@@ -123,7 +123,7 @@ macro "declare_Hax_int_ops" s:(&"signed" <|> &"unsigned") typeName:ident width:t
         and when dividing by zero. -/
       instance : HaxDiv $typeName where
         div x y :=
-          if BitVec.sdivOverflow x.toBitVec y.toBitVec then .fail .integerOverflow
+          if x = $(mkIdent (typeName.getId ++ `minValue)) && y = -1 then .fail .integerOverflow
           else if y = 0 then .fail .divisionByZero
           else pure (x / y)
 
@@ -131,7 +131,7 @@ macro "declare_Hax_int_ops" s:(&"signed" <|> &"unsigned") typeName:ident width:t
         and when the modulus is zero. -/
       instance : HaxRem $typeName where
         rem x y :=
-          if BitVec.sdivOverflow x.toBitVec y.toBitVec then .fail .integerOverflow
+          if x = $(mkIdent (typeName.getId ++ `minValue)) && y = -1 then .fail .integerOverflow
           else if y = 0 then .fail .divisionByZero
           else pure (x % y)
     )

--- a/hax-lib/proof-libs/lean/Hax/MissingLean.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean.lean
@@ -1,7 +1,9 @@
 import Hax.MissingLean.Init.Data.Array.Lemmas
 import Hax.MissingLean.Init.Data.BitVec.Basic
 import Hax.MissingLean.Init.Data.Nat.Div.Basic
+import Hax.MissingLean.Init.Data.UInt.Basic
 import Hax.MissingLean.Init.Data.UInt.Lemmas
+import Hax.MissingLean.Init.Data.SInt.Basic
 import Hax.MissingLean.Init.Data.SInt.Lemmas
 import Hax.MissingLean.Init.Data.Vector.Basic
 import Hax.MissingLean.Init.Prelude

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/SInt/Basic.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/SInt/Basic.lean
@@ -1,0 +1,50 @@
+
+open Lean in
+set_option hygiene false in
+macro "additional_int_decls" typeName:ident width:term : command => do `(
+  namespace $typeName
+
+  def addOverflow (a b : $typeName) : Bool :=
+    BitVec.saddOverflow a.toBitVec b.toBitVec
+
+  def subOverflow (a b : $typeName) : Bool :=
+    BitVec.ssubOverflow a.toBitVec b.toBitVec
+
+  def mulOverflow (a b : $typeName) : Bool :=
+    BitVec.smulOverflow a.toBitVec b.toBitVec
+
+  @[grind]
+  theorem addOverflow_iff {a b : $typeName} : addOverflow a b ↔
+      a.toInt + b.toInt ≥ 2 ^ ($width - 1) ∨ a.toInt + b.toInt < - 2 ^ ($width - 1) := by
+    simp [addOverflow, BitVec.saddOverflow]
+
+  @[grind]
+  theorem subOverflow_iff {a b : $typeName} : subOverflow a b ↔
+      a.toInt - b.toInt ≥ 2 ^ ($width - 1) ∨ a.toInt - b.toInt < - 2 ^ ($width - 1) := by
+    simp [subOverflow, BitVec.ssubOverflow]
+
+  @[grind]
+  theorem mulOverflow_iff {a b : $typeName} : mulOverflow a b ↔
+      a.toInt * b.toInt ≥ 2 ^ ($width - 1) ∨ a.toInt * b.toInt < - 2 ^ ($width - 1) := by
+    simp [mulOverflow, BitVec.smulOverflow]
+
+  @[grind]
+  theorem toInt_add_of_not_addOverflow {x y : $typeName} (h : ¬ addOverflow x y) :
+      (x + y).toInt = x.toInt + y.toInt := BitVec.toInt_add_of_not_saddOverflow h
+
+  @[grind]
+  theorem toInt_sub_of_not_subOverflow {x y : $typeName} (h : ¬ subOverflow x y) :
+      (x - y).toInt = x.toInt - y.toInt := BitVec.toInt_sub_of_not_ssubOverflow h
+
+  @[grind]
+  theorem toInt_mul_of_not_mulOverflow {x y : $typeName} (h : ¬ mulOverflow x y) :
+      (x * y).toInt = x.toInt * y.toInt := BitVec.toInt_mul_of_not_smulOverflow h
+
+  end $typeName
+)
+
+additional_int_decls Int8 8
+additional_int_decls Int16 16
+additional_int_decls Int32 32
+additional_int_decls Int64 64
+additional_int_decls ISize System.Platform.numBits

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Basic.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Basic.lean
@@ -1,0 +1,45 @@
+open Lean in
+set_option hygiene false in
+macro "additional_uint_decls" typeName:ident width:term : command => do
+  let mut cmds := ← Syntax.getArgs <$> `(
+    namespace $typeName
+
+    theorem toNat_add_of_lt {x y : $typeName} (h : x.toNat + y.toNat < 2 ^ $width) :
+        (x + y).toNat = x.toNat + y.toNat := BitVec.toNat_add_of_lt h
+
+    theorem toNat_sub_of_lt {x y : $typeName} (h : y.toNat ≤ x.toNat) :
+        (x - y).toNat = x.toNat - y.toNat := BitVec.toNat_sub_of_le h
+
+    theorem toNat_mul_of_lt {x y : $typeName} (h : x.toNat * y.toNat < 2 ^ $width) :
+        (x * y).toNat = x.toNat * y.toNat := BitVec.toNat_mul_of_lt h
+
+    def addOverflow (a b : $typeName) : Bool :=
+      BitVec.uaddOverflow a.toBitVec b.toBitVec
+
+    def subOverflow (a b : $typeName) : Bool :=
+      BitVec.usubOverflow a.toBitVec b.toBitVec
+
+    def mulOverflow (a b : $typeName) : Bool :=
+      BitVec.umulOverflow a.toBitVec b.toBitVec
+
+    @[grind]
+    theorem addOverflow_iff {a b : $typeName} : addOverflow a b ↔ a.toNat + b.toNat ≥ 2 ^ $width :=
+      decide_eq_true_iff
+
+    @[grind]
+    theorem subOverflow_iff {a b : $typeName} : subOverflow a b ↔ a.toNat < b.toNat :=
+      decide_eq_true_iff
+
+    @[grind]
+    theorem mulOverflow_iff {a b : $typeName} : mulOverflow a b ↔ a.toNat * b.toNat ≥ 2 ^ $width :=
+      decide_eq_true_iff
+
+    end $typeName
+  )
+  return ⟨mkNullNode cmds⟩
+
+additional_uint_decls UInt8 8
+additional_uint_decls UInt16 16
+additional_uint_decls UInt32 32
+additional_uint_decls UInt64 64
+additional_uint_decls USize System.Platform.numBits


### PR DESCRIPTION
This PR reformulates the specs of integer operations using mathematical integers.

For now, the specs of unsigned integers still use `Nat` instead of `Int` because the API support for `Int` is bad (e.g. `UInt32.toInt` does not exist). I'll leave that for a future PR. (Issue https://github.com/cryspen/hax/issues/1830)