### PR TITLE
feat(lean): preliminary core model extraction

### DIFF
--- a/hax-lib/core-models/hax.sh
+++ b/hax-lib/core-models/hax.sh
@@ -1,10 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
-function extract_and_copy() {
+function extract_fstar() {
     go_to "./"
     HAX_CORE_MODELS_EXTRACTION_MODE=on cargo hax into -i '-**::ops::arith::** -**::convert::**' fstar --interfaces '+!**::num::* +!**::panicking::internal +!core_models::borrow +!core_models::default +!core_models::error +!core_models::hash +!core_models::hint +!core_models::num +!core_models::ops::bit'
     cp proofs/fstar/extraction/*.fst* ../proof-libs/fstar/core
+}
+
+function extract_lean() {
+    go_to "./"
+    LEAN_FILTERS=""
+    LEAN_FILTERS+=" -core_models::ops::function::Fn" # Issue #1710
+    LEAN_FILTERS+=" -core_models::result::**::ok" # Issue #1823
+    LEAN_FILTERS+=" -core_models::result::**::unwrap" # Issue #1818
+    LEAN_FILTERS+=" -core_models::result::**::expect" # Issue #1818
+    LEAN_FILTERS+=" -core_models::option::**::expect" # Issue #1818
+    LEAN_FILTERS+=" -core_models::option::**::unwrap" # Issue #1818
+    LEAN_FILTERS="$(echo "$LEAN_FILTERS" | xargs)"
+    HAX_CORE_MODELS_EXTRACTION_MODE=on cargo hax into -i "$LEAN_FILTERS" lean
+    sed -i 's/def Core_models\.Cmp\.Ordering /def Core_models.Cmp.Ordering_ /g' proofs/lean/extraction/Core_models.lean # Issue #1646
+    sed -i 's/Core_models.Convert.From.from/Core_models.Convert.From._from/g' proofs/lean/extraction/Core_models.lean # Issue #1853
+    
+    cp proofs/lean/extraction/Core_models.lean ../proof-libs/lean/Hax/CoreModels.lean
 }
 
 function init_vars() {
@@ -37,7 +54,7 @@ function msg() {
 
 
 function help() {
-    echo "Script to extract to F* and place the result in proof-libs"
+    echo "Script to extract to F* or Lean and place the result in proof-libs"
     echo ""
     echo "Usage: $0 [COMMAND]"
     echo ""
@@ -57,9 +74,27 @@ function cli() {
     case "$1" in
         --help) #> Show help message
             help;;
-        extract) #> Extract the F* code and copy it to proof-libs.
-            extract_and_copy
-            msg "$GREEN" "done"
+        extract) #> Extract the F* code and copy it to proof-libs. Use `extract fstar` for F*, `extract lean` for Lean, or `extract` for both
+            case "$2" in
+                "")  # no subcommand -> run both
+                    extract_fstar
+                    extract_lean
+                    msg "$GREEN" "done"
+                    ;;
+                fstar)
+                    extract_fstar
+                    msg "$GREEN" "done"
+                    ;;
+                lean)
+                    extract_lean
+                    msg "$GREEN" "done"
+                    ;;
+                *)
+                    echo "Invalid option for extract: $2"
+                    help
+                    exit 1
+                    ;;
+            esac
             ;;
         *)
             echo "Invalid option: $1"

--- a/hax-lib/core-models/src/core/clone.rs
+++ b/hax-lib/core-models/src/core/clone.rs
@@ -9,7 +9,7 @@
   f_clone: x:self -> r:self {x == r}
 }"
 )]
-trait Clone {
+pub trait Clone {
     fn clone(self) -> Self;
 }
 

--- a/hax-lib/core-models/src/core/marker.rs
+++ b/hax-lib/core-models/src/core/marker.rs
@@ -1,3 +1,5 @@
+use super::clone::Clone;
+
 pub trait Copy: Clone {}
 pub trait Send {}
 pub trait Sync {}

--- a/hax-lib/proof-libs/lean/Hax/Core.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core.lean
@@ -7,3 +7,4 @@ import Hax.Core.Panicking
 import Hax.Core.Result
 import Hax.Core.Option
 import Hax.Core.Convert
+import Hax.Core.Marker

--- a/hax-lib/proof-libs/lean/Hax/Core/Marker.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core/Marker.lean
@@ -1,0 +1,12 @@
+import Hax.Core.Clone
+
+class Core.Marker.Copy.AssociatedTypes (Self : Type) where
+
+class Core.Marker.Copy
+  (Self : Type)
+  [associatedTypes : outParam (Core.Marker.Copy.AssociatedTypes (Self :
+      Type))]
+  where
+  [trait_constr : Core.Clone.Clone Self]
+
+attribute [instance] Core.Marker.Copy.trait_constr

--- a/hax-lib/proof-libs/lean/Hax/Lib.lean
+++ b/hax-lib/proof-libs/lean/Hax/Lib.lean
@@ -215,10 +215,12 @@ abbrev u16 := UInt16
 abbrev u32 := UInt32
 abbrev u64 := UInt64
 abbrev usize := USize64
+abbrev u128 := BitVec 128
 abbrev i8 := Int8
 abbrev i16 := Int16
 abbrev i32 := Int32
 abbrev i64 := Int64
+abbrev i128 := BitVec 128
 abbrev isize := ISize
 
 /-- Class of objects that can be transformed into Nat -/
@@ -395,6 +397,8 @@ end Rust_primitives.Hax.Machine_int
 
 @[simp, spec, hax_bv_decide]
 def Core.Ops.Arith.Neg.neg {α} [Neg α] (x:α) : RustM α := pure (-x)
+
+abbrev Core.Cmp.PartialEq.eq {α} [BEq α] (a b : α) := BEq.beq a b
 
 
 /-
@@ -1151,7 +1155,12 @@ structure Spec {α}
   pureEnsures : {p : α → Prop // pureRequires.val → ∀ a, ⦃ ⌜ True ⌝ ⦄ ensures a ⦃ ⇓r => ⌜ r = p a ⌝ ⦄}
   contract : ⦃ ⌜ pureRequires.val ⌝ ⦄ f ⦃ ⇓r => ⌜ pureEnsures.val r ⌝ ⦄
 
--- Miscellaneous
+
+/-
+
+# Miscellaneous
+
+-/
 def Core.Ops.Deref.Deref.deref {α Allocator} (β : Type) (v: Alloc.Vec.Vec α Allocator)
   : RustM (Array α)
   := pure v
@@ -1171,6 +1180,10 @@ abbrev assert (b:Bool) : RustM Tuple0 :=
 
 abbrev assume : Prop -> RustM Tuple0 := fun _ => pure ⟨ ⟩
 
-abbrev Prop.Constructors.from_bool (b :Bool) : Prop := (b = true)
+abbrev Prop.Constructors.from_bool (b : Bool) : Prop := (b = true)
+
+abbrev Prop.Impl.from_bool (b : Bool) : Prop := (b = true)
+
+abbrev Prop.Constructors.implies (a b : Prop) : Prop := a → b
 
 end Hax_lib

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives.lean
@@ -1,3 +1,10 @@
 import Hax.Integers.Ops
 import Hax.Integers.Spec
 import Hax.Float
+
+namespace Rust_primitives.Hax
+
+  abbrev Never : Type := Empty
+  abbrev never_to_any.{u} {α : Sort u} : Never → α := Empty.elim
+
+end Rust_primitives.Hax

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -507,7 +507,7 @@ const _: () = {
                             docs![
                                 "requires",
                                 softline!(),
-                                ":=",
+                                ":= do",
                                 line!(),
                                 spec.precondition.map_or(reflow!("pure True"), |p| docs![p])
                             ]
@@ -523,7 +523,7 @@ const _: () = {
                                         line!(),
                                         p.result_binder,
                                         softline!(),
-                                        "=>",
+                                        "=> do",
                                         line!(),
                                         p.body,
                                     ]
@@ -1180,7 +1180,11 @@ set_option linter.unusedVariables false
                         ]
                         .group()
                         .nest(INDENT),
-                        &self.spec(item, name, generics, params)
+                        if opaque {
+                            nil!()
+                        } else {
+                            docs![&self.spec(item, name, generics, params)]
+                        }
                     ]
                 }
                 ItemKind::TyAlias { name, generics, ty } => docs![

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -893,7 +893,7 @@ def
       (self : Lean_tests.Specs.Issue_1852.T)
        :
     Spec
-      (requires := (Lean_tests.Specs.Issue_1852.Impl.test self))
+      (requires := do (Lean_tests.Specs.Issue_1852.Impl.test self))
       (ensures := fun _ => pure True)
       (Lean_tests.Specs.Issue_1852.Impl.func
         (self : Lean_tests.Specs.Issue_1852.T)
@@ -908,8 +908,8 @@ def Lean_tests.Specs.test (x : u8) : RustM u8 := do (pure x)
 @[spec]
 def Lean_tests.Specs.test.spec (x : u8)  :
     Spec
-      (requires := (Rust_primitives.Hax.Machine_int.gt x (0 : u8)))
-      (ensures := fun r => (Rust_primitives.Hax.Machine_int.eq r x))
+      (requires := do (Rust_primitives.Hax.Machine_int.gt x (0 : u8)))
+      (ensures := fun r => do (Rust_primitives.Hax.Machine_int.eq r x))
       (Lean_tests.Specs.test (x : u8) ) := {
   pureRequires := by constructor; mvcgen <;> try grind
   pureEnsures := by constructor; intros; mvcgen <;> try grind
@@ -921,8 +921,8 @@ def Lean_tests.Specs.test_proof (x : u8) : RustM u8 := do (pure x)
 @[spec]
 def Lean_tests.Specs.test_proof.spec (x : u8)  :
     Spec
-      (requires := (Rust_primitives.Hax.Machine_int.gt x (0 : u8)))
-      (ensures := fun r => (Rust_primitives.Hax.Machine_int.eq r x))
+      (requires := do (Rust_primitives.Hax.Machine_int.gt x (0 : u8)))
+      (ensures := fun r => do (Rust_primitives.Hax.Machine_int.eq r x))
       (Lean_tests.Specs.test_proof (x : u8) ) := {
   pureRequires := by constructor; mvcgen <;> try grind
   pureEnsures := by constructor; intros; mvcgen <;> try grind
@@ -1093,8 +1093,8 @@ def Lean_tests.Loops.while_loop1 (s : u32) : RustM u32 := do
 @[spec]
 def Lean_tests.Loops.while_loop1.spec (s : u32)  :
     Spec
-      (requires := pure True)
-      (ensures := fun r => (pure true))
+      (requires := do pure True)
+      (ensures := fun r => do (pure true))
       (Lean_tests.Loops.while_loop1 (s : u32) ) := {
   pureRequires := by constructor; mvcgen <;> try grind
   pureEnsures := by constructor; intros; mvcgen <;> try grind


### PR DESCRIPTION
This PR adds an option to `core-models/hax.sh` to extract Lean code from Core models. It is able to generate a Lean file that compiles.

To make the extraction work, I currently must exclude some functions and do some text replacements using `sed` (see `hax.sh`). This is due to the following issues:
- #1710
- #1823
- #1818 
- #1852 
- #1646 
- #1853 

Moreover, the following points should be improved in future PRs:
- The types `i128` and `u128` should get a proper implementation (https://github.com/cryspen/hax/issues/1854)
- I have deactivated spec generation for opaque definitions here, but they should instead get an axiomatized spec. (https://github.com/cryspen/hax/issues/1847)
- `==` should be rendered `==` (https://github.com/cryspen/hax/issues/1845)

This PR lets us produce a compiling Lean file, but the file is not part of this PR. This is because the generated items are all in the namespace `Core_models`, whereas extracted Code references `Core`. So we cannot use the file just yet. In a future PR, I plan to make extraction generate references to the `Core_models` namespace whenever extracting something that is not Core models itself. (#1855)

[skip changelog]