### PR TITLE
fix(lean): fix rendering of impl items with constraints

### DIFF
--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -1538,9 +1538,19 @@ set_option linter.unusedVariables false
                     docs![
                         name,
                         softline!(),
-                        generics,
-                        zip_right!(params, line!()).group(),
-                        ":= do",
+                        ":=",
+                        line!(),
+                        docs![
+                            "fun",
+                            line!(),
+                            generics,
+                            zip_right!(params, line!()).group(),
+                            "=>",
+                            softline!(),
+                            "do"
+                        ]
+                        .group()
+                        .nest(INDENT)
                     ]
                     .group(),
                     line!(),

--- a/test-harness/src/snapshots/toolchain__lean-core-models into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-core-models into-lean.snap
@@ -155,7 +155,7 @@ instance Lean_core_models.Option.Impl.AssociatedTypes :
 instance Lean_core_models.Option.Impl :
   Core.Default.Default Lean_core_models.Option.S
   where
-  default (_ : Rust_primitives.Hax.Tuple0) := do
+  default := fun (_ : Rust_primitives.Hax.Tuple0) => do
     (pure (Lean_core_models.Option.S.mk (f1 := (42 : u32))))
 
 def Lean_core_models.Option.test
@@ -252,7 +252,7 @@ instance Lean_core_models.Default.Structs.Impl.AssociatedTypes :
 instance Lean_core_models.Default.Structs.Impl :
   Core.Default.Default Lean_core_models.Default.Structs.S
   where
-  default (_ : Rust_primitives.Hax.Tuple0) := do
+  default := fun (_ : Rust_primitives.Hax.Tuple0) => do
     (pure (Lean_core_models.Default.Structs.S.mk (f1 := (0 : usize))))
 
 def Lean_core_models.Default.Structs.test
@@ -280,7 +280,7 @@ instance Lean_core_models.Default.Enums.Impl
   :
   Core.Default.Default (Lean_core_models.Default.Enums.E T)
   where
-  default (_ : Rust_primitives.Hax.Tuple0) := do
+  default := fun (_ : Rust_primitives.Hax.Tuple0) => do
     (pure (Lean_core_models.Default.Enums.E.C2
       (← (Core.Default.Default.default T Rust_primitives.Hax.Tuple0.mk))))
 

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -91,6 +91,51 @@ open Std.Tactic
 set_option mvcgen.warning false
 set_option linter.unusedVariables false
 
+class Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes (Self : Type)
+  where
+
+class Lean_tests.Traits.Trait_with_constraints.T1
+  (Self : Type)
+  [associatedTypes : outParam
+    (Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes (Self : Type))]
+  where
+
+class Lean_tests.Traits.Trait_with_constraints.T2.AssociatedTypes (Self : Type)
+  where
+
+class Lean_tests.Traits.Trait_with_constraints.T2
+  (Self : Type)
+  [associatedTypes : outParam
+    (Lean_tests.Traits.Trait_with_constraints.T2.AssociatedTypes (Self : Type))]
+  where
+  func (Self)
+    [Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes Self]
+    [Lean_tests.Traits.Trait_with_constraints.T1 Self ]
+    :
+    (Self -> RustM Bool)
+
+instance Lean_tests.Traits.Trait_with_constraints.Impl.AssociatedTypes
+  (A : Type)
+  [Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes A]
+  [Lean_tests.Traits.Trait_with_constraints.T1 A ]
+  :
+  Lean_tests.Traits.Trait_with_constraints.T2.AssociatedTypes A
+  where
+
+instance Lean_tests.Traits.Trait_with_constraints.Impl
+  (A : Type)
+  [Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes A]
+  [Lean_tests.Traits.Trait_with_constraints.T1 A ]
+  :
+  Lean_tests.Traits.Trait_with_constraints.T2 A
+  where
+  func :=
+    fun
+      [Lean_tests.Traits.Trait_with_constraints.T1.AssociatedTypes A]
+      [Lean_tests.Traits.Trait_with_constraints.T1 A ]
+      (self : A) => do
+    (pure true)
+
 class Lean_tests.Traits.Trait_level_args.T1.AssociatedTypes (Self : Type) (A :
   Type) (B : Type) where
 
@@ -119,11 +164,11 @@ instance Lean_tests.Traits.Trait_level_args.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Trait_level_args.Impl :
   Lean_tests.Traits.Trait_level_args.T1 usize u32 u64
   where
-  f1 (C : Type) (D : Type) (self : usize) := do
+  f1 := fun (C : Type) (D : Type) (self : usize) => do
     (pure Rust_primitives.Hax.Tuple0.mk)
-  f2 (C : Type) (D : Type) (self : usize) (x : u32) := do
+  f2 := fun (C : Type) (D : Type) (self : usize) (x : u32) => do
     (pure Rust_primitives.Hax.Tuple0.mk)
-  f3 (C : Type) (D : Type) (self : usize) (x : u32) (y : u64) := do
+  f3 := fun (C : Type) (D : Type) (self : usize) (x : u32) (y : u64) => do
     (pure Rust_primitives.Hax.Tuple0.mk)
 
 def Lean_tests.Traits.Trait_level_args.test
@@ -181,7 +226,7 @@ instance Lean_tests.Traits.Overlapping_methods.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Overlapping_methods.Impl :
   Lean_tests.Traits.Overlapping_methods.T1 u32
   where
-  f (self : u32) := do (pure (0 : usize))
+  f := fun (self : u32) => do (pure (0 : usize))
 
 instance Lean_tests.Traits.Overlapping_methods.Impl_1.AssociatedTypes :
   Lean_tests.Traits.Overlapping_methods.T2.AssociatedTypes u32
@@ -190,7 +235,7 @@ instance Lean_tests.Traits.Overlapping_methods.Impl_1.AssociatedTypes :
 instance Lean_tests.Traits.Overlapping_methods.Impl_1 :
   Lean_tests.Traits.Overlapping_methods.T2 u32
   where
-  f (self : u32) := do (pure (1 : usize))
+  f := fun (self : u32) => do (pure (1 : usize))
 
 instance Lean_tests.Traits.Overlapping_methods.Impl_2.AssociatedTypes :
   Lean_tests.Traits.Overlapping_methods.T3.AssociatedTypes u32
@@ -199,7 +244,7 @@ instance Lean_tests.Traits.Overlapping_methods.Impl_2.AssociatedTypes :
 instance Lean_tests.Traits.Overlapping_methods.Impl_2 :
   Lean_tests.Traits.Overlapping_methods.T3 u32
   where
-  f (self : u32) := do (pure (2 : usize))
+  f := fun (self : u32) => do (pure (2 : usize))
 
 def Lean_tests.Traits.Overlapping_methods.test
   (_ : Rust_primitives.Hax.Tuple0)
@@ -294,7 +339,7 @@ instance Lean_tests.Traits.Inheritance.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Inheritance.Impl :
   Lean_tests.Traits.Inheritance.T1 Lean_tests.Traits.Inheritance.S
   where
-  f1 (self : Lean_tests.Traits.Inheritance.S) := do (pure (1 : usize))
+  f1 := fun (self : Lean_tests.Traits.Inheritance.S) => do (pure (1 : usize))
 
 instance Lean_tests.Traits.Inheritance.Impl_1.AssociatedTypes :
   Lean_tests.Traits.Inheritance.T2.AssociatedTypes
@@ -304,7 +349,7 @@ instance Lean_tests.Traits.Inheritance.Impl_1.AssociatedTypes :
 instance Lean_tests.Traits.Inheritance.Impl_1 :
   Lean_tests.Traits.Inheritance.T2 Lean_tests.Traits.Inheritance.S
   where
-  f2 (self : Lean_tests.Traits.Inheritance.S) := do (pure (2 : usize))
+  f2 := fun (self : Lean_tests.Traits.Inheritance.S) => do (pure (2 : usize))
 
 instance Lean_tests.Traits.Inheritance.Impl_2.AssociatedTypes :
   Lean_tests.Traits.Inheritance.T3.AssociatedTypes
@@ -314,7 +359,7 @@ instance Lean_tests.Traits.Inheritance.Impl_2.AssociatedTypes :
 instance Lean_tests.Traits.Inheritance.Impl_2 :
   Lean_tests.Traits.Inheritance.T3 Lean_tests.Traits.Inheritance.S
   where
-  f3 (self : Lean_tests.Traits.Inheritance.S) := do (pure (3 : usize))
+  f3 := fun (self : Lean_tests.Traits.Inheritance.S) => do (pure (3 : usize))
 
 instance Lean_tests.Traits.Inheritance.Impl_3.AssociatedTypes :
   Lean_tests.Traits.Inheritance.Tp1.AssociatedTypes
@@ -324,7 +369,7 @@ instance Lean_tests.Traits.Inheritance.Impl_3.AssociatedTypes :
 instance Lean_tests.Traits.Inheritance.Impl_3 :
   Lean_tests.Traits.Inheritance.Tp1 Lean_tests.Traits.Inheritance.S
   where
-  f1 (self : Lean_tests.Traits.Inheritance.S) := do (pure (10 : usize))
+  f1 := fun (self : Lean_tests.Traits.Inheritance.S) => do (pure (10 : usize))
 
 instance Lean_tests.Traits.Inheritance.Impl_4.AssociatedTypes :
   Lean_tests.Traits.Inheritance.Tp2.AssociatedTypes
@@ -334,7 +379,7 @@ instance Lean_tests.Traits.Inheritance.Impl_4.AssociatedTypes :
 instance Lean_tests.Traits.Inheritance.Impl_4 :
   Lean_tests.Traits.Inheritance.Tp2 Lean_tests.Traits.Inheritance.S
   where
-  fp2 (self : Lean_tests.Traits.Inheritance.S) := do
+  fp2 := fun (self : Lean_tests.Traits.Inheritance.S) => do
     ((← ((← ((← (Lean_tests.Traits.Inheritance.Tp1.f1
             Lean_tests.Traits.Inheritance.S self))
           +? (← (Lean_tests.Traits.Inheritance.T1.f1
@@ -368,7 +413,7 @@ instance Lean_tests.Traits.Default.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Default.Impl :
   Lean_tests.Traits.Default.Easy usize
   where
-  dft (self : usize) := do (self +? (1 : usize))
+  dft := fun (self : usize) => do (self +? (1 : usize))
 
 instance Lean_tests.Traits.Default.Impl_1.AssociatedTypes :
   Lean_tests.Traits.Default.Easy.AssociatedTypes u32
@@ -409,10 +454,10 @@ instance Lean_tests.Traits.Default.Impl_2.AssociatedTypes :
 instance Lean_tests.Traits.Default.Impl_2 :
   Lean_tests.Traits.Default.T1 (Lean_tests.Traits.Default.S usize)
   where
-  f1 (self : (Lean_tests.Traits.Default.S usize)) := do
+  f1 := fun (self : (Lean_tests.Traits.Default.S usize)) => do
     ((Lean_tests.Traits.Default.S._0 self)
       +? (Lean_tests.Traits.Default.S._1 self))
-  f2 (self : (Lean_tests.Traits.Default.S usize)) := do
+  f2 := fun (self : (Lean_tests.Traits.Default.S usize)) => do
     (pure (Lean_tests.Traits.Default.S._1 self))
 
 instance Lean_tests.Traits.Default.Impl_3.AssociatedTypes :
@@ -423,12 +468,12 @@ instance Lean_tests.Traits.Default.Impl_3.AssociatedTypes :
 instance Lean_tests.Traits.Default.Impl_3 :
   Lean_tests.Traits.Default.T1 (Lean_tests.Traits.Default.S Bool)
   where
-  f1 (self : (Lean_tests.Traits.Default.S Bool)) := do
+  f1 := fun (self : (Lean_tests.Traits.Default.S Bool)) => do
     if (Lean_tests.Traits.Default.S._1 self) then
       (pure (Lean_tests.Traits.Default.S._0 self))
     else
       (pure (9 : usize))
-  f2 (self : (Lean_tests.Traits.Default.S Bool)) := do
+  f2 := fun (self : (Lean_tests.Traits.Default.S Bool)) => do
     ((Lean_tests.Traits.Default.S._0 self) +? (1 : usize))
 
 instance Lean_tests.Traits.Default.Impl_4.AssociatedTypes :
@@ -439,7 +484,7 @@ instance Lean_tests.Traits.Default.Impl_4.AssociatedTypes :
 instance Lean_tests.Traits.Default.Impl_4 :
   Lean_tests.Traits.Default.T1 (Lean_tests.Traits.Default.S Alloc.String.String)
   where
-  f1 (self : (Lean_tests.Traits.Default.S Alloc.String.String)) := do
+  f1 := fun (self : (Lean_tests.Traits.Default.S Alloc.String.String)) => do
     (pure (0 : usize))
 
 class Lean_tests.Traits.Bounds.T1.AssociatedTypes (Self : Type) where
@@ -495,7 +540,7 @@ instance Lean_tests.Traits.Bounds.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Bounds.Impl :
   Lean_tests.Traits.Bounds.T1 Lean_tests.Traits.Bounds.S1
   where
-  f1 (self : Lean_tests.Traits.Bounds.S1) := do (pure (0 : usize))
+  f1 := fun (self : Lean_tests.Traits.Bounds.S1) => do (pure (0 : usize))
 
 structure Lean_tests.Traits.Bounds.S2 where
 
@@ -507,7 +552,7 @@ instance Lean_tests.Traits.Bounds.Impl_1.AssociatedTypes :
 instance Lean_tests.Traits.Bounds.Impl_1 :
   Lean_tests.Traits.Bounds.T2 Lean_tests.Traits.Bounds.S2
   where
-  f2 (self : Lean_tests.Traits.Bounds.S2) := do (pure (1 : usize))
+  f2 := fun (self : Lean_tests.Traits.Bounds.S2) => do (pure (1 : usize))
 
 instance Lean_tests.Traits.Bounds.Impl_2.AssociatedTypes :
   Lean_tests.Traits.Bounds.Test.AssociatedTypes
@@ -520,9 +565,10 @@ instance Lean_tests.Traits.Bounds.Impl_2 :
   Lean_tests.Traits.Bounds.S2
   Lean_tests.Traits.Bounds.S1
   where
-  f_test (self : Lean_tests.Traits.Bounds.S2)
-    (x : Lean_tests.Traits.Bounds.S1)
-    := do
+  f_test :=
+    fun
+      (self : Lean_tests.Traits.Bounds.S2) (x : Lean_tests.Traits.Bounds.S1) =>
+      do
     ((← ((← (Lean_tests.Traits.Bounds.T1.f1 Lean_tests.Traits.Bounds.S1 x))
         +? (← (Lean_tests.Traits.Bounds.T2.f2
           Lean_tests.Traits.Bounds.S2 self))))
@@ -558,10 +604,11 @@ instance Lean_tests.Traits.Basic.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Basic.Impl :
   Lean_tests.Traits.Basic.T1 Lean_tests.Traits.Basic.S
   where
-  f1 (self : Lean_tests.Traits.Basic.S) := do (pure (42 : usize))
-  f2 (self : Lean_tests.Traits.Basic.S)
-    (other : Lean_tests.Traits.Basic.S)
-    := do
+  f1 := fun (self : Lean_tests.Traits.Basic.S) => do (pure (42 : usize))
+  f2 :=
+    fun
+      (self : Lean_tests.Traits.Basic.S) (other : Lean_tests.Traits.Basic.S) =>
+      do
     (pure (43 : usize))
 
 def Lean_tests.Traits.Basic.f
@@ -657,7 +704,7 @@ instance Lean_tests.Traits.Associated_types.Impl.AssociatedTypes :
 instance Lean_tests.Traits.Associated_types.Impl :
   Lean_tests.Traits.Associated_types.T1 Lean_tests.Traits.Associated_types.S
   where
-  f (self : Lean_tests.Traits.Associated_types.S) (x : i32) := do
+  f := fun (self : Lean_tests.Traits.Associated_types.S) (x : i32) => do
     (pure (2121 : i32))
 
 class Lean_tests.Traits.Associated_types.T2.AssociatedTypes (Self : Type) where
@@ -682,9 +729,11 @@ instance Lean_tests.Traits.Associated_types.Impl_1.AssociatedTypes :
 instance Lean_tests.Traits.Associated_types.Impl_1 :
   Lean_tests.Traits.Associated_types.T2 Lean_tests.Traits.Associated_types.S
   where
-  f (self : Lean_tests.Traits.Associated_types.S)
-    (x : Lean_tests.Traits.Associated_types.S)
-    := do
+  f :=
+    fun
+      (self : Lean_tests.Traits.Associated_types.S)
+      (x : Lean_tests.Traits.Associated_types.S)
+      => do
     (pure (21 : usize))
 
 structure Lean_tests.Structs.Miscellaneous.S where
@@ -1128,9 +1177,11 @@ instance Lean_tests.Constants.Const_parameters.Impl (N_TRAIT : usize) :
   (Lean_tests.Constants.Const_parameters.S (N_TRAIT))
   (N_TRAIT)
   where
-  f (N_FIELD : usize) (self :
-    (Lean_tests.Constants.Const_parameters.S (N_TRAIT)))
-    := do
+  f :=
+    fun
+      (N_FIELD : usize) (self :
+      (Lean_tests.Constants.Const_parameters.S (N_TRAIT)))
+      => do
     (N_TRAIT -? N_FIELD)
 
 def Lean_tests.Constants.Const_parameters.test2
@@ -1233,9 +1284,9 @@ instance Lean_tests.Associated_types.Multiple_associated_types.Impl :
   Lean_tests.Associated_types.Multiple_associated_types.Pair
   (Rust_primitives.Hax.Tuple2 i32 Bool)
   where
-  first (self : (Rust_primitives.Hax.Tuple2 i32 Bool)) := do
+  first := fun (self : (Rust_primitives.Hax.Tuple2 i32 Bool)) => do
     (pure (Rust_primitives.Hax.Tuple2._0 self))
-  second (self : (Rust_primitives.Hax.Tuple2 i32 Bool)) := do
+  second := fun (self : (Rust_primitives.Hax.Tuple2 i32 Bool)) => do
     (pure (Rust_primitives.Hax.Tuple2._1 self))
 
 def Lean_tests.Associated_types.Multiple_associated_types.b
@@ -1310,7 +1361,7 @@ instance Lean_tests.Associated_types.Basic.Impl.AssociatedTypes :
 instance Lean_tests.Associated_types.Basic.Impl :
   Lean_tests.Associated_types.Basic.Iterable Bool
   where
-  first (self : Bool) := do (pure (3 : i32))
+  first := fun (self : Bool) => do (pure (3 : i32))
 
 def Lean_tests.Associated_types.Basic.a
   (_ : Rust_primitives.Hax.Tuple0)

--- a/tests/lean-tests/src/traits.rs
+++ b/tests/lean-tests/src/traits.rs
@@ -278,3 +278,23 @@ mod trait_level_args {
         x.f3::<C, D>(a, b);
     }
 }
+
+mod trait_with_constraints {
+
+    trait T1 {}
+
+    trait T2 {
+        fn func(&self) -> bool
+        where
+            Self: T1;
+    }
+
+    impl<A: T1> T2 for A {
+        fn func(&self) -> bool
+        where
+            A: T1,
+        {
+            true
+        }
+    }
+}


### PR DESCRIPTION
Lean does not accept the following notation:
```
instance : Y where
  lt [X] := true
```
In my opinion, this is a Lean bug, but there are simple workarounds, so this will probably not get fixed:
[#lean4 > possible parsing bug: invalid {...} notation](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/possible.20parsing.20bug.3A.20invalid.20.7B.2E.2E.2E.7D.20notation/with/564287220)

This PR implements one of these workarounds.

[skip changelog]