### PR TITLE
fix(lean): associated type projections on multiple parameters

### DIFF
--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -635,14 +635,16 @@ set_option linter.unusedVariables false
                 zip_right!(&generics.params, line!()),
                 zip_right!(
                     generics.type_constraints().map(|impl_ident| {
-                        let projections = generics.projection_constraints()
-                            .map(|p|
-                                if let ImplExprKind::LocalBound { id } = &*p.impl_.kind && *id == impl_ident.name {
+                        let projections = generics
+                            .projection_constraints()
+                            .filter(|p| !matches!(&*p.impl_.kind, ImplExprKind::LocalBound { id } if *id != impl_ident.name ))
+                            .map(|p| {
+                                if let ImplExprKind::LocalBound { .. } = &*p.impl_.kind {
                                     docs![p]
                                 } else {
                                     emit_error!(issue 1710, "Unsupported variant of associated type projection")
                                 }
-                            )
+                            })
                             .collect::<Vec<_>>();
                         docs![
                             docs![

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -1184,6 +1184,55 @@ def Lean_tests.Constants.test
   let z : u32 ← (Lean_tests.Constants.C4 -? Lean_tests.Constants.C3);
   (pure Rust_primitives.Hax.Tuple0.mk)
 
+class Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes
+  (Self : Type) (T : Type) where
+  Output : Type
+
+abbrev Lean_tests.Associated_types.Multiple_projections.FnOnce.Output :=
+  Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes.Output
+
+class Lean_tests.Associated_types.Multiple_projections.FnOnce
+  (Self : Type)
+  (T : Type)
+  [associatedTypes : outParam
+    (Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes
+      (Self : Type) (T : Type))]
+  where
+
+def Lean_tests.Associated_types.Multiple_projections.func
+  (T : Type)
+  (U : Type)
+  (D : Type)
+  (F : Type)
+  [Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes F T]
+  [Lean_tests.Associated_types.Multiple_projections.FnOnce
+    F
+    T
+    (associatedTypes := {
+      show
+        Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes
+        F
+        T
+      by infer_instance
+      with Output := U})]
+  [Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes D T]
+  [Lean_tests.Associated_types.Multiple_projections.FnOnce
+    D
+    T
+    (associatedTypes := {
+      show
+        Lean_tests.Associated_types.Multiple_projections.FnOnce.AssociatedTypes
+        D
+        T
+      by infer_instance
+      with Output := U})]
+  (d : D)
+  (f : F)
+  (u : U)
+  : RustM Rust_primitives.Hax.Tuple0
+  := do
+  (pure Rust_primitives.Hax.Tuple0.mk)
+
 class Lean_tests.Associated_types.Multiple_associated_types.Pair.AssociatedTypes
   (Self : Type) where
   First : Type

--- a/tests/lean-tests/src/associated_types.rs
+++ b/tests/lean-tests/src/associated_types.rs
@@ -56,3 +56,16 @@ mod multiple_associated_types {
         pair.first()
     }
 }
+
+mod multiple_projections {
+    trait FnOnce<T> {
+        type Output;
+    }
+
+    pub fn func<T, U, D, F>(d: D, f: F, u: U)
+    where
+        F: FnOnce<T, Output = U>,
+        D: FnOnce<T, Output = U>,
+    {
+    }
+}


### PR DESCRIPTION
The error "Unsupported variant of associated type projection" got triggered when there are multiple parameters with projections on them. So I first apply `filter` first to get rid of unrelated projections and then check if the remaining projections are supported.

[skip changelog]