### PR TITLE
feat(lean): Add support for while loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes to hax-lib:
  - Lean lib: add new setup for `bv_decide` (#1828)
  - Lean lib: base specs on mathematical integers (#1829)
  - Lean lib: represent `usize` via a copy of `UInt64` (#1829)
+ - Lean lib: Add support for while loops (#1857)
 
 Changes to the Lean backend:
  - Support for constants with arbitrary computation (#1738)

--- a/hax-lib/proof-libs/lean/Hax/Integers/Spec.lean
+++ b/hax-lib/proof-libs/lean/Hax/Integers/Spec.lean
@@ -26,7 +26,7 @@ macro "declare_Hax_int_ops_spec" s:(&"signed" <|> &"unsigned") typeName:ident wi
   let minValue := mkIdent (typeName.getId ++ `minValue)
   let grind : TSyntax `tactic ←
     if signed then `(tactic| grind)
-    else `(tactic| grind [toNat_add_of_lt, toNat_sub_of_lt, toNat_mul_of_lt])
+    else `(tactic| grind [toNat_add_of_lt, toNat_sub_of_le', toNat_mul_of_lt])
 
   let mut cmds ← Syntax.getArgs <$> `(
     namespace $typeName

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Basic.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Basic.lean
@@ -7,7 +7,7 @@ macro "additional_uint_decls" typeName:ident width:term : command => do
     theorem toNat_add_of_lt {x y : $typeName} (h : x.toNat + y.toNat < 2 ^ $width) :
         (x + y).toNat = x.toNat + y.toNat := BitVec.toNat_add_of_lt h
 
-    theorem toNat_sub_of_lt {x y : $typeName} (h : y.toNat ≤ x.toNat) :
+    theorem toNat_sub_of_le' {x y : $typeName} (h : y.toNat ≤ x.toNat) :
         (x - y).toNat = x.toNat - y.toNat := BitVec.toNat_sub_of_le h
 
     theorem toNat_mul_of_lt {x y : $typeName} (h : x.toNat * y.toNat < 2 ^ $width) :

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Init/While.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Init/While.lean
@@ -1,0 +1,50 @@
+import Std.Do
+
+namespace Lean
+
+open Order
+open Std.Do
+
+universe u v
+
+/-- Runs one iteration of a loop and continues with `l`. -/
+def Loop.loopCombinator {β : Type u} {m : Type u → Type v} [Monad m]
+    (f : Unit → β → m (ForInStep β)) (l : β → m β) (b : β) := do
+  match ← f () b with
+    | ForInStep.done b => pure b
+    | ForInStep.yield b => l b
+
+/-- A monad function must implement this type class to be able to use loops based on
+`partial_fixpoint`. -/
+class Loop.MonoLoopCombinator
+    {β : Type u} {m : Type u → Type v} [Monad m] [∀ α, CCPO (m α)]
+    (f : Unit → β → m (ForInStep β)) where
+  mono : monotone (loopCombinator f) := by unfold Lean.Loop.loopCombinator <;> monotonicity
+
+/-- Our own copy of `Loop.forIn` because the original one is `partial` and thus we cannot reason
+about it. -/
+@[inline]
+def Loop.MonoLoopCombinator.forIn {β : Type u} {m : Type u → Type v} [Monad m] [∀ α, CCPO (m α)]
+    (_ : Loop) (init : β) (f : Unit → β → m (ForInStep β)) [MonoLoopCombinator f] :
+    m β :=
+  let rec @[specialize] loop [MonoLoopCombinator f] (b : β) : m β :=
+    loopCombinator f loop b
+  partial_fixpoint monotonicity MonoLoopCombinator.mono
+  loop init
+
+/-- A while loop based on `Loop.MonoLoopCombinator.forIn`. -/
+def Loop.MonoLoopCombinator.while_loop  {m} {ps : PostShape} {β: Type}
+    [Monad m] [∀ α, Order.CCPO (m α)] [WPMonad m ps]
+    (loop : Loop)
+    (cond: β → m Bool)
+    (init : β)
+    (body : β -> m β)
+    [∀ f : Unit → β → m (ForInStep β), Loop.MonoLoopCombinator f] : m β :=
+  Loop.MonoLoopCombinator.forIn loop init fun () s => do
+    if ← cond s then
+      let s ← body s
+      pure (.yield s)
+    else
+      pure (.done s)
+
+end Lean

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Std/Do/PostCond.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Std/Do/PostCond.lean
@@ -1,0 +1,11 @@
+import Std.Do.PostCond
+
+namespace Std.Do
+universe u
+variable {ps : PostShape.{u}} {α σ ε : Type u}
+
+theorem PostCond.entails.of_left_entails
+    {p q : α → Assertion ps} {x : ExceptConds ps}  (h : ∀ a, p a ⊢ₛ q a) :
+    (p, x) ⊢ₚ (q, x) := by simp [h]
+
+end Std.Do

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Std/Do/Triple/SpecLemmas.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Std/Do/Triple/SpecLemmas.lean
@@ -1,0 +1,64 @@
+import Std.Do.Triple.Basic
+import Hax.MissingLean.Init.While
+import Hax.MissingLean.Std.Do.PostCond
+
+namespace Std.Do
+open Lean
+
+@[spec]
+theorem Spec.forIn_monoLoopCombinator {m} {ps : PostShape} {β: Type}
+    [Monad m] [∀ α, Order.CCPO (m α)] [WPMonad m ps]
+    (loop : Loop)
+    (init : β)
+    (f : Unit → β → m (ForInStep β)) [Loop.MonoLoopCombinator f]
+    (inv : PostCond β ps)
+    (termination : β -> Nat)
+    (step : ∀ b,
+      ⦃inv.1 b⦄
+        f () b
+      ⦃(fun r => match r with
+        | .yield b' => spred(⌜ termination b' < termination b ⌝ ∧ inv.1 b')
+        | .done b' => inv.1 b', inv.2)⦄) :
+    ⦃inv.1 init⦄ Loop.MonoLoopCombinator.forIn loop init f ⦃(fun b => inv.1 b, inv.2)⦄ := by
+  unfold Loop.MonoLoopCombinator.forIn Loop.MonoLoopCombinator.forIn.loop Loop.loopCombinator
+  apply Triple.bind
+  · apply step
+  · rintro (b | b)
+    · refine Triple.pure b ?_
+      exact SPred.entails.refl (inv.fst b)
+    · apply SPred.imp_elim
+      apply SPred.pure_elim'
+      intro h
+      rw [SPred.entails_true_intro]
+      apply Spec.forIn_monoLoopCombinator loop _ f inv termination step
+termination_by termination init
+decreasing_by exact h
+
+@[spec]
+theorem Spec.MonoLoopCombinator.while_loop {m} {ps : PostShape} {β: Type}
+    [Monad m] [∀ α, Order.CCPO (m α)] [WPMonad m ps]
+    [∀ f : Unit → β → m (ForInStep β), Loop.MonoLoopCombinator f]
+    (init : β)
+    (loop : Loop)
+    (cond: β → m Bool)
+    (body : β → m β)
+    (inv: β → Prop)
+    (termination : β → Nat)
+    (step :
+      ∀ (b : β),
+        ⦃⌜ inv b ⌝⦄
+          do
+            if ← cond b
+            then return ForInStep.yield (← body b)
+            else return ForInStep.done b
+        ⦃(fun r =>
+          match r with
+          | ForInStep.yield b' => spred(⌜ termination b' < termination b ⌝ ∧ ⌜ inv b' ⌝)
+          | ForInStep.done b' => ⌜ inv b' ⌝,
+          ExceptConds.false)⦄ ) :
+    ⦃⌜ inv init ⌝⦄
+      Loop.MonoLoopCombinator.while_loop loop cond init body
+    ⦃⇓ b => ⌜ inv b ⌝⦄ := by
+  apply Spec.forIn_monoLoopCombinator
+    (inv := (fun b => ⌜ inv b ⌝ , ExceptConds.false))
+    (step := step)

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -1061,6 +1061,65 @@ def Lean_tests.Loops.Errors.loop4
     | (Core.Ops.Control_flow.ControlFlow.Continue e)
       => (pure (Core.Result.Result.Ok (Rust_primitives.Hax.Tuple2.mk e e)))
 
+def Lean_tests.Loops.loop1 (_ : Rust_primitives.Hax.Tuple0) : RustM u32 := do
+  let x : u32 := (0 : u32);
+  let x : u32 ←
+    (Rust_primitives.Hax.Folds.fold_range
+      (1 : u32)
+      (10 : u32)
+      (fun x _ => (do (pure true) : RustM Bool))
+      x
+      (fun x i => (do (x +? i) : RustM u32)));
+  (pure x)
+
+def Lean_tests.Loops.loop2 (_ : Rust_primitives.Hax.Tuple0) : RustM u32 := do
+  let x : u32 := (0 : u32);
+  match
+    (← (Rust_primitives.Hax.Folds.fold_range_return
+      (1 : u32)
+      (10 : u32)
+      (fun x _ => (do (pure true) : RustM Bool))
+      x
+      (fun x i => (do
+        if (← (Rust_primitives.Hax.Machine_int.eq i (5 : u32))) then
+          (pure (Core.Ops.Control_flow.ControlFlow.Break
+            (Core.Ops.Control_flow.ControlFlow.Break x)))
+        else
+          (pure (Core.Ops.Control_flow.ControlFlow.Continue (← (x +? i)))) :
+        RustM
+        (Core.Ops.Control_flow.ControlFlow
+          (Core.Ops.Control_flow.ControlFlow
+            u32
+            (Rust_primitives.Hax.Tuple2 Rust_primitives.Hax.Tuple0 u32))
+          u32)))))
+  with
+    | (Core.Ops.Control_flow.ControlFlow.Break ret) => (pure ret)
+    | (Core.Ops.Control_flow.ControlFlow.Continue x) => (pure x)
+
+def Lean_tests.Loops.while_loop1 (s : u32) : RustM u32 := do
+  let x : u32 := s;
+  let x : u32 ←
+    (Rust_primitives.Hax.while_loop
+      (fun x => (do (pure true) : RustM Bool))
+      (fun x => (do
+        (Rust_primitives.Hax.Machine_int.gt x (0 : u32)) : RustM Bool))
+      (fun x => (do
+        (Rust_primitives.Hax.Int.from_machine x) : RustM Hax_lib.Int.Int))
+      x
+      (fun x => (do let x : u32 ← (x -? (1 : u32)); (pure x) : RustM u32)));
+  (pure x)
+
+@[spec]
+def Lean_tests.Loops.while_loop1.spec (s : u32)  :
+    Spec
+      (requires := pure True)
+      (ensures := fun r => (pure true))
+      (Lean_tests.Loops.while_loop1 (s : u32) ) := {
+  pureRequires := by constructor; mvcgen <;> try grind
+  pureEnsures := by constructor; intros; mvcgen <;> try grind
+  contract := by mvcgen[Lean_tests.Loops.while_loop1] <;> try grind
+}
+
 def Lean_tests.Floats.N : f32 := RustM.of_isOk (do (pure (1.0 : f32))) (by rfl)
 
 def Lean_tests.Floats.test
@@ -1620,41 +1679,6 @@ def Lean_tests.Matching.test_binding_subpattern_matching
         ((← ((← (a +? b)) +? (Rust_primitives.Hax.Tuple2._0 pair)))
           +? (Rust_primitives.Hax.Tuple2._1 pair))
     | _ => (pure (0 : u8))
-
-def Lean_tests.Loops.loop1 (_ : Rust_primitives.Hax.Tuple0) : RustM u32 := do
-  let x : u32 := (0 : u32);
-  let x : u32 ←
-    (Rust_primitives.Hax.Folds.fold_range
-      (1 : u32)
-      (10 : u32)
-      (fun x _ => (do (pure true) : RustM Bool))
-      x
-      (fun x i => (do (x +? i) : RustM u32)));
-  (pure x)
-
-def Lean_tests.Loops.loop2 (_ : Rust_primitives.Hax.Tuple0) : RustM u32 := do
-  let x : u32 := (0 : u32);
-  match
-    (← (Rust_primitives.Hax.Folds.fold_range_return
-      (1 : u32)
-      (10 : u32)
-      (fun x _ => (do (pure true) : RustM Bool))
-      x
-      (fun x i => (do
-        if (← (Rust_primitives.Hax.Machine_int.eq i (5 : u32))) then
-          (pure (Core.Ops.Control_flow.ControlFlow.Break
-            (Core.Ops.Control_flow.ControlFlow.Break x)))
-        else
-          (pure (Core.Ops.Control_flow.ControlFlow.Continue (← (x +? i)))) :
-        RustM
-        (Core.Ops.Control_flow.ControlFlow
-          (Core.Ops.Control_flow.ControlFlow
-            u32
-            (Rust_primitives.Hax.Tuple2 Rust_primitives.Hax.Tuple0 u32))
-          u32)))))
-  with
-    | (Core.Ops.Control_flow.ControlFlow.Break ret) => (pure ret)
-    | (Core.Ops.Control_flow.ControlFlow.Continue x) => (pure x)
 
 def Lean_tests.Ite.test1 (_ : Rust_primitives.Hax.Tuple0) : RustM i32 := do
   let x : i32 ← if true then (pure (0 : i32)) else (pure (1 : i32));

--- a/tests/lean-tests/src/loops.rs
+++ b/tests/lean-tests/src/loops.rs
@@ -23,6 +23,16 @@ fn loop2() -> u32 {
     x
 }
 
+#[hax_lib::ensures(|r| true)]
+fn while_loop1(s: u32) -> u32 {
+    let mut x: u32 = s;
+    while x > 0 {
+        hax_lib::loop_decreases!(x);
+        x = x - 1;
+    }
+    x
+}
+
 mod errors {
     enum Error {
         Foo,


### PR DESCRIPTION
This PR adds support for simple while loops. Panic freedom of the loop in the test gets verified fully automatically.

Future work:
* support while loops with returns and continues
* implement a better default tactic to prove invariant and termination measure being pure
* add an attribute to allow the user to replace this default tactic