### PR TITLE
feat(rengine): move escaping into RenderView

### DIFF
--- a/hax-lib/proof-libs/lean/Hax/Lib.lean
+++ b/hax-lib/proof-libs/lean/Hax/Lib.lean
@@ -546,7 +546,7 @@ section Cast
 
 /-- Hax-introduced explicit cast. It is partial (returns a `RustM`) -/
 @[simp, spec, hax_bv_decide]
-def Core.Convert.From.from (β α) [Coe α (RustM β)] (x:α) : (RustM β) := x
+def Core.Convert.From._from (β α) [Coe α (RustM β)] (x:α) : (RustM β) := x
 
 /-- Rust-supported casts on base types -/
 class Cast (α β: Type) where


### PR DESCRIPTION
This PR moves the logic for name escaping into `RenderView` to be reusable by other backends. This is a step towards #1630.

Fixes #1853

[skip changelog]