### PR TITLE
[Lean] add Core_models.Slice.Impl.is_empty

### DIFF
--- a/hax-lib/proof-libs/lean/Hax/Lib.lean
+++ b/hax-lib/proof-libs/lean/Hax/Lib.lean
@@ -860,6 +860,10 @@ def Rust_primitives.unsize {α n} (a: Vector α n) : RustM (Array α) :=
 @[simp, spec]
 def Core_models.Slice.Impl.len α (a: Array α) : RustM usize := pure a.size
 
+def Core_models.Slice.Impl.is_empty α (a : Array α) : RustM Bool := do
+  let n ← Core_models.Slice.Impl.len α a
+  pure (n == 0)
+
 /-
 
 # Vectors


### PR DESCRIPTION
A small PR to address issue [#1881](https://github.com/cryspen/hax/issues/1881):

### Pull Request Summary

**Changes**

    Added Core_models.Slice.Impl.is_empty

**Files Modified**

    hax-lib/proof-libs/lean/Hax/Lib.lean

Fixes #1881

[skip changelog]