### PR TITLE
Various core models fixes.

### DIFF
--- a/hax-lib/core-models/rust_primitives/src/lib.rs
+++ b/hax-lib/core-models/rust_primitives/src/lib.rs
@@ -183,12 +183,13 @@ pub mod arithmetic {
         }
     }
 
-    // Dummy values, to be defined by backends
-    pub const SIZE_BYTES: usize = 0;
-    pub const SIZE_BITS: u32 = 0;
-    pub const USIZE_MAX: usize = 0;
-    pub const ISIZE_MAX: isize = 0;
-    pub const ISIZE_MIN: isize = 0;
+    // Rust inlines these values, for now we model usize by u64
+    // eventually we could try to define in the backend as 32 or 64
+    pub const SIZE_BYTES: usize = 8;
+    pub const SIZE_BITS: u32 = 64;
+    pub const USIZE_MAX: usize = u64::MAX as usize;
+    pub const ISIZE_MAX: isize = i64::MAX as isize;
+    pub const ISIZE_MIN: isize = i64::MIN as isize;
 
     arithmetic_ops! {
         types: u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize,

--- a/hax-lib/core-models/src/core/convert.rs
+++ b/hax-lib/core-models/src/core/convert.rs
@@ -69,7 +69,9 @@ impl<T> From<T> for T {
     }
 }
 
+#[hax_lib::attributes]
 trait AsRef<T> {
+    #[hax_lib::requires(true)]
     fn as_ref(self) -> T;
 }
 
@@ -119,21 +121,21 @@ macro_rules! int_try_from {
 }
 
 int_from! {
-    u8  u8  u16 u8  u16 u32 usize u8   u16  u32  u64  usize u8    u16   u32,
-    u16 u32 u32 u64 u64 u64 u64   u128 u128 u128 u128 u128  usize usize usize,
+    u8  u8  u16 u8  u16 u32 u8   u16  u32  u64  usize u8    u16,
+    u16 u32 u32 u64 u64 u64 u128 u128 u128 u128 u128  usize usize,
 }
 
 int_from! {
-    i8  i8  i16 i8  i16 i32 isize i8   i16  i32  i64  isize i8    i16   i32,
-    i16 i32 i32 i64 i64 i64 i64   i128 i128 i128 i128 i128  isize isize isize,
+    i8  i8  i16 i8  i16 i32 i8   i16  i32  i64  isize i8    i16,
+    i16 i32 i32 i64 i64 i64 i128 i128 i128 i128 i128  isize isize,
 }
 
 int_try_from! {
-    u16 u32 u32 u64 u64 u64 u64   u128 u128 u128 u128 u128  usize usize usize,
-    u8  u8  u16 u8  u16 u32 usize u8   u16  u32  u64  usize u8    u16   u32,
+    u16 u32 u32 u32   u64 u64 u64 u64   u128 u128 u128 u128 u128  usize usize usize usize,
+    u8  u8  u16 usize u8  u16 u32 usize u8   u16  u32  u64  usize u8    u16   u32   u64,
 }
 
 int_try_from! {
-    i16 i32 i32 i64 i64 i64 i64   i128 i128 i128 i128 i128  isize isize isize,
-    i8  i8  i16 i8  i16 i32 isize i8   i16  i32  i64  isize i8    i16   i32,
+    i16 i32 i32 i32   i64 i64 i64 i64   i128 i128 i128 i128 i128  isize isize isize isize,
+    i8  i8  i16 isize i8  i16 i32 isize i8   i16  i32  i64  isize i8    i16   i32   i64,
 }

--- a/hax-lib/core-models/src/core/iter.rs
+++ b/hax-lib/core-models/src/core/iter.rs
@@ -118,7 +118,9 @@ pub mod traits {
             type IntoIter; //: Iterator<Item = Self::Item>
             fn into_iter(self) -> Self::IntoIter;
         }
+        #[hax_lib::attributes]
         pub trait FromIterator<A>: Sized {
+            #[hax_lib::requires(true)]
             fn from_iter<T: IntoIterator>(iter: T) -> Self;
         }
     }

--- a/hax-lib/core-models/src/core/result.rs
+++ b/hax-lib/core-models/src/core/result.rs
@@ -16,6 +16,12 @@ impl<T, E> Result<T, E> {
             Err(_) => super::panicking::internal::panic(),
         }
     }
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Ok(t) => t,
+            Err(_) => default,
+        }
+    }
     #[hax_lib::requires(self.is_ok())]
     pub fn expect(self, _msg: &str) -> T {
         match self {

--- a/hax-lib/core-models/std/src/lib.rs
+++ b/hax-lib/core-models/std/src/lib.rs
@@ -43,8 +43,11 @@ pub mod hash {
 }
 
 mod io {
+    #[hax_lib::attributes]
     pub trait Read {
         // Required method
+        #[hax_lib::requires(true)]
+        #[hax_lib::ensures(|_| future(buf).len() == buf.len())]
         fn read(&mut self, buf: &mut [u8]) -> Result<usize, error::Error>;
 
         // Provided methods (not provided in this model as hax doesn't support default methods)
@@ -52,6 +55,8 @@ mod io {
         fn is_read_vectored(&self) -> bool;
         fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize>;
         fn read_to_string(&mut self, buf: &mut String) -> Result<usize>; */
+        #[hax_lib::requires(true)]
+        #[hax_lib::ensures(|_| future(buf).len() == buf.len())]
         fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), error::Error>;
         /* fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> Result<()>;
         fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_>) -> Result<()>;
@@ -64,14 +69,18 @@ mod io {
         fn take(self, limit: u64) -> Take<Self>
         where Self: Sized; */
     }
+    #[hax_lib::attributes]
     pub trait Write {
         // Required methods
+        #[hax_lib::requires(true)]
         fn write(&mut self, buf: &[u8]) -> Result<usize, error::Error>;
+        #[hax_lib::requires(true)]
         fn flush(&mut self) -> Result<(), error::Error>;
 
         // Provided methods (not provided in this model as hax doesn't support default methods)
         /* fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize>;
         fn is_write_vectored(&self) -> bool; */
+        #[hax_lib::requires(true)]
         fn write_all(&mut self, buf: &[u8]) -> Result<(), error::Error>;
         /* fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> Result<()>;
         fn write_fmt(&mut self, args: Arguments<'_>) -> Result<()>;

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -202,6 +202,11 @@ let impl__ok_or_else
     <:
     t_Result v_T v_E
 
+let impl__unwrap_or__from__result (#v_T #v_E: Type0) (self: t_Result v_T v_E) (v_default: v_T) : v_T =
+  match self <: t_Result v_T v_E with
+  | Result_Ok t -> t
+  | Result_Err _ -> v_default
+
 let impl__map__from__result
       (#v_T #v_E #v_U #v_F: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core_models.Ops.Function.t_FnOnce v_F v_T)

--- a/hax-lib/proof-libs/fstar/core/Core_models.Convert.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Convert.fst
@@ -35,7 +35,7 @@ let impl_4 (#v_T: Type0) : t_From v_T v_T =
   }
 
 class t_AsRef (v_Self: Type0) (v_T: Type0) = {
-  f_as_ref_pre:v_Self -> Type0;
+  f_as_ref_pre:self_: v_Self -> pred: Type0{true ==> pred};
   f_as_ref_post:v_Self -> v_T -> Type0;
   f_as_ref:x0: v_Self -> Prims.Pure v_T (f_as_ref_pre x0) (fun result -> f_as_ref_post x0 result)
 }
@@ -97,15 +97,7 @@ let impl_11: t_From u64 u32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_12: t_From u64 usize =
-  {
-    f_from_pre = (fun (x: usize) -> true);
-    f_from_post = (fun (x: usize) (out: u64) -> true);
-    f_from = fun (x: usize) -> cast (x <: usize) <: u64
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_13: t_From u128 u8 =
+let impl_12: t_From u128 u8 =
   {
     f_from_pre = (fun (x: u8) -> true);
     f_from_post = (fun (x: u8) (out: u128) -> true);
@@ -113,7 +105,7 @@ let impl_13: t_From u128 u8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_14: t_From u128 u16 =
+let impl_13: t_From u128 u16 =
   {
     f_from_pre = (fun (x: u16) -> true);
     f_from_post = (fun (x: u16) (out: u128) -> true);
@@ -121,7 +113,7 @@ let impl_14: t_From u128 u16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_15: t_From u128 u32 =
+let impl_14: t_From u128 u32 =
   {
     f_from_pre = (fun (x: u32) -> true);
     f_from_post = (fun (x: u32) (out: u128) -> true);
@@ -129,7 +121,7 @@ let impl_15: t_From u128 u32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_16: t_From u128 u64 =
+let impl_15: t_From u128 u64 =
   {
     f_from_pre = (fun (x: u64) -> true);
     f_from_post = (fun (x: u64) (out: u128) -> true);
@@ -137,7 +129,7 @@ let impl_16: t_From u128 u64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_17: t_From u128 usize =
+let impl_16: t_From u128 usize =
   {
     f_from_pre = (fun (x: usize) -> true);
     f_from_post = (fun (x: usize) (out: u128) -> true);
@@ -145,7 +137,7 @@ let impl_17: t_From u128 usize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_18: t_From usize u8 =
+let impl_17: t_From usize u8 =
   {
     f_from_pre = (fun (x: u8) -> true);
     f_from_post = (fun (x: u8) (out: usize) -> true);
@@ -153,7 +145,7 @@ let impl_18: t_From usize u8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_19: t_From usize u16 =
+let impl_18: t_From usize u16 =
   {
     f_from_pre = (fun (x: u16) -> true);
     f_from_post = (fun (x: u16) (out: usize) -> true);
@@ -161,15 +153,7 @@ let impl_19: t_From usize u16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_20: t_From usize u32 =
-  {
-    f_from_pre = (fun (x: u32) -> true);
-    f_from_post = (fun (x: u32) (out: usize) -> true);
-    f_from = fun (x: u32) -> cast (x <: u32) <: usize
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_21: t_From i16 i8 =
+let impl_19: t_From i16 i8 =
   {
     f_from_pre = (fun (x: i8) -> true);
     f_from_post = (fun (x: i8) (out: i16) -> true);
@@ -177,7 +161,7 @@ let impl_21: t_From i16 i8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_22: t_From i32 i8 =
+let impl_20: t_From i32 i8 =
   {
     f_from_pre = (fun (x: i8) -> true);
     f_from_post = (fun (x: i8) (out: i32) -> true);
@@ -185,7 +169,7 @@ let impl_22: t_From i32 i8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_23: t_From i32 i16 =
+let impl_21: t_From i32 i16 =
   {
     f_from_pre = (fun (x: i16) -> true);
     f_from_post = (fun (x: i16) (out: i32) -> true);
@@ -193,7 +177,7 @@ let impl_23: t_From i32 i16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_24: t_From i64 i8 =
+let impl_22: t_From i64 i8 =
   {
     f_from_pre = (fun (x: i8) -> true);
     f_from_post = (fun (x: i8) (out: i64) -> true);
@@ -201,7 +185,7 @@ let impl_24: t_From i64 i8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_25: t_From i64 i16 =
+let impl_23: t_From i64 i16 =
   {
     f_from_pre = (fun (x: i16) -> true);
     f_from_post = (fun (x: i16) (out: i64) -> true);
@@ -209,7 +193,7 @@ let impl_25: t_From i64 i16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_26: t_From i64 i32 =
+let impl_24: t_From i64 i32 =
   {
     f_from_pre = (fun (x: i32) -> true);
     f_from_post = (fun (x: i32) (out: i64) -> true);
@@ -217,15 +201,7 @@ let impl_26: t_From i64 i32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_27: t_From i64 isize =
-  {
-    f_from_pre = (fun (x: isize) -> true);
-    f_from_post = (fun (x: isize) (out: i64) -> true);
-    f_from = fun (x: isize) -> cast (x <: isize) <: i64
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_28: t_From i128 i8 =
+let impl_25: t_From i128 i8 =
   {
     f_from_pre = (fun (x: i8) -> true);
     f_from_post = (fun (x: i8) (out: i128) -> true);
@@ -233,7 +209,7 @@ let impl_28: t_From i128 i8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_29: t_From i128 i16 =
+let impl_26: t_From i128 i16 =
   {
     f_from_pre = (fun (x: i16) -> true);
     f_from_post = (fun (x: i16) (out: i128) -> true);
@@ -241,7 +217,7 @@ let impl_29: t_From i128 i16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_30: t_From i128 i32 =
+let impl_27: t_From i128 i32 =
   {
     f_from_pre = (fun (x: i32) -> true);
     f_from_post = (fun (x: i32) (out: i128) -> true);
@@ -249,7 +225,7 @@ let impl_30: t_From i128 i32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_31: t_From i128 i64 =
+let impl_28: t_From i128 i64 =
   {
     f_from_pre = (fun (x: i64) -> true);
     f_from_post = (fun (x: i64) (out: i128) -> true);
@@ -257,7 +233,7 @@ let impl_31: t_From i128 i64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_32: t_From i128 isize =
+let impl_29: t_From i128 isize =
   {
     f_from_pre = (fun (x: isize) -> true);
     f_from_post = (fun (x: isize) (out: i128) -> true);
@@ -265,7 +241,7 @@ let impl_32: t_From i128 isize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_33: t_From isize i8 =
+let impl_30: t_From isize i8 =
   {
     f_from_pre = (fun (x: i8) -> true);
     f_from_post = (fun (x: i8) (out: isize) -> true);
@@ -273,19 +249,11 @@ let impl_33: t_From isize i8 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_34: t_From isize i16 =
+let impl_31: t_From isize i16 =
   {
     f_from_pre = (fun (x: i16) -> true);
     f_from_post = (fun (x: i16) (out: isize) -> true);
     f_from = fun (x: i16) -> cast (x <: i16) <: isize
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_35: t_From isize i32 =
-  {
-    f_from_pre = (fun (x: i32) -> true);
-    f_from_post = (fun (x: i32) (out: isize) -> true);
-    f_from = fun (x: i32) -> cast (x <: i32) <: isize
   }
 
 class t_TryInto (v_Self: Type0) (v_T: Type0) = {
@@ -371,7 +339,7 @@ let impl_3 (#v_T #v_U: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: t_T
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_36: t_TryFrom u8 u16 =
+let impl_32: t_TryFrom u8 u16 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u16) -> true);
@@ -399,7 +367,7 @@ let impl_36: t_TryFrom u8 u16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_37: t_TryFrom u8 u32 =
+let impl_33: t_TryFrom u8 u32 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u32) -> true);
@@ -427,7 +395,7 @@ let impl_37: t_TryFrom u8 u32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_38: t_TryFrom u16 u32 =
+let impl_34: t_TryFrom u16 u32 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u32) -> true);
@@ -455,7 +423,38 @@ let impl_38: t_TryFrom u16 u32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_39: t_TryFrom u8 u64 =
+let impl_35: t_TryFrom usize u32 =
+  {
+    f_Error = Core_models.Num.Error.t_TryFromIntError;
+    f_try_from_pre = (fun (x: u32) -> true);
+    f_try_from_post
+    =
+    (fun
+        (x: u32)
+        (out: Core_models.Result.t_Result usize Core_models.Num.Error.t_TryFromIntError)
+        ->
+        true);
+    f_try_from
+    =
+    fun (x: u32) ->
+      if
+        x >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u32) ||
+        x <. (cast (Core_models.Num.impl_usize__MIN <: usize) <: u32)
+      then
+        Core_models.Result.Result_Err
+        (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
+          <:
+          Core_models.Num.Error.t_TryFromIntError)
+        <:
+        Core_models.Result.t_Result usize Core_models.Num.Error.t_TryFromIntError
+      else
+        Core_models.Result.Result_Ok (cast (x <: u32) <: usize)
+        <:
+        Core_models.Result.t_Result usize Core_models.Num.Error.t_TryFromIntError
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_36: t_TryFrom u8 u64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u64) -> true);
@@ -483,7 +482,7 @@ let impl_39: t_TryFrom u8 u64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_40: t_TryFrom u16 u64 =
+let impl_37: t_TryFrom u16 u64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u64) -> true);
@@ -511,7 +510,7 @@ let impl_40: t_TryFrom u16 u64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_41: t_TryFrom u32 u64 =
+let impl_38: t_TryFrom u32 u64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u64) -> true);
@@ -539,7 +538,7 @@ let impl_41: t_TryFrom u32 u64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_42: t_TryFrom usize u64 =
+let impl_39: t_TryFrom usize u64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u64) -> true);
@@ -570,7 +569,7 @@ let impl_42: t_TryFrom usize u64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_43: t_TryFrom u8 u128 =
+let impl_40: t_TryFrom u8 u128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u128) -> true);
@@ -598,7 +597,7 @@ let impl_43: t_TryFrom u8 u128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_44: t_TryFrom u16 u128 =
+let impl_41: t_TryFrom u16 u128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u128) -> true);
@@ -626,7 +625,7 @@ let impl_44: t_TryFrom u16 u128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_45: t_TryFrom u32 u128 =
+let impl_42: t_TryFrom u32 u128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u128) -> true);
@@ -654,7 +653,7 @@ let impl_45: t_TryFrom u32 u128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_46: t_TryFrom u64 u128 =
+let impl_43: t_TryFrom u64 u128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u128) -> true);
@@ -682,7 +681,7 @@ let impl_46: t_TryFrom u64 u128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_47: t_TryFrom usize u128 =
+let impl_44: t_TryFrom usize u128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: u128) -> true);
@@ -713,7 +712,7 @@ let impl_47: t_TryFrom usize u128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_48: t_TryFrom u8 usize =
+let impl_45: t_TryFrom u8 usize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: usize) -> true);
@@ -741,7 +740,7 @@ let impl_48: t_TryFrom u8 usize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_49: t_TryFrom u16 usize =
+let impl_46: t_TryFrom u16 usize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: usize) -> true);
@@ -772,7 +771,7 @@ let impl_49: t_TryFrom u16 usize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_50: t_TryFrom u32 usize =
+let impl_47: t_TryFrom u32 usize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: usize) -> true);
@@ -803,7 +802,38 @@ let impl_50: t_TryFrom u32 usize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_51: t_TryFrom i8 i16 =
+let impl_48: t_TryFrom u64 usize =
+  {
+    f_Error = Core_models.Num.Error.t_TryFromIntError;
+    f_try_from_pre = (fun (x: usize) -> true);
+    f_try_from_post
+    =
+    (fun
+        (x: usize)
+        (out: Core_models.Result.t_Result u64 Core_models.Num.Error.t_TryFromIntError)
+        ->
+        true);
+    f_try_from
+    =
+    fun (x: usize) ->
+      if
+        x >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: usize) ||
+        x <. (cast (Core_models.Num.impl_u64__MIN <: u64) <: usize)
+      then
+        Core_models.Result.Result_Err
+        (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
+          <:
+          Core_models.Num.Error.t_TryFromIntError)
+        <:
+        Core_models.Result.t_Result u64 Core_models.Num.Error.t_TryFromIntError
+      else
+        Core_models.Result.Result_Ok (cast (x <: usize) <: u64)
+        <:
+        Core_models.Result.t_Result u64 Core_models.Num.Error.t_TryFromIntError
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_49: t_TryFrom i8 i16 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i16) -> true);
@@ -831,7 +861,7 @@ let impl_51: t_TryFrom i8 i16 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_52: t_TryFrom i8 i32 =
+let impl_50: t_TryFrom i8 i32 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i32) -> true);
@@ -859,7 +889,7 @@ let impl_52: t_TryFrom i8 i32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_53: t_TryFrom i16 i32 =
+let impl_51: t_TryFrom i16 i32 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i32) -> true);
@@ -887,7 +917,38 @@ let impl_53: t_TryFrom i16 i32 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_54: t_TryFrom i8 i64 =
+let impl_52: t_TryFrom isize i32 =
+  {
+    f_Error = Core_models.Num.Error.t_TryFromIntError;
+    f_try_from_pre = (fun (x: i32) -> true);
+    f_try_from_post
+    =
+    (fun
+        (x: i32)
+        (out: Core_models.Result.t_Result isize Core_models.Num.Error.t_TryFromIntError)
+        ->
+        true);
+    f_try_from
+    =
+    fun (x: i32) ->
+      if
+        x >. (cast (Core_models.Num.impl_isize__MAX <: isize) <: i32) ||
+        x <. (cast (Core_models.Num.impl_isize__MIN <: isize) <: i32)
+      then
+        Core_models.Result.Result_Err
+        (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
+          <:
+          Core_models.Num.Error.t_TryFromIntError)
+        <:
+        Core_models.Result.t_Result isize Core_models.Num.Error.t_TryFromIntError
+      else
+        Core_models.Result.Result_Ok (cast (x <: i32) <: isize)
+        <:
+        Core_models.Result.t_Result isize Core_models.Num.Error.t_TryFromIntError
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_53: t_TryFrom i8 i64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i64) -> true);
@@ -915,7 +976,7 @@ let impl_54: t_TryFrom i8 i64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_55: t_TryFrom i16 i64 =
+let impl_54: t_TryFrom i16 i64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i64) -> true);
@@ -943,7 +1004,7 @@ let impl_55: t_TryFrom i16 i64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_56: t_TryFrom i32 i64 =
+let impl_55: t_TryFrom i32 i64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i64) -> true);
@@ -971,7 +1032,7 @@ let impl_56: t_TryFrom i32 i64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_57: t_TryFrom isize i64 =
+let impl_56: t_TryFrom isize i64 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i64) -> true);
@@ -1002,7 +1063,7 @@ let impl_57: t_TryFrom isize i64 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_58: t_TryFrom i8 i128 =
+let impl_57: t_TryFrom i8 i128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i128) -> true);
@@ -1030,7 +1091,7 @@ let impl_58: t_TryFrom i8 i128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_59: t_TryFrom i16 i128 =
+let impl_58: t_TryFrom i16 i128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i128) -> true);
@@ -1058,7 +1119,7 @@ let impl_59: t_TryFrom i16 i128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_60: t_TryFrom i32 i128 =
+let impl_59: t_TryFrom i32 i128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i128) -> true);
@@ -1086,7 +1147,7 @@ let impl_60: t_TryFrom i32 i128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_61: t_TryFrom i64 i128 =
+let impl_60: t_TryFrom i64 i128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i128) -> true);
@@ -1114,7 +1175,7 @@ let impl_61: t_TryFrom i64 i128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_62: t_TryFrom isize i128 =
+let impl_61: t_TryFrom isize i128 =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: i128) -> true);
@@ -1145,7 +1206,7 @@ let impl_62: t_TryFrom isize i128 =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_63: t_TryFrom i8 isize =
+let impl_62: t_TryFrom i8 isize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: isize) -> true);
@@ -1173,7 +1234,7 @@ let impl_63: t_TryFrom i8 isize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_64: t_TryFrom i16 isize =
+let impl_63: t_TryFrom i16 isize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: isize) -> true);
@@ -1204,7 +1265,7 @@ let impl_64: t_TryFrom i16 isize =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_65: t_TryFrom i32 isize =
+let impl_64: t_TryFrom i32 isize =
   {
     f_Error = Core_models.Num.Error.t_TryFromIntError;
     f_try_from_pre = (fun (x: isize) -> true);
@@ -1232,4 +1293,35 @@ let impl_65: t_TryFrom i32 isize =
         Core_models.Result.Result_Ok (cast (x <: isize) <: i32)
         <:
         Core_models.Result.t_Result i32 Core_models.Num.Error.t_TryFromIntError
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_65: t_TryFrom i64 isize =
+  {
+    f_Error = Core_models.Num.Error.t_TryFromIntError;
+    f_try_from_pre = (fun (x: isize) -> true);
+    f_try_from_post
+    =
+    (fun
+        (x: isize)
+        (out: Core_models.Result.t_Result i64 Core_models.Num.Error.t_TryFromIntError)
+        ->
+        true);
+    f_try_from
+    =
+    fun (x: isize) ->
+      if
+        x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: isize) ||
+        x <. (cast (Core_models.Num.impl_i64__MIN <: i64) <: isize)
+      then
+        Core_models.Result.Result_Err
+        (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
+          <:
+          Core_models.Num.Error.t_TryFromIntError)
+        <:
+        Core_models.Result.t_Result i64 Core_models.Num.Error.t_TryFromIntError
+      else
+        Core_models.Result.Result_Ok (cast (x <: isize) <: i64)
+        <:
+        Core_models.Result.t_Result i64 Core_models.Num.Error.t_TryFromIntError
   }

--- a/hax-lib/proof-libs/fstar/core/Core_models.Iter.Traits.Collect.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Iter.Traits.Collect.fst
@@ -12,7 +12,8 @@ class t_IntoIterator (v_Self: Type0) = {
 }
 
 class t_FromIterator (v_Self: Type0) (v_A: Type0) = {
-  f_from_iter_pre:#v_T: Type0 -> {| i1: t_IntoIterator v_T |} -> v_T -> Type0;
+  f_from_iter_pre:#v_T: Type0 -> {| i1: t_IntoIterator v_T |} -> iter: v_T
+    -> pred: Type0{true ==> pred};
   f_from_iter_post:#v_T: Type0 -> {| i1: t_IntoIterator v_T |} -> v_T -> v_Self -> Type0;
   f_from_iter:#v_T: Type0 -> {| i1: t_IntoIterator v_T |} -> x0: v_T
     -> Prims.Pure v_Self

--- a/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
@@ -834,25 +834,25 @@ unfold
 let impl_usize__from_str_radix = impl_usize__from_str_radix'
 
 assume
-val impl_usize__from_be_bytes': bytes: t_Array u8 (mk_usize 0) -> usize
+val impl_usize__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
 
 unfold
 let impl_usize__from_be_bytes = impl_usize__from_be_bytes'
 
 assume
-val impl_usize__from_le_bytes': bytes: t_Array u8 (mk_usize 0) -> usize
+val impl_usize__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
 
 unfold
 let impl_usize__from_le_bytes = impl_usize__from_le_bytes'
 
 assume
-val impl_usize__to_be_bytes': bytes: usize -> t_Array u8 (mk_usize 0)
+val impl_usize__to_be_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
 
 unfold
 let impl_usize__to_be_bytes = impl_usize__to_be_bytes'
 
 assume
-val impl_usize__to_le_bytes': bytes: usize -> t_Array u8 (mk_usize 0)
+val impl_usize__to_le_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
 
 unfold
 let impl_usize__to_le_bytes = impl_usize__to_le_bytes'
@@ -1716,25 +1716,25 @@ unfold
 let impl_isize__from_str_radix = impl_isize__from_str_radix'
 
 assume
-val impl_isize__from_be_bytes': bytes: t_Array u8 (mk_usize 0) -> isize
+val impl_isize__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
 
 unfold
 let impl_isize__from_be_bytes = impl_isize__from_be_bytes'
 
 assume
-val impl_isize__from_le_bytes': bytes: t_Array u8 (mk_usize 0) -> isize
+val impl_isize__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
 
 unfold
 let impl_isize__from_le_bytes = impl_isize__from_le_bytes'
 
 assume
-val impl_isize__to_be_bytes': bytes: isize -> t_Array u8 (mk_usize 0)
+val impl_isize__to_be_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
 
 unfold
 let impl_isize__to_be_bytes = impl_isize__to_be_bytes'
 
 assume
-val impl_isize__to_le_bytes': bytes: isize -> t_Array u8 (mk_usize 0)
+val impl_isize__to_le_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
 
 unfold
 let impl_isize__to_le_bytes = impl_isize__to_le_bytes'

--- a/hax-lib/proof-libs/fstar/core/Core_models.Ops.Arith.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Ops.Arith.fsti
@@ -31,6 +31,13 @@ class t_DivAssign (v_Self: Type0) (v_Rhs: Type0) = {
     -> Prims.Pure v_Self (f_div_assign_pre x0 x1) (fun result -> f_div_assign_post x0 x1 result)
 }
 
+class t_RemAssign (v_Self: Type0) (v_Rhs: Type0) = {
+  f_rem_assign_pre:v_Self -> v_Rhs -> Type0;
+  f_rem_assign_post:v_Self -> v_Rhs -> v_Self -> Type0;
+  f_rem_assign:x0: v_Self -> x1: v_Rhs
+    -> Prims.Pure v_Self (f_rem_assign_pre x0 x1) (fun result -> f_rem_assign_post x0 x1 result)
+}
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 val impl:t_AddAssign u8 u8
 
@@ -100,12 +107,4 @@ class t_Rem (v_Self: Type0) (v_Rhs: Type0) = {
   f_rem_post:v_Self -> v_Rhs -> f_Output -> Type0;
   f_rem:x0: v_Self -> x1: v_Rhs
     -> Prims.Pure f_Output (f_rem_pre x0 x1) (fun result -> f_rem_post x0 x1 result)
-}
-
-class t_RemAssign (v_Self: Type0) (v_Rhs: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_Output:Type0;
-  f_rem_assign_pre:v_Self -> v_Rhs -> Type0;
-  f_rem_assign_post:v_Self -> v_Rhs -> f_Output -> Type0;
-  f_rem_assign:x0: v_Self -> x1: v_Rhs
-    -> Prims.Pure f_Output (f_rem_assign_pre x0 x1) (fun result -> f_rem_assign_post x0 x1 result)
 }

--- a/hax-lib/proof-libs/fstar/core/Core_models.Result.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Result.fst
@@ -11,6 +11,8 @@ include Core_models.Bundle {Result_Err as Result_Err}
 
 include Core_models.Bundle {impl__unwrap__from__result as impl__unwrap}
 
+include Core_models.Bundle {impl__unwrap_or__from__result as impl__unwrap_or}
+
 include Core_models.Bundle {impl__expect__from__result as impl__expect}
 
 include Core_models.Bundle {impl__map__from__result as impl__map}

--- a/hax-lib/proof-libs/fstar/core/Std.Io.fsti
+++ b/hax-lib/proof-libs/fstar/core/Std.Io.fsti
@@ -4,22 +4,42 @@ open FStar.Mul
 open Rust_primitives
 
 class t_Read (v_Self: Type0) = {
-  f_read_pre:v_Self -> t_Slice u8 -> Type0;
+  f_read_pre:self_: v_Self -> buf: t_Slice u8 -> pred: Type0{true ==> pred};
   f_read_post:
-      v_Self ->
-      t_Slice u8 ->
-      (v_Self & t_Slice u8 & Core_models.Result.t_Result usize Std.Io.Error.t_Error)
-    -> Type0;
+      self_: v_Self ->
+      buf: t_Slice u8 ->
+      x: (v_Self & t_Slice u8 & Core_models.Result.t_Result usize Std.Io.Error.t_Error)
+    -> pred:
+      Type0
+        { pred ==>
+          (let
+            (self_e_future: v_Self),
+            (buf_future: t_Slice u8),
+            (_: Core_models.Result.t_Result usize Std.Io.Error.t_Error) =
+              x
+            in
+            (Core_models.Slice.impl__len #u8 buf_future <: usize) =.
+            (Core_models.Slice.impl__len #u8 buf <: usize)) };
   f_read:x0: v_Self -> x1: t_Slice u8
     -> Prims.Pure (v_Self & t_Slice u8 & Core_models.Result.t_Result usize Std.Io.Error.t_Error)
         (f_read_pre x0 x1)
         (fun result -> f_read_post x0 x1 result);
-  f_read_exact_pre:v_Self -> t_Slice u8 -> Type0;
+  f_read_exact_pre:self_: v_Self -> buf: t_Slice u8 -> pred: Type0{true ==> pred};
   f_read_exact_post:
-      v_Self ->
-      t_Slice u8 ->
-      (v_Self & t_Slice u8 & Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error)
-    -> Type0;
+      self_: v_Self ->
+      buf: t_Slice u8 ->
+      x: (v_Self & t_Slice u8 & Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error)
+    -> pred:
+      Type0
+        { pred ==>
+          (let
+            (self_e_future: v_Self),
+            (buf_future: t_Slice u8),
+            (_: Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error) =
+              x
+            in
+            (Core_models.Slice.impl__len #u8 buf_future <: usize) =.
+            (Core_models.Slice.impl__len #u8 buf <: usize)) };
   f_read_exact:x0: v_Self -> x1: t_Slice u8
     -> Prims.Pure
         (v_Self & t_Slice u8 & Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error)
@@ -28,7 +48,7 @@ class t_Read (v_Self: Type0) = {
 }
 
 class t_Write (v_Self: Type0) = {
-  f_write_pre:v_Self -> t_Slice u8 -> Type0;
+  f_write_pre:self_: v_Self -> buf: t_Slice u8 -> pred: Type0{true ==> pred};
   f_write_post:
       v_Self ->
       t_Slice u8 ->
@@ -38,14 +58,14 @@ class t_Write (v_Self: Type0) = {
     -> Prims.Pure (v_Self & Core_models.Result.t_Result usize Std.Io.Error.t_Error)
         (f_write_pre x0 x1)
         (fun result -> f_write_post x0 x1 result);
-  f_flush_pre:v_Self -> Type0;
+  f_flush_pre:self_: v_Self -> pred: Type0{true ==> pred};
   f_flush_post:v_Self -> (v_Self & Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error)
     -> Type0;
   f_flush:x0: v_Self
     -> Prims.Pure (v_Self & Core_models.Result.t_Result Prims.unit Std.Io.Error.t_Error)
         (f_flush_pre x0)
         (fun result -> f_flush_post x0 result);
-  f_write_all_pre:v_Self -> t_Slice u8 -> Type0;
+  f_write_all_pre:self_: v_Self -> buf: t_Slice u8 -> pred: Type0{true ==> pred};
   f_write_all_post:
       v_Self ->
       t_Slice u8 ->

--- a/hax-lib/proof-libs/lean/Hax/CoreModels.lean
+++ b/hax-lib/proof-libs/lean/Hax/CoreModels.lean
@@ -883,23 +883,23 @@ opaque Core_models.Num.Impl_11.leading_zeros (x : usize) : RustM u32
 opaque Core_models.Num.Impl_11.ilog2 (x : usize) : RustM u32 
 
 opaque Core_models.Num.Impl_11.from_be_bytes
-  (bytes : (RustArray u8 0))
+  (bytes : (RustArray u8 8))
   : RustM usize
 
 
 opaque Core_models.Num.Impl_11.from_le_bytes
-  (bytes : (RustArray u8 0))
+  (bytes : (RustArray u8 8))
   : RustM usize
 
 
 opaque Core_models.Num.Impl_11.to_be_bytes
   (bytes : usize)
-  : RustM (RustArray u8 0)
+  : RustM (RustArray u8 8)
 
 
 opaque Core_models.Num.Impl_11.to_le_bytes
   (bytes : usize)
-  : RustM (RustArray u8 0)
+  : RustM (RustArray u8 8)
 
 
 @[reducible] instance Core_models.Num.Impl_10.AssociatedTypes :
@@ -1093,23 +1093,23 @@ opaque Core_models.Num.Impl_23.leading_zeros (x : isize) : RustM u32
 opaque Core_models.Num.Impl_23.ilog2 (x : isize) : RustM u32 
 
 opaque Core_models.Num.Impl_23.from_be_bytes
-  (bytes : (RustArray u8 0))
+  (bytes : (RustArray u8 8))
   : RustM isize
 
 
 opaque Core_models.Num.Impl_23.from_le_bytes
-  (bytes : (RustArray u8 0))
+  (bytes : (RustArray u8 8))
   : RustM isize
 
 
 opaque Core_models.Num.Impl_23.to_be_bytes
   (bytes : isize)
-  : RustM (RustArray u8 0)
+  : RustM (RustArray u8 8)
 
 
 opaque Core_models.Num.Impl_23.to_le_bytes
   (bytes : isize)
-  : RustM (RustArray u8 0)
+  : RustM (RustArray u8 8)
 
 
 @[reducible] instance Core_models.Num.Impl_22.AssociatedTypes :
@@ -1162,6 +1162,17 @@ class Core_models.Ops.Arith.DivAssign
       (Self : Type) (Rhs : Type))]
   where
   div_assign (Self Rhs) : (Self -> Rhs -> RustM Self)
+
+class Core_models.Ops.Arith.RemAssign.AssociatedTypes (Self : Type) (Rhs : Type)
+  where
+
+class Core_models.Ops.Arith.RemAssign
+  (Self : Type)
+  (Rhs : Type)
+  [associatedTypes : outParam (Core_models.Ops.Arith.RemAssign.AssociatedTypes
+      (Self : Type) (Rhs : Type))]
+  where
+  rem_assign (Self Rhs) : (Self -> Rhs -> RustM Self)
 
 inductive Core_models.Ops.Control_flow.ControlFlow (B : Type) (C : Type) : Type
 | Continue : C -> Core_models.Ops.Control_flow.ControlFlow
@@ -1938,6 +1949,15 @@ def Core_models.Option.Impl.ok_or
     | (Core_models.Option.Option.None )
       => (pure (Core_models.Result.Result.Err err))
 
+def Core_models.Result.Impl.unwrap_or
+  (T : Type) (E : Type) (self : (Core_models.Result.Result T E))
+  (default : T)
+  : RustM T
+  := do
+  match self with
+    | (Core_models.Result.Result.Ok t) => (pure t)
+    | (Core_models.Result.Result.Err _) => (pure default)
+
 def Core_models.Result.Impl.is_ok
   (T : Type) (E : Type) (self : (Core_models.Result.Result T E))
   : RustM Bool
@@ -2121,23 +2141,6 @@ class Core_models.Ops.Arith.Rem
       Type) (Rhs : Type))]
   where
   rem (Self Rhs) : (Self -> Rhs -> RustM associatedTypes.Output)
-
-class Core_models.Ops.Arith.RemAssign.AssociatedTypes (Self : Type) (Rhs : Type)
-  where
-  Output : Type
-
-attribute [reducible] Core_models.Ops.Arith.RemAssign.AssociatedTypes.Output
-
-abbrev Core_models.Ops.Arith.RemAssign.Output :=
-  Core_models.Ops.Arith.RemAssign.AssociatedTypes.Output
-
-class Core_models.Ops.Arith.RemAssign
-  (Self : Type)
-  (Rhs : Type)
-  [associatedTypes : outParam (Core_models.Ops.Arith.RemAssign.AssociatedTypes
-      (Self : Type) (Rhs : Type))]
-  where
-  rem_assign (Self Rhs) : (Self -> Rhs -> RustM associatedTypes.Output)
 
 class Core_models.Ops.Bit.Shr.AssociatedTypes (Self : Type) (Rhs : Type) where
   Output : Type


### PR DESCRIPTION
Fixes:
- Number of bytes, bits, etc. for usize/isize. Hard-coded to 64 bits for now
- Some conversions between usize/isize and other types that need to be `TryFrom` and not `From`

Adds:
- `unwrap_or` on results
- Some `true` preconditions on various trait methods

[skip changelog]