### PR TITLE
feat(lean): Separate symbolic and bit-blasting specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes to hax-lib:
  - Lean lib: Add casting for all integer type pairs (#1837)
  - Lean lib: bump lean to v4.28.0-rc1 (#1900)
  - Lean lib: Extract more core models (#1919)
+ - Lean lib: Separate symbolic and bit-blasting specs (#1933)
 
 Changes to the Lean backend:
  - Add `hax_zify` and `hax_construct_pure` tactics (#1888)

--- a/examples/lean_chacha20/src/hacspec_helper.rs
+++ b/examples/lean_chacha20/src/hacspec_helper.rs
@@ -1,5 +1,6 @@
 use super::State;
 
+#[hax_lib::lean::before("set_option hax_mvcgen.specset \"int\"")]
 #[hax_lib::lean::after(
     "
 @[spec]
@@ -9,7 +10,7 @@ theorem lean_chacha20.hacspec_helper.to_le_u32s_3.spec bytes :
   (lean_chacha20.hacspec_helper.to_le_u32s_3 bytes)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intros
-  mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_3] <;> try grind
+  hax_mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_3] <;> try grind
 "
 )]
 pub(super) fn to_le_u32s_3(bytes: &[u8]) -> [u32; 3] {
@@ -31,7 +32,7 @@ theorem lean_chacha20.hacspec_helper.to_le_u32s_8_spec (bytes : (Array u8)) :
   ( lean_chacha20.hacspec_helper.to_le_u32s_8 bytes )
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intros
-  mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_8] <;> try grind
+  hax_mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_8] <;> try grind
 "
 )]
 pub(super) fn to_le_u32s_8(bytes: &[u8]) -> [u32; 8] {
@@ -52,7 +53,7 @@ theorem lean_chacha20.hacspec_helper.to_le_u32s_16_spec bytes :
   (lean_chacha20.hacspec_helper.to_le_u32s_16 bytes)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intro
-  mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_16] <;> try grind
+  hax_mvcgen [lean_chacha20.hacspec_helper.to_le_u32s_16] <;> try grind
 "
 )]
 pub(super) fn to_le_u32s_16(bytes: &[u8]) -> [u32; 16] {
@@ -73,7 +74,7 @@ theorem lean_chacha20.hacspec_helper.u32s_to_le_bytes_spec (state : (Vector u32 
   (lean_chacha20.hacspec_helper.u32s_to_le_bytes state)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intros
-  mvcgen [lean_chacha20.hacspec_helper.u32s_to_le_bytes, core_models.num.Impl_8.to_le_bytes]
+  hax_mvcgen [lean_chacha20.hacspec_helper.u32s_to_le_bytes, core_models.num.Impl_8.to_le_bytes]
     <;> try grind
 "
 )]
@@ -97,7 +98,7 @@ theorem lean_chacha20.hacspec_helper.xor_state_spec (state other: (Vector u32 16
   (lean_chacha20.hacspec_helper.xor_state state other)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intros
-  mvcgen [lean_chacha20.hacspec_helper.xor_state, core_models.num.Impl_8.to_le_bytes]
+  hax_mvcgen [lean_chacha20.hacspec_helper.xor_state, core_models.num.Impl_8.to_le_bytes]
     <;> try grind
 "
 )]
@@ -116,7 +117,7 @@ theorem lean_chacha20.hacspec_helper.add_state_spec (state : (Vector u32 16)) (o
   (lean_chacha20.hacspec_helper.add_state state other)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   have := USize.le_size
-  mvcgen [lean_chacha20.hacspec_helper.add_state]
+  hax_mvcgen [lean_chacha20.hacspec_helper.add_state]
   <;> simp [Vector.size] at *
   <;> apply (USize.lt_ofNat_iff _).mp
   <;> omega
@@ -139,7 +140,7 @@ theorem lean_chacha20.hacspec_helper.update_array_spec (a: (Vector u8 64)) (v: A
   (lean_chacha20.hacspec_helper.update_array a v)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
   intros
-  mvcgen [lean_chacha20.hacspec_helper.update_array, hax_lib.assert]
+  hax_mvcgen [lean_chacha20.hacspec_helper.update_array, hax_lib.assert]
     <;> try grind
 "
 )]

--- a/examples/lean_chacha20/src/lib.rs
+++ b/examples/lean_chacha20/src/lib.rs
@@ -10,6 +10,7 @@ type ChaChaKey = [u8; 32];
 
 type StateIdx = hax_bounded_integers::BoundedUsize<0, 15>;
 
+#[hax_lib::lean::before("set_option hax_mvcgen.specset \"int\"")]
 #[hax_lib::lean::after(
     "
 @[spec]
@@ -24,7 +25,7 @@ theorem lean_chacha20.chacha20_line_spec
   ⦃ ⌜ True ⌝ ⦄
   (lean_chacha20.chacha20_line a b d s m )
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄
-  := by intros; mvcgen [lean_chacha20.chacha20_line] <;> omega
+  := by intros; hax_mvcgen [lean_chacha20.chacha20_line] <;> omega
 "
 )]
 fn chacha20_line(a: StateIdx, b: StateIdx, d: StateIdx, s: u32, m: State) -> State {
@@ -48,7 +49,7 @@ theorem lean_chacha20.chacha20_quarter_round_spec a b c d state:
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄
 := by
   intros
-  mvcgen [lean_chacha20.chacha20_quarter_round,
+  hax_mvcgen [lean_chacha20.chacha20_quarter_round,
           lean_chacha20.chacha20_line,
           RustM.ofOption, ]
   <;> try omega
@@ -186,7 +187,7 @@ theorem lean_chacha20.chacha20_encrypt_block_spec (st0 : (Vector u32 16)) (ctr :
   ( lean_chacha20.chacha20_encrypt_block st0 ctr plain)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄
   := by
-  mvcgen [chacha20_encrypt_block,
+  hax_mvcgen [chacha20_encrypt_block,
           chacha20_core,
           chacha20_rounds,
           chacha20_double_round]
@@ -211,7 +212,7 @@ theorem lean_chacha20.chacha20_encrypt_last_spec (st0 : (Vector u32 16)) (ctr : 
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄
 := by
   intros
-  mvcgen [lean_chacha20.chacha20_encrypt_last,
+  hax_mvcgen [lean_chacha20.chacha20_encrypt_last,
           lean_chacha20.chacha20_key_block,
           lean_chacha20.chacha20_init,
           lean_chacha20.chacha20_core,
@@ -237,7 +238,7 @@ theorem lean_chacha20.chacha20_update_spec (st0 : (Vector u32 16)) (m : (Array u
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄ :=
 by
   intros
-  mvcgen [lean_chacha20.chacha20_update,
+  hax_mvcgen [lean_chacha20.chacha20_update,
       alloc.slice.Impl.to_vec,
       core_models.result.Impl.unwrap.spec,
       alloc.vec.Impl.new,
@@ -275,7 +276,7 @@ theorem lean_chacha20.chacha20_spec
   ⦃⌜True⌝⦄
   (lean_chacha20.chacha20 m key iv ctr)
   ⦃ ⇓ _ => ⌜ True ⌝ ⦄
-:= by intros ; mvcgen [lean_chacha20.chacha20, chacha20_init] <;> simp at *
+:= by intros ; hax_mvcgen [lean_chacha20.chacha20, chacha20_init] <;> simp at *
 "
 )]
 pub fn chacha20(m: &[u8], key: &ChaChaKey, iv: &ChaChaIV, ctr: u32) -> Vec<u8> {

--- a/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Folds.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Folds.lean
@@ -1,4 +1,5 @@
 import Hax.Core_models.Extracted
+import Hax.Tactic.SpecSet
 open Std.Do
 
 set_option mvcgen.warning false
@@ -95,7 +96,7 @@ theorem rust_primitives.hax.folds.fold_range_spec {α}
     suffices (s + (e - s)) = e by (rw [← this]; assumption)
     omega
 
-@[spec]
+@[specset int]
 theorem rust_primitives.hax.folds.usize.fold_range_spec {α}
   (s e : usize)
   (inv : α -> usize -> RustM Bool)

--- a/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Integers.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Integers.lean
@@ -33,7 +33,7 @@ macro "declare_Hax_convert_from_instances" : command => do
 
 declare_Hax_convert_from_instances
 
-attribute [hax_bv_decide]
+attribute [specset bv, hax_bv_decide]
   core_models.convert.From._from
 
 namespace core_models.num.Impl_8

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/Cast.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/Cast.lean
@@ -16,7 +16,7 @@ def Core.Convert.From._from (β α) [Coe α (RustM β)] (x:α) : (RustM β) := x
 class Cast (α β: Type) where
   cast : α → RustM β
 
-attribute [hax_bv_decide] Cast.cast
+attribute [specset bv, hax_bv_decide] Cast.cast
 
 -- Macro to generate Cast instances for all integer type pairs.
 open Lean in

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/Index.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/Index.lean
@@ -1,5 +1,6 @@
 import Hax.Rust_primitives.RustM
 import Hax.Rust_primitives.Num
+import Hax.Tactic.SpecSet
 
 open Error
 open Std.Do

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/Num.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/Num.lean
@@ -1,5 +1,6 @@
 import Hax.Rust_primitives.USize64
 import Hax.Tactic.Init
+import Hax.Tactic.SpecSet
 import Hax.Rust_primitives.RustM
 open Std.Do
 open Std.Tactic
@@ -98,22 +99,22 @@ infixl:60 " &&&? " => fun a b => pure (HAnd.hAnd a b)
   are also provided -/
 namespace rust_primitives.hax.machine_int
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def eq {α} (x y: α) [BEq α] : RustM Bool := pure (x == y)
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def ne {α} (x y: α) [BEq α] : RustM Bool := pure (x != y)
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def lt {α} (x y: α) [(LT α)] [Decidable (x < y)] : RustM Bool := pure (x < y)
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def le {α} (x y: α) [(LE α)] [Decidable (x ≤ y)] : RustM Bool := pure (x ≤ y)
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def gt {α} (x y: α) [(LT α)] [Decidable (x > y)] : RustM Bool := pure (x > y)
 
-@[simp, hax_bv_decide]
+@[simp, specset bv, hax_bv_decide]
 def ge {α} (x y: α) [(LE α)] [Decidable (x ≥ y)] : RustM Bool := pure (x ≥ y)
 
 open Lean in
@@ -129,27 +130,27 @@ macro "declare_comparison_specs" s:(&"signed" <|> &"unsigned") typeName:ident wi
     return ← `(
       namespace $typeName
 
-      @[spec]
+      @[specset int]
       def eq_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ eq x y ⦃ ⇓ r => ⌜ r = (x.toInt == y.toInt) ⌝ ⦄ := by
         mvcgen [eq]; rw [← @Bool.coe_iff_coe]; simp [x.toInt_inj]
 
-      @[spec]
+      @[specset int]
       def ne_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ ne x y ⦃ ⇓ r => ⌜ r = (x.toInt != y.toInt) ⌝ ⦄ := by
         mvcgen [ne]; rw [← @Bool.coe_iff_coe]; simp [x.toInt_inj]
 
-      @[spec]
+      @[specset int]
       def lt_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ lt x y ⦃ ⇓ r => ⌜ r = decide (x.toInt < y.toInt) ⌝ ⦄ := by
         mvcgen [lt]; simp [x.lt_iff_toInt_lt]
 
-      @[spec]
+      @[specset int]
       def le_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ le x y ⦃ ⇓ r => ⌜ r = decide (x.toInt ≤ y.toInt) ⌝ ⦄ := by
         mvcgen [le]; simp [x.le_iff_toInt_le]
 
-      @[spec]
+      @[specset int]
       def gt_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ gt x y ⦃ ⇓ r => ⌜ r = decide (x.toInt > y.toInt ) ⌝ ⦄ := by
         mvcgen [gt]; simp [y.lt_iff_toInt_lt]
 
-      @[spec]
+      @[specset int]
       def ge_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ ge x y ⦃ ⇓ r => ⌜ r = decide (x.toInt ≥ y.toInt) ⌝ ⦄ := by
         mvcgen [ge]; simp [y.le_iff_toInt_le]
 
@@ -158,27 +159,27 @@ macro "declare_comparison_specs" s:(&"signed" <|> &"unsigned") typeName:ident wi
   else return ← `(
       namespace $typeName
 
-      @[spec]
+      @[specset int]
       def eq_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ eq x y ⦃ ⇓ r => ⌜ r = (x.toNat == y.toNat) ⌝ ⦄ := by
         mvcgen [eq]; rw [← @Bool.coe_iff_coe]; simp [x.toNat_inj]
 
-      @[spec]
+      @[specset int]
       def ne_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ ne x y ⦃ ⇓ r => ⌜ r = (x.toNat != y.toNat) ⌝ ⦄ := by
         mvcgen [ne]; rw [← @Bool.coe_iff_coe]; simp [x.toNat_inj]
 
-      @[spec]
+      @[specset int]
       def lt_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ lt x y ⦃ ⇓ r => ⌜ r = decide (x.toNat < y.toNat) ⌝ ⦄ := by
         mvcgen [lt]
 
-      @[spec]
+      @[specset int]
       def le_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ le x y ⦃ ⇓ r => ⌜ r = decide (x.toNat ≤ y.toNat) ⌝ ⦄ := by
         mvcgen [le]
 
-      @[spec]
+      @[specset int]
       def gt_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ gt x y ⦃ ⇓ r => ⌜ r = decide (x.toNat > y.toNat ) ⌝ ⦄ := by
         mvcgen [gt]
 
-      @[spec]
+      @[specset int]
       def ge_spec (x y : $typeName) : ⦃ ⌜ True ⌝ ⦄ ge x y ⦃ ⇓ r => ⌜ r = decide (x.toNat ≥ y.toNat) ⌝ ⦄ := by
         mvcgen [ge]
 
@@ -198,7 +199,7 @@ declare_comparison_specs unsigned USize64 64
 
 end rust_primitives.hax.machine_int
 
-@[simp, spec, hax_bv_decide]
+@[simp, spec, specset bv, hax_bv_decide]
 def CoreModels.Ops.Arith.Neg.neg {α} [Neg α] (x:α) : RustM α := pure (-x)
 
 abbrev core.cmp.PartialEq.eq {α} [BEq α] (a b : α) := BEq.beq a b
@@ -246,7 +247,7 @@ infixl:70 " %? "   => rust_primitives.ops.arith.Rem.rem
 infixl:70 " /? "   => rust_primitives.ops.arith.Div.div
 prefix:75 "-?"   => rust_primitives.ops.arith.Neg.neg
 
-attribute [hax_bv_decide]
+attribute [specset bv, hax_bv_decide]
   rust_primitives.ops.arith.Add.add
   rust_primitives.ops.arith.Sub.sub
   rust_primitives.ops.arith.Mul.mul

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/RustM.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/RustM.lean
@@ -1,4 +1,5 @@
 import Hax.Tactic.Init
+import Hax.Tactic.SpecSet
 import Hax.MissingLean.Init.While
 import Std.Tactic.Do
 
@@ -62,7 +63,7 @@ def isOk {α : Type} (x: RustM α) : Bool := match x with
 | .ok _ => true
 | _ => false
 
-@[reducible, hax_bv_decide]
+@[reducible, specset bv, hax_bv_decide]
 def of_isOk {α : Type} (x: RustM α) (h: RustM.isOk x): α :=
   match x with
   | .ok v => v

--- a/hax-lib/proof-libs/lean/Hax/Tactic.lean
+++ b/hax-lib/proof-libs/lean/Hax/Tactic.lean
@@ -1,4 +1,6 @@
 import Hax.Tactic.HaxBVDecide
 import Hax.Tactic.HaxConstructPure
+import Hax.Tactic.HaxMvcgen
 import Hax.Tactic.HaxZify
 import Hax.Tactic.Init
+import Hax.Tactic.SpecSet

--- a/hax-lib/proof-libs/lean/Hax/Tactic/HaxConstructPure.lean
+++ b/hax-lib/proof-libs/lean/Hax/Tactic/HaxConstructPure.lean
@@ -1,4 +1,5 @@
 import Hax.Tactic.HaxZify
+import Hax.Tactic.HaxMvcgen
 import Qq
 
 open Lean Elab Tactic Meta Qq Std.Do
@@ -68,7 +69,7 @@ syntax (name := hax_construct_pure) "hax_construct_pure" (" => " tacticSeq)? : t
 def elabHaxConstructPure : Tactic := fun stx => do
   let tac ← match stx with
   | `(tactic| hax_construct_pure => $tac:tacticSeq) => pure tac
-  | `(tactic| hax_construct_pure) => `(tacticSeq| mvcgen)
+  | `(tactic| hax_construct_pure) => `(tacticSeq| hax_mvcgen -trivial)
   | _ => throwUnsupportedSyntax
 
   let goal ← getMainGoal

--- a/hax-lib/proof-libs/lean/Hax/Tactic/HaxMvcgen.lean
+++ b/hax-lib/proof-libs/lean/Hax/Tactic/HaxMvcgen.lean
@@ -1,0 +1,34 @@
+import Hax.Tactic.SpecSet
+import Hax.Tactic.Init
+
+namespace Hax.HaxMvcgen
+
+open Lean Elab Syntax Parser Tactic
+
+def mkMvcgenCall (args: Array Name) (cfgStx : Syntax) (argStx : Syntax) : CoreM Syntax := do
+  let cfgStx : TSyntax `Lean.Parser.Tactic.optConfig := .mk cfgStx
+  let mut elems := argStx[1].getArgs.getSepElems
+  for arg in args do
+    elems := elems.push
+      (Syntax.node .none ``Lean.Parser.Tactic.simpLemma #[mkNullNode, mkNullNode, mkIdent arg])
+  let argStx : TSepArray _ _ := Syntax.TSepArray.ofElems (elems.map .mk)
+  let tac := ← `(tactic| mvcgen $cfgStx [$argStx,*])
+  pure tac
+
+syntax (name := hax_mvcgen) "hax_mvcgen" optConfig
+  (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")? : tactic
+
+/-- A customized version of the `mvcgen` tactic. It provides `mvcgen` with additional lemmas
+gathered from `@[specset X]` annotations, where `X` is the current setting of
+`set_option hax_mvcgen.specset`. -/
+@[tactic hax_mvcgen]
+def elabHaxMvcgen : Tactic := fun stx => do
+  let specset := hax_mvcgen.specset.get (← getOptions)
+  let cfgStx := stx[1]
+  let argStx := stx[2]
+  let extState := specSetExt.getState (← getEnv)
+  let decls := (extState.getD specset.toName {}).toArray
+  let tac ← mkMvcgenCall decls cfgStx argStx
+  Tactic.evalTactic tac
+
+end  Hax.HaxMvcgen

--- a/hax-lib/proof-libs/lean/Hax/Tactic/Init.lean
+++ b/hax-lib/proof-libs/lean/Hax/Tactic/Init.lean
@@ -4,3 +4,9 @@ initialize do pure () <*
   Lean.Meta.registerSimpAttr `hax_bv_decide "simp rules for hax-specific bv_decide preprocessing"
 
 initialize Lean.registerTraceClass `Hax.hax_construct_pure
+
+
+register_option hax_mvcgen.specset : String := {
+  defValue := "bv"
+  descr    := "Identifier of the set of specs used for `hax_mvcgen`"
+}

--- a/hax-lib/proof-libs/lean/Hax/Tactic/SpecSet.lean
+++ b/hax-lib/proof-libs/lean/Hax/Tactic/SpecSet.lean
@@ -1,0 +1,37 @@
+import Lean
+
+open Lean Elab Std
+
+abbrev SpecSetMap := HashMap Name (HashSet Name)
+
+structure SpecSetEntry where
+  specSet : Name
+  decl : Name
+
+/-- Environment extension to store spec sets, i.e., sets of declarations to use with
+`hax_mvcgen`. -/
+initialize specSetExt : SimplePersistentEnvExtension SpecSetEntry SpecSetMap ←
+  registerSimplePersistentEnvExtension {
+    name := `specSetExt
+    addEntryFn := fun state {specSet, decl} =>
+      let set := state.getD specSet {}
+      state.insert specSet (set.insert decl)
+    addImportedFn := fun states =>
+      states.foldl
+        (fun acc st =>
+          st.foldl
+            (fun acc {specSet, decl} =>
+              let merged := (acc.getD specSet {}).insert decl
+              acc.insert specSet merged)
+            acc)
+        {}
+  }
+
+initialize
+  registerBuiltinAttribute {
+    name  := `specset
+    descr := "Add a declaration to a given spec set for `hax_mvcgen`. The spec set can be activated
+      via `set_option hax_mvcgen.specset`"
+    add   := fun decl stx kind => do
+      setEnv $ specSetExt.addEntry (← getEnv) {specSet := stx[1][0].getId, decl}
+  }


### PR DESCRIPTION
This PR adds support for multiple sets of specifications. I labelled specs in terms of mathematical integers as `specset int` and specs intended for bit-blasting as `specset bv`. I added a Lean option `set_option hax_mvcgen.specset` to switch between the two. A wrapper `hax_mvcgen` around `mvcgen` allows us to use the annotated specs. I updated the Lean-Chacha20 example to use the new feature.

A similar feature will likely be added to `mvcgen` in the future by the Lean FRO. When they do, we can switch to that.

Fixes #1894
