### PR TITLE
fix(lean): Support functions without arguments in specs

### DIFF
--- a/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
@@ -355,10 +355,8 @@ def f (_ : Rust_primitives.Hax.Tuple0) : RustM Rust_primitives.Hax.Tuple0 := do
 
 @[spec]
 def f.spec (_ : Rust_primitives.Hax.Tuple0) :
-    Spec
-      (requires := do (pure true))
-      (ensures := fun _ => pure True)
-      (f (_ : Rust_primitives.Hax.Tuple0)) := {
+    Spec (requires := do (pure true)) (ensures := fun _ => pure True) (f ⟨⟩) :=
+{
   pureRequires := by constructor; mvcgen <;> try grind
   pureEnsures := by constructor; intros; mvcgen <;> try grind
   contract := by mvcgen[f] <;> try grind

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -696,6 +696,23 @@ def test_proof.spec (x : u8) :
   contract := by unfold Lean_tests.Specs.test_proof; hax_bv_decide
 }
 
+--  Test function without arguments
+--  https://github.com/cryspen/hax/issues/1856
+def fn_without_args (_ : Rust_primitives.Hax.Tuple0) :
+    RustM Rust_primitives.Hax.Tuple0 := do
+  (pure Rust_primitives.Hax.Tuple0.mk)
+
+@[spec]
+def fn_without_args.spec (_ : Rust_primitives.Hax.Tuple0) :
+    Spec
+      (requires := do pure True)
+      (ensures := fun _ => do (pure true))
+      (fn_without_args ⟨⟩) := {
+  pureRequires := by constructor; mvcgen <;> try grind
+  pureEnsures := by constructor; intros; mvcgen <;> try grind
+  contract := by mvcgen[fn_without_args] <;> try grind
+}
+
 end Lean_tests.Specs
 
 

--- a/tests/lean-tests/src/specs.rs
+++ b/tests/lean-tests/src/specs.rs
@@ -11,6 +11,11 @@ fn test_proof(x: u8) -> u8 {
     x
 }
 
+/// Test function without arguments
+/// https://github.com/cryspen/hax/issues/1856
+#[hax_lib::ensures(|_| true)]
+fn fn_without_args() {}
+
 /// The Lean backend used to produce `self_` instead of `self` in annotations in
 /// impl blocks. See https://github.com/cryspen/hax/issues/1852.
 mod issue_1852 {


### PR DESCRIPTION
Fixes #1856

[skip changelog]