### PR TITLE
Render suffixes in the rust engine and backends.

### DIFF
--- a/rust-engine/src/ast/identifiers/global_id.rs
+++ b/rust-engine/src/ast/identifiers/global_id.rs
@@ -516,7 +516,7 @@ impl From<ConcreteId> for GlobalId {
 impl ConcreteId {
     /// Renders a view of the concrete identifier.
     fn view(&self) -> view::View {
-        self.def_id.clone().into()
+        view::View::from(self.def_id.clone()).with_suffix(self.suffix.clone())
     }
 
     /// Gets the closest module only parent identifier, that is, the closest

--- a/rust-engine/src/ast/identifiers/global_id/view.rs
+++ b/rust-engine/src/ast/identifiers/global_id/view.rs
@@ -766,12 +766,15 @@ impl PathSegment {
 
 mod view_encapsulation {
     //! Encapsulation module to scope [`View`]'s invariants
-    use crate::ast::{identifiers::global_id::FreshModule, span::Span};
+    use crate::ast::{
+        identifiers::global_id::{FreshModule, ReservedSuffix},
+        span::Span,
+    };
 
     use super::*;
     /// A view for an [`ExplicitDefId`], materialized as a list of typed
     /// [`PathSegment`]s ordered from the crate root/module towards the item.
-    pub struct View(Vec<PathSegment>);
+    pub struct View(Vec<PathSegment>, Option<ReservedSuffix>);
 
     impl View {
         /// Returns the full list of segments (non-empty).
@@ -818,6 +821,17 @@ mod view_encapsulation {
                 .last()
                 .expect("Broken invariant, a name has at least a crate")
         }
+
+        /// Get the optional suffix of this view
+        pub fn suffix(&self) -> &Option<ReservedSuffix> {
+            &self.1
+        }
+
+        /// Add a suffix to a view
+        pub fn with_suffix(mut self, suffix: Option<ReservedSuffix>) -> Self {
+            self.1 = suffix;
+            self
+        }
     }
 
     impl From<ExplicitDefId> for View {
@@ -829,7 +843,7 @@ mod view_encapsulation {
                 std::iter::from_fn(|| PathSegment::from_iterator(&mut it)).collect::<Vec<_>>();
             inner.reverse();
             debug_assert!(!inner.is_empty()); // invariant: non-empty
-            Self(inner)
+            Self(inner, None)
         }
     }
 

--- a/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
@@ -59,7 +59,7 @@ end Cyclic_modules.Typ_a
 
 namespace Cyclic_modules.Typ_b
 
-def T1 (x : T1) : RustM isize := do
+def T1_cast_to_repr (x : T1) : RustM isize := do
   match x with | (T1.T1 ) => (pure (0 : isize))
 
 inductive T2 : Type
@@ -143,7 +143,7 @@ inductive T : Type
 | t1 : T
 | t2 : T
 
-def T (x : T) : RustM isize := do
+def T_cast_to_repr (x : T) : RustM isize := do
   match x with | (T.t1 ) => (pure (0 : isize)) | (T.t2 ) => (pure (1 : isize))
 
 end Cyclic_modules.Rec


### PR DESCRIPTION
Fixes https://github.com/cryspen/hax/issues/1646

As described in https://github.com/cryspen/hax/issues/1646#issuecomment-3878716264, name clashes could happen but the resolution is left for a future PR.

[skip changelog]