### PR TITLE
feat(lean): for-loops for all unsigned integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes to hax-lib:
  - Lean lib: Separate symbolic and bit-blasting specs (#1933)
  - Lean lib: Communicate user-generated specs to mvcgen (#1937)
  - Lean lib: Rust primitives for prop (#1942)
+ - Lean lib: For-loops for all unsigned integers (#1951)
 
 Changes to the Lean backend:
  - Add `hax_zify` and `hax_construct_pure` tactics (#1888)

--- a/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Folds.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core_models/Missing/Folds.lean
@@ -15,134 +15,145 @@ Hax represents for-loops as folds over a range
 section Fold
 
 open core_models.ops.control_flow
+open rust_primitives.hax
 
 class rust_primitives.hax.folds {int_type: Type} where
+  /-- Encoding of Rust for-loops without early returns -/
   fold_range {α : Type}
     (s e : int_type)
-    (inv : α -> int_type -> RustM Bool)
+    (inv : α -> int_type -> RustM Prop)
     (init: α)
     (body : α -> int_type -> RustM α)
-    : RustM α
+    (pureInv:
+        {i : α -> int_type -> Prop // ∀ a b, ⦃⌜ True ⌝⦄ inv a b ⦃⇓ r => ⌜ r = (i a b) ⌝⦄} := by
+      set_option hax_mvcgen.specset "bv" in hax_construct_pure <;> bv_decide) :
+    RustM α
+  /-- Encoding of Rust for-loops with early returns -/
   fold_range_return  {α_acc α_ret : Type}
     (s e: int_type)
-    (inv : α_acc -> int_type -> RustM Bool)
+    (inv : α_acc -> int_type -> RustM Prop)
     (init: α_acc)
     (body : α_acc -> int_type ->
       RustM (ControlFlow (ControlFlow α_ret (Tuple2 Tuple0 α_acc)) α_acc ))
-    : RustM (ControlFlow α_ret α_acc)
+    (pureInv:
+        {i : α_acc -> int_type -> Prop // ∀ a b, ⦃⌜ True ⌝⦄ inv a b ⦃⇓ r => ⌜ r = (i a b) ⌝⦄} := by
+      set_option hax_mvcgen.specset "bv" in hax_construct_pure <;> bv_decide) :
+    RustM (ControlFlow α_ret α_acc)
 
-instance : Coe Nat Nat where
-  coe x := x
+open Lean in
+set_option hygiene false in
+macro "declare_fold_specs" s:(&"signed" <|> &"unsigned") typeName:ident width:term : command => do
+  let tyDot (n : Name) := mkIdent (typeName.getId ++ n)
+  let tySimp (n : Name) : TSyntax _ := .mk
+    (Syntax.node .none ``Lean.Parser.Tactic.simpLemma #[mkNullNode, mkNullNode, tyDot n])
+  let tyRw (n : Name) : TSyntax `Lean.Parser.Tactic.rwRule := .mk
+    (Syntax.node .none ``Lean.Parser.Tactic.rwRule #[mkNullNode, tyDot n])
+  `(
+    /-- Implementation of Rust for-loops without early returns -/
+    def $(tyDot `fold_range) {α : Type}
+        (s e : $typeName)
+        (inv : α -> $typeName -> RustM Prop)
+        (init: α)
+        (body : α -> $typeName -> RustM α)
+        (pureInv: {i : α -> $typeName -> Prop // ∀ a b, ⦃⌜ True ⌝⦄ inv a b ⦃⇓ r => ⌜ r = (i a b) ⌝⦄})
+        : RustM α := do
+        if s < e
+        then fold_range (s + 1) e inv (← body init s) body pureInv
+        else pure init
+    termination_by (e - s)
+    decreasing_by
+      simp only [$(tySimp `sizeOf), Nat.add_lt_add_iff_right]
+      exact $(tyDot `sub_succ_lt_self) _ _ (by assumption)
 
-@[simp]
-instance {α} [Coe α Nat] [Coe Nat α]: @rust_primitives.hax.folds α where
-  fold_range s e inv init body := do
-    let mut acc := init
-    for i in [s:e] do
-      acc := (← body acc i)
-    return acc
+    /-- Implementation of Rust for-loops with early returns -/
+    def $(tyDot `fold_range_return) {α_acc α_ret : Type}
+        (s e: $typeName)
+        (inv : α_acc -> $typeName -> RustM Prop)
+        (init: α_acc)
+        (body : α_acc -> $typeName ->
+          RustM (ControlFlow (ControlFlow α_ret (Tuple2 Tuple0 α_acc)) α_acc ))
+        (pureInv: {i : α_acc -> $typeName -> Prop // ∀ a b, ⦃⌜ True ⌝⦄ inv a b ⦃⇓ r => ⌜ r = (i a b) ⌝⦄}) := do
+      if s < e
+      then
+        match (← body init s) with
+        | .Break (.Break res ) => pure (ControlFlow.Break res)
+        | .Break (.Continue ⟨ ⟨ ⟩, res⟩) => pure (ControlFlow.Continue res)
+        | .Continue res => fold_range_return (s + 1) e inv res body pureInv
+      else
+        pure (ControlFlow.Continue init)
+    termination_by (e - s)
+    decreasing_by
+      simp only [$(tySimp `sizeOf), Nat.add_lt_add_iff_right]
+      exact $(tyDot `sub_succ_lt_self) _ _ (by assumption)
 
-  fold_range_return {α_acc α_ret} s e inv init body := do
-    let mut acc := init
-    for i in [s:e] do
-      match (← body acc i) with
-      | .Break (.Break res ) => return (.Break res)
-      | .Break (.Continue ⟨ ⟨ ⟩, res⟩) => return (.Continue res)
-      | .Continue acc' => acc := acc'
-    pure (ControlFlow.Continue acc)
+    @[spec]
+    instance : @rust_primitives.hax.folds $typeName where
+      fold_range := $(tyDot `fold_range)
+      fold_range_return := $(tyDot `fold_range_return)
 
-/-
-Nat-based specification for hax_folds_fold_range. It requires that the invariant
-holds on the initial value, and that for any index `i` between the start and end
-values, executing body of the loop on a value that satisfies the invariant
-produces a result that also satisfies the invariant.
+    /-- Specification of Rust for-loops without early returns (for bv_decide) -/
+    @[specset bv]
+    theorem $(mkIdent (s!"rust_primitives.hax.folds.fold_range_spec_bv_{typeName.getId}").toName) {α}
+      (s e : $typeName)
+      (inv : α -> $typeName -> RustM Prop)
+      (pureInv)
+      (init: α)
+      (body : α -> $typeName -> RustM α) :
+      s ≤ e →
+      pureInv.val init s →
+      (∀ (acc : α) (i : $typeName),
+        s ≤ i →
+        i < e →
+        pureInv.val acc i →
+        ⦃ ⌜ True ⌝ ⦄
+        (body acc i)
+        ⦃ ⇓ res => ⌜ pureInv.val res (i+1) ⌝ ⦄) →
+      ⦃ ⌜ True ⌝ ⦄
+      ($(tyDot `fold_range) s e inv init body pureInv)
+      ⦃ ⇓ r => ⌜ pureInv.val r e ⌝ ⦄
+    := by
+      intro h_le h_inv_s h_body
+      unfold $(tyDot `fold_range)
+      mvcgen
+      · mstart
+        mspec h_body _ _ ($(tyDot `le_refl) s) (by assumption) h_inv_s
+        mspec $(mkIdent (s!"rust_primitives.hax.folds.fold_range_spec_bv_{typeName.getId}").toName)
+          <;> grind
+      · grind
+    termination_by (e - s)
+    decreasing_by
+      simp only [$(tySimp `sizeOf), Nat.add_lt_add_iff_right]
+      exact $(tyDot `sub_succ_lt_self) _ _ (by assumption)
 
--/
-@[spec]
-theorem rust_primitives.hax.folds.fold_range_spec {α}
-  (s e : Nat)
-  (inv : α -> Nat -> RustM Bool)
-  (init: α)
-  (body : α -> Nat -> RustM α) :
-  s ≤ e →
-  inv init s = pure true →
-  (∀ (acc:α) (i:Nat),
-    s ≤ i →
-    i < e →
-    inv acc i = pure true →
-    ⦃ ⌜ True ⌝ ⦄
-    (body acc i)
-    ⦃ ⇓ res => ⌜ inv res (i+1) = pure true ⌝ ⦄) →
-  ⦃ ⌜ True ⌝ ⦄
-  (rust_primitives.hax.folds.fold_range s e inv init body)
-  ⦃ ⇓ r => ⌜ inv r e = pure true ⌝ ⦄
-:= by
-  intro h_inv_s h_le h_body
-  mvcgen [Spec.forIn_list, fold_range]
-  case inv1 =>
-    simp [Coe.coe]
-    exact (⇓ (⟨ suff, _, _ ⟩ , acc ) => ⌜ inv acc (s + suff.length) = pure true ⌝ )
-  case vc1.step _ x _ h_list _ h =>
-    intros
-    simp [Coe.coe] at h_list h
-    have ⟨k ,⟨ h_k, h_pre, h_suff⟩⟩ := List.range'_eq_append_iff.mp h_list
-    let h_suff := Eq.symm h_suff
-    let ⟨ h_x ,_ , h_suff⟩ := List.range'_eq_cons_iff.mp h_suff
-    mstart ; mspec h_body <;> simp [Coe.coe] at * <;> try grind
-  case vc2.pre | vc4.post.except =>
-    simp [Coe.coe] at * <;> try assumption
-  case vc3.post.success =>
-    simp at *
-    suffices (s + (e - s)) = e by (rw [← this]; assumption)
-    omega
+    /-- Specification of Rust for-loops without early returns (for grind) -/
+    @[specset int]
+    theorem $(mkIdent (s!"rust_primitives.hax.folds.fold_range_spec_int_{typeName.getId}").toName) {α}
+        (s e : $typeName)
+        (inv : α -> $typeName -> RustM Prop)
+        (pureInv)
+        (init: α)
+        (body : α -> $typeName -> RustM α) :
+        s.toNat ≤ e.toNat →
+        pureInv.val init s →
+        (∀ (acc : α) (i : $typeName),
+          s.toNat ≤ i.toNat →
+          i.toNat < e.toNat →
+          pureInv.val acc i →
+          ⦃ ⌜ True ⌝ ⦄
+          (body acc i)
+          ⦃ ⇓ res => ⌜ pureInv.val res (i+1) ⌝ ⦄) →
+        ⦃ ⌜ True ⌝ ⦄
+        ($(tyDot `fold_range) s e inv init body pureInv)
+        ⦃ ⇓ r => ⌜ pureInv.val r e ⌝ ⦄ := by
+      apply $(mkIdent (s!"rust_primitives.hax.folds.fold_range_spec_bv_{typeName.getId}").toName)
 
-@[specset int]
-theorem rust_primitives.hax.folds.usize.fold_range_spec {α}
-  (s e : usize)
-  (inv : α -> usize -> RustM Bool)
-  (init: α)
-  (body : α -> usize -> RustM α) :
-  s.toNat ≤ e.toNat →
-  inv init s = pure true →
-  (∀ (acc:α) (i:usize),
-    s.toNat ≤ i.toNat →
-    i.toNat < e.toNat →
-    inv acc i = pure true →
-    ⦃ ⌜ True ⌝ ⦄
-    (body acc i)
-    ⦃ ⇓ res => ⌜ inv res (i+1) = pure true ⌝ ⦄) →
-  ⦃ ⌜ True ⌝ ⦄
-  (rust_primitives.hax.folds.fold_range s e inv init body)
-  ⦃ ⇓ r => ⌜ inv r e = pure true ⌝ ⦄
-:= by
-  intro h_inv_s h_le h_body
-  have : s.toNat < USize64.size := by apply USize64.toNat_lt_size
-  have : e.toNat < USize64.size := by apply USize64.toNat_lt_size
-  mvcgen [Spec.forIn_list, fold_range]
-  case inv1 =>
-    simp [Coe.coe]
-    exact (⇓ (⟨ suff, _, _ ⟩ , acc ) => ⌜ inv acc (s + (USize64.ofNat suff.length)) = pure true ⌝ )
-  case vc2.pre | vc4.post.except =>
-    simp [Coe.coe, USize64.ofNat] at * <;> try assumption
-  case vc3.post.success =>
-    simp at *
-    suffices (s + USize64.ofNat (USize64.toNat e - USize64.toNat s)) = e by rwa [← this]
-    rw [USize64.ofNat_sub, USize64.ofNat_toNat, USize64.ofNat_toNat] <;> try assumption
-    rw (occs := [2])[← USize64.sub_add_cancel (b := s) (a := e)]
-    rw [USize64.add_comm]
-  case vc1.step _ x _ h_list _ h =>
-    intros
-    simp [Coe.coe] at h_list h
-    have ⟨k ,⟨ h_k, h_pre, h_suff⟩⟩ := List.range'_eq_append_iff.mp h_list
-    let h_suff := Eq.symm h_suff
-    let ⟨ h_x ,_ , h_suff⟩ := List.range'_eq_cons_iff.mp h_suff
-    unfold USize64.size at *
-    mstart ; mspec h_body <;> simp [Coe.coe] at *
-    . rw [← h_x, Nat.mod_eq_of_lt] <;> grind
-    . rw [← h_x, Nat.mod_eq_of_lt] <;> grind [Nat.add_sub_cancel']
-    . rw [← h_x, USize64.ofNat_add, USize64.ofNat_toNat]
-      rwa [h_pre, List.length_range'] at h
-    . rw [h_pre, List.length_range', ← h_x, USize64.ofNat_add, USize64.ofNat_toNat, USize64.add_assoc]
-      intro; assumption
+  )
+
+declare_fold_specs unsigned UInt8 8
+declare_fold_specs unsigned UInt16 16
+declare_fold_specs unsigned UInt32 32
+declare_fold_specs unsigned UInt64 64
+declare_fold_specs unsigned USize64 64
+
 
 end Fold

--- a/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Lemmas.lean
+++ b/hax-lib/proof-libs/lean/Hax/MissingLean/Init/Data/UInt/Lemmas.lean
@@ -24,20 +24,35 @@ theorem UInt64.add_le_of_le {a b c : UInt64} (habc : a + b ≤ c) (hab : a.toNat
   rw [UInt64.le_iff_toNat_le, UInt64.toNat_add_of_lt hab] at *
   omega
 
-
 open Lean in
 set_option hygiene false in
-macro "additional_uint_lemmas" typeName:ident _width:term : command => do `(
-  namespace $typeName
+macro "additional_uint_lemmas" typeName:ident _width:term : command => do
+  let tyDot (n : Name) := mkIdent (typeName.getId ++ n)
+  let tyRw (n : Name) : TSyntax `Lean.Parser.Tactic.rwRule := .mk
+    (Syntax.node .none ``Lean.Parser.Tactic.rwRule #[mkNullNode, tyDot n])
+  `(
+    namespace $typeName
 
-    theorem ofNat_eq_of_toNat_eq {a : Nat} {b : $typeName} (h : b.toNat = a) : ofNat a = b := by
-      subst_vars; exact $(mkIdent (typeName.getId ++ `ofNat_toNat))
+      theorem ofNat_eq_of_toNat_eq {a : Nat} {b : $typeName} (h : b.toNat = a) : ofNat a = b := by
+        subst_vars; exact $(mkIdent (typeName.getId ++ `ofNat_toNat))
 
-  end $typeName
-)
+      theorem sub_add_eq {a b c : $typeName} : a - (b + c) = a - b - c := by grind
+
+      theorem sub_succ_lt_self (a b : $typeName) (h : a < b) :
+          (b - (a + 1)).toNat < (b - a).toNat := by
+        rw [sub_add_eq]
+        rw [$(tyRw `toNat_sub_of_le)]
+        try simp only [USize.toNat_one]
+        apply Nat.sub_one_lt_of_lt
+        · change (0 : $typeName).toNat < (b - a).toNat
+          rw [← lt_iff_toNat_lt]
+          grind
+        · grind
+
+    end $typeName
+  )
 
 additional_uint_lemmas UInt8 8
 additional_uint_lemmas UInt16 16
 additional_uint_lemmas UInt32 32
 additional_uint_lemmas UInt64 64
-additional_uint_lemmas USize System.Platform.numBits

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/Hax.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/Hax.lean
@@ -56,6 +56,8 @@ def gt {α} (x y: α) [LT α] [Decidable (x > y)] : RustM Bool := pure (x > y)
 @[simp, specset bv, hax_bv_decide]
 def ge {α} (x y: α) [LE α] [Decidable (x ≥ y)] : RustM Bool := pure (x ≥ y)
 
+attribute [specset bv] bne
+
 @[spec] def bitand {α} (x y: α) [AndOp α] : RustM α := pure (x &&& y)
 @[spec] def bitor  {α} (x y: α) [OrOp α]  : RustM α := pure (x ||| y)
 @[spec] def bitxor {α} (x y: α) [XorOp α] : RustM α := pure (x ^^^ y)

--- a/hax-lib/proof-libs/lean/Hax/Rust_primitives/USize64.lean
+++ b/hax-lib/proof-libs/lean/Hax/Rust_primitives/USize64.lean
@@ -242,9 +242,6 @@ theorem USize64.ofNat_sub {a b : Nat} (hab : b ≤ a) : USize64.ofNat (a - b) = 
 theorem USize64.le_ofNat_iff {n : USize64} {m : Nat} (h : m < size) : n ≤ ofNat m ↔ n.toNat ≤ m := by
   rw [le_iff_toNat_le, toNat_ofNat_of_lt' h]
 
-theorem USize64.ofNat_eq_of_toNat_eq {a : Nat} {b : USize64} (h : b.toNat = a) : ofNat a = b := by
-  subst_vars; exact USize64.ofNat_toNat
-
 /-!
 ## Grind's ToInt
 
@@ -426,3 +423,30 @@ dsimproc [seval] isValue ((OfNat.ofNat _ : USize64)) := fun e => do
   return .done e
 
 end USize64
+
+/-
+## Lemmas from `Init.SizeOfLemmas`:
+-/
+
+@[simp] protected theorem USize64.sizeOf (a : USize64) : sizeOf a = a.toNat + 3 := by
+  cases a; simp +arith [USize64.toNat, BitVec.toNat, -BitVec.val_toFin]
+
+/-
+## Lemmas from `MissingLean`:
+-/
+
+theorem USize64.ofNat_eq_of_toNat_eq {a : Nat} {b : USize64} (h : b.toNat = a) : ofNat a = b := by
+  subst_vars; exact USize64.ofNat_toNat
+
+theorem USize64.sub_add_eq {a b c : USize64} : a - (b + c) = a - b - c := by grind
+
+theorem USize64.sub_succ_lt_self (a b : USize64) (h : a < b) :
+    (b - (a + 1)).toNat < (b - a).toNat := by
+  rw [sub_add_eq]
+  rw [USize64.toNat_sub_of_le]
+  try simp only [USize.toNat_one]
+  apply Nat.sub_one_lt_of_lt
+  · change (0 : USize64).toNat < (b - a).toNat
+    rw [← lt_iff_toNat_lt]
+    grind
+  · grind

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -343,6 +343,7 @@ end lean_tests.ite
 
 namespace lean_tests.loops
 
+--  Simple for-loop
 @[spec]
 def loop1 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
   let x : u32 := (0 : u32);
@@ -355,6 +356,7 @@ def loop1 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
       (fun x i => (do (x +? i) : RustM u32)));
   (pure x)
 
+--  For-loop with a return
 @[spec]
 def loop2 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
   let x : u32 := (0 : u32);
@@ -382,6 +384,44 @@ def loop2 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
     | (core_models.ops.control_flow.ControlFlow.Break  ret) => do (pure ret)
     | (core_models.ops.control_flow.ControlFlow.Continue  x) => do (pure x)
 
+--  For-loop with a spec
+def for_loop_with_spec (y : u64) : RustM u64 := do
+  let x : u64 := y;
+  let x : u64 ←
+    (rust_primitives.hax.folds.fold_range
+      (0 : u64)
+      y
+      (fun x i =>
+        (do (rust_primitives.hax.machine_int.gt x (0 : u64)) : RustM Bool))
+      x
+      (fun x i =>
+        (do
+        if
+        (← (rust_primitives.hax.machine_int.eq (← (x %? (5 : u64))) (0 : u64)))
+        then do
+          let x : u64 := (200 : u64);
+          (pure x)
+        else do
+          let x : u64 ← (x %? (5 : u64));
+          (pure x) :
+        RustM u64)));
+  (pure x)
+
+set_option hax_mvcgen.specset "bv" in
+@[hax_spec]
+def for_loop_with_spec.spec (y : u64) :
+    Spec
+      (requires := do (rust_primitives.hax.machine_int.gt y (0 : u64)))
+      (ensures := fun
+          res => do
+          (rust_primitives.hax.machine_int.gt res (0 : u64)))
+      (for_loop_with_spec (y : u64)) := {
+  pureRequires := by hax_construct_pure <;> bv_decide
+  pureEnsures := by hax_construct_pure <;> bv_decide
+  contract := by hax_mvcgen [for_loop_with_spec] <;> bv_decide
+}
+
+--  while-loop
 def while_loop1 (s : u32) : RustM u32 := do
   let x : u32 := s;
   let x : u32 ←

--- a/tests/lean-tests/src/loops.rs
+++ b/tests/lean-tests/src/loops.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
-// Simple loop
+/// Simple for-loop
 fn loop1() -> u32 {
     let mut x: u32 = 0;
     for i in 1..10 {
@@ -11,7 +11,7 @@ fn loop1() -> u32 {
     x
 }
 
-// Loop with a return
+/// For-loop with a return
 fn loop2() -> u32 {
     let mut x: u32 = 0;
     for i in 1..10 {
@@ -23,6 +23,23 @@ fn loop2() -> u32 {
     x
 }
 
+/// For-loop with a spec
+#[hax_lib::requires(y > 0)]
+#[hax_lib::ensures(|res| res > 0)]
+fn for_loop_with_spec(y: u64) -> u64 {
+    let mut x: u64 = y;
+    for i in 0..y {
+        hax_lib::loop_invariant!(|i: u64| x > 0);
+        if x % 5 == 0 {
+            x = 200;
+        } else {
+            x = x % 5;
+        }
+    }
+    x
+}
+
+/// while-loop
 #[hax_lib::ensures(|r| r == 0)]
 #[hax_lib::lean::proof_method::grind]
 fn while_loop1(s: u32) -> u32 {


### PR DESCRIPTION
This PR adds a mechanism to convert invariants in for-loops into pure functions, which then allows us to verify them. Moreover, we extend the support for for-loops to cover all unsigned integer types.

Future work:
- unsigned integer types
- custom purification proofs
- automatically choose the correct proof method for purification, depending on the proof method used on the entire function.

This is working towards #1783