### PR TITLE
fix(lean): print "do" in all ITE & match-branches

### DIFF
--- a/hax-lib/proof-libs/lean/Hax/Core_models/Extracted.lean
+++ b/hax-lib/proof-libs/lean/Hax/Core_models/Extracted.lean
@@ -102,9 +102,9 @@ def Ordering.Greater.AnonConst : isize := (1 : isize)
 @[spec]
 def Ordering_cast_to_repr (x : Ordering) : RustM isize := do
   match x with
-    | (Ordering.Less ) => (pure Ordering.Less.AnonConst)
-    | (Ordering.Equal ) => (pure Ordering.Equal.AnonConst)
-    | (Ordering.Greater ) => (pure Ordering.Greater.AnonConst)
+    | (Ordering.Less ) => do (pure Ordering.Less.AnonConst)
+    | (Ordering.Equal ) => do (pure Ordering.Equal.AnonConst)
+    | (Ordering.Greater ) => do (pure Ordering.Greater.AnonConst)
 
 class Neq.AssociatedTypes (Self : Type) (Rhs : Type) where
 
@@ -1219,33 +1219,33 @@ instance Impl_1
       [trait_constr_lt_associated_type_i1 : PartialOrd.AssociatedTypes T T]
       [trait_constr_lt_i1 : PartialOrd T T ] (self : T) (y : T) => do
     match (← (PartialOrd.partial_cmp T T self y)) with
-      | (core_models.option.Option.Some  (Ordering.Less )) => (pure true)
-      | _ => (pure false)
+      | (core_models.option.Option.Some  (Ordering.Less )) => do (pure true)
+      | _ => do (pure false)
   le :=
     fun
       [trait_constr_le_associated_type_i1 : PartialOrd.AssociatedTypes T T]
       [trait_constr_le_i1 : PartialOrd T T ] (self : T) (y : T) => do
     match (← (PartialOrd.partial_cmp T T self y)) with
       | (core_models.option.Option.Some  (Ordering.Less )) |
-        (core_models.option.Option.Some  (Ordering.Equal )) =>
+        (core_models.option.Option.Some  (Ordering.Equal )) => do
         (pure true)
-      | _ => (pure false)
+      | _ => do (pure false)
   gt :=
     fun
       [trait_constr_gt_associated_type_i1 : PartialOrd.AssociatedTypes T T]
       [trait_constr_gt_i1 : PartialOrd T T ] (self : T) (y : T) => do
     match (← (PartialOrd.partial_cmp T T self y)) with
-      | (core_models.option.Option.Some  (Ordering.Greater )) => (pure true)
-      | _ => (pure false)
+      | (core_models.option.Option.Some  (Ordering.Greater )) => do (pure true)
+      | _ => do (pure false)
   ge :=
     fun
       [trait_constr_ge_associated_type_i1 : PartialOrd.AssociatedTypes T T]
       [trait_constr_ge_i1 : PartialOrd T T ] (self : T) (y : T) => do
     match (← (PartialOrd.partial_cmp T T self y)) with
       | (core_models.option.Option.Some  (Ordering.Greater )) |
-        (core_models.option.Option.Some  (Ordering.Equal )) =>
+        (core_models.option.Option.Some  (Ordering.Equal )) => do
         (pure true)
-      | _ => (pure false)
+      | _ => do (pure false)
 
 class Ord.AssociatedTypes (Self : Type) where
   [trait_constr_Ord_i0 : Eq.AssociatedTypes Self]
@@ -1275,8 +1275,8 @@ def max
     (v2 : T) :
     RustM T := do
   match (← (Ord.cmp T v1 v2)) with
-    | (Ordering.Greater ) => (pure v1)
-    | _ => (pure v2)
+    | (Ordering.Greater ) => do (pure v1)
+    | _ => do (pure v2)
 
 @[spec]
 def min
@@ -1287,8 +1287,8 @@ def min
     (v2 : T) :
     RustM T := do
   match (← (Ord.cmp T v1 v2)) with
-    | (Ordering.Greater ) => (pure v2)
-    | _ => (pure v1)
+    | (Ordering.Greater ) => do (pure v2)
+    | _ => do (pure v1)
 
 @[reducible] instance Impl_2.AssociatedTypes
   (T : Type)
@@ -1328,24 +1328,24 @@ instance Impl_5
 
 instance Impl_30 : PartialOrd u8 u8 where
   partial_cmp := fun (self : u8) (other : u8) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_31.AssociatedTypes : Ord.AssociatedTypes u8 where
 
 instance Impl_31 : Ord u8 where
   cmp := fun (self : u8) (other : u8) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_32.AssociatedTypes :
@@ -1354,24 +1354,24 @@ instance Impl_31 : Ord u8 where
 
 instance Impl_32 : PartialOrd i8 i8 where
   partial_cmp := fun (self : i8) (other : i8) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_33.AssociatedTypes : Ord.AssociatedTypes i8 where
 
 instance Impl_33 : Ord i8 where
   cmp := fun (self : i8) (other : i8) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_34.AssociatedTypes :
@@ -1380,24 +1380,24 @@ instance Impl_33 : Ord i8 where
 
 instance Impl_34 : PartialOrd u16 u16 where
   partial_cmp := fun (self : u16) (other : u16) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_35.AssociatedTypes : Ord.AssociatedTypes u16 where
 
 instance Impl_35 : Ord u16 where
   cmp := fun (self : u16) (other : u16) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_36.AssociatedTypes :
@@ -1406,24 +1406,24 @@ instance Impl_35 : Ord u16 where
 
 instance Impl_36 : PartialOrd i16 i16 where
   partial_cmp := fun (self : i16) (other : i16) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_37.AssociatedTypes : Ord.AssociatedTypes i16 where
 
 instance Impl_37 : Ord i16 where
   cmp := fun (self : i16) (other : i16) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_38.AssociatedTypes :
@@ -1432,24 +1432,24 @@ instance Impl_37 : Ord i16 where
 
 instance Impl_38 : PartialOrd u32 u32 where
   partial_cmp := fun (self : u32) (other : u32) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_39.AssociatedTypes : Ord.AssociatedTypes u32 where
 
 instance Impl_39 : Ord u32 where
   cmp := fun (self : u32) (other : u32) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_40.AssociatedTypes :
@@ -1458,24 +1458,24 @@ instance Impl_39 : Ord u32 where
 
 instance Impl_40 : PartialOrd i32 i32 where
   partial_cmp := fun (self : i32) (other : i32) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_41.AssociatedTypes : Ord.AssociatedTypes i32 where
 
 instance Impl_41 : Ord i32 where
   cmp := fun (self : i32) (other : i32) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_42.AssociatedTypes :
@@ -1484,24 +1484,24 @@ instance Impl_41 : Ord i32 where
 
 instance Impl_42 : PartialOrd u64 u64 where
   partial_cmp := fun (self : u64) (other : u64) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_43.AssociatedTypes : Ord.AssociatedTypes u64 where
 
 instance Impl_43 : Ord u64 where
   cmp := fun (self : u64) (other : u64) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_44.AssociatedTypes :
@@ -1510,24 +1510,24 @@ instance Impl_43 : Ord u64 where
 
 instance Impl_44 : PartialOrd i64 i64 where
   partial_cmp := fun (self : i64) (other : i64) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_45.AssociatedTypes : Ord.AssociatedTypes i64 where
 
 instance Impl_45 : Ord i64 where
   cmp := fun (self : i64) (other : i64) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_46.AssociatedTypes :
@@ -1536,24 +1536,24 @@ instance Impl_45 : Ord i64 where
 
 instance Impl_46 : PartialOrd u128 u128 where
   partial_cmp := fun (self : u128) (other : u128) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_47.AssociatedTypes : Ord.AssociatedTypes u128 where
 
 instance Impl_47 : Ord u128 where
   cmp := fun (self : u128) (other : u128) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_48.AssociatedTypes :
@@ -1562,24 +1562,24 @@ instance Impl_47 : Ord u128 where
 
 instance Impl_48 : PartialOrd i128 i128 where
   partial_cmp := fun (self : i128) (other : i128) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_49.AssociatedTypes : Ord.AssociatedTypes i128 where
 
 instance Impl_49 : Ord i128 where
   cmp := fun (self : i128) (other : i128) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_50.AssociatedTypes :
@@ -1588,24 +1588,24 @@ instance Impl_49 : Ord i128 where
 
 instance Impl_50 : PartialOrd usize usize where
   partial_cmp := fun (self : usize) (other : usize) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_51.AssociatedTypes : Ord.AssociatedTypes usize where
 
 instance Impl_51 : Ord usize where
   cmp := fun (self : usize) (other : usize) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 @[reducible] instance Impl_52.AssociatedTypes :
@@ -1614,24 +1614,24 @@ instance Impl_51 : Ord usize where
 
 instance Impl_52 : PartialOrd isize isize where
   partial_cmp := fun (self : isize) (other : isize) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure (core_models.option.Option.Some Ordering.Less))
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure (core_models.option.Option.Some Ordering.Greater))
-      else
+      else do
         (pure (core_models.option.Option.Some Ordering.Equal))
 
 @[reducible] instance Impl_53.AssociatedTypes : Ord.AssociatedTypes isize where
 
 instance Impl_53 : Ord isize where
   cmp := fun (self : isize) (other : isize) => do
-    if (← (rust_primitives.hax.machine_int.lt self other)) then
+    if (← (rust_primitives.hax.machine_int.lt self other)) then do
       (pure Ordering.Less)
-    else
-      if (← (rust_primitives.hax.machine_int.gt self other)) then
+    else do
+      if (← (rust_primitives.hax.machine_int.gt self other)) then do
         (pure Ordering.Greater)
-      else
+      else do
         (pure Ordering.Equal)
 
 end core_models.cmp
@@ -1652,14 +1652,14 @@ namespace core_models.option
 @[spec]
 def Impl.as_ref (T : Type) (self : (Option T)) : RustM (Option T) := do
   match self with
-    | (Option.Some  x) => (pure (Option.Some x))
-    | (Option.None ) => (pure Option.None)
+    | (Option.Some  x) => do (pure (Option.Some x))
+    | (Option.None ) => do (pure Option.None)
 
 @[spec]
 def Impl.unwrap_or (T : Type) (self : (Option T)) (default : T) : RustM T := do
   match self with
-    | (Option.Some  x) => (pure x)
-    | (Option.None ) => (pure default)
+    | (Option.Some  x) => do (pure x)
+    | (Option.None ) => do (pure default)
 
 @[spec]
 def Impl.unwrap_or_default
@@ -1671,8 +1671,8 @@ def Impl.unwrap_or_default
     (self : (Option T)) :
     RustM T := do
   match self with
-    | (Option.Some  x) => (pure x)
-    | (Option.None ) =>
+    | (Option.Some  x) => do (pure x)
+    | (Option.None ) => do
       (core_models.default.Default.default T rust_primitives.hax.Tuple0.mk)
 
 @[spec]
@@ -1681,7 +1681,7 @@ def Impl.take (T : Type) (self : (Option T)) :
   (pure (rust_primitives.hax.Tuple2.mk Option.None self))
 
 def Impl.is_some (T : Type) (self : (Option T)) : RustM Bool := do
-  match self with | (Option.Some  _) => (pure true) | _ => (pure false)
+  match self with | (Option.Some  _) => do (pure true) | _ => do (pure false)
 
 set_option hax_mvcgen.specset "bv" in
 @[hax_spec]
@@ -1887,8 +1887,8 @@ namespace core_models.option
 def Impl.ok_or (T : Type) (E : Type) (self : (Option T)) (err : E) :
     RustM (core_models.result.Result T E) := do
   match self with
-    | (Option.Some  v) => (pure (core_models.result.Result.Ok v))
-    | (Option.None ) => (pure (core_models.result.Result.Err err))
+    | (Option.Some  v) => do (pure (core_models.result.Result.Ok v))
+    | (Option.None ) => do (pure (core_models.result.Result.Err err))
 
 end core_models.option
 
@@ -1899,19 +1899,19 @@ namespace core_models.result
 def Impl.unwrap_or (T : Type) (E : Type) (self : (Result T E)) (default : T) :
     RustM T := do
   match self with
-    | (Result.Ok  t) => (pure t)
-    | (Result.Err  _) => (pure default)
+    | (Result.Ok  t) => do (pure t)
+    | (Result.Err  _) => do (pure default)
 
 @[spec]
 def Impl.is_ok (T : Type) (E : Type) (self : (Result T E)) : RustM Bool := do
-  match self with | (Result.Ok  _) => (pure true) | _ => (pure false)
+  match self with | (Result.Ok  _) => do (pure true) | _ => do (pure false)
 
 @[spec]
 def Impl.ok (T : Type) (E : Type) (self : (Result T E)) :
     RustM (core_models.option.Option T) := do
   match self with
-    | (Result.Ok  x) => (pure (core_models.option.Option.Some x))
-    | (Result.Err  _) => (pure core_models.option.Option.None)
+    | (Result.Ok  x) => do (pure (core_models.option.Option.Some x))
+    | (Result.Err  _) => do (pure core_models.option.Option.None)
 
 end core_models.result
 
@@ -2088,9 +2088,9 @@ def Impl.split_at_checked (T : Type) (s : (RustSlice T)) (mid : usize) :
     (core_models.option.Option
       (rust_primitives.hax.Tuple2 (RustSlice T) (RustSlice T)))
     := do
-  if (← (rust_primitives.hax.machine_int.le mid (← (Impl.len T s)))) then
+  if (← (rust_primitives.hax.machine_int.le mid (← (Impl.len T s)))) then do
     (pure (core_models.option.Option.Some (← (Impl.split_at T s mid))))
-  else
+  else do
     (pure core_models.option.Option.None)
 
 end core_models.slice
@@ -2616,7 +2616,7 @@ instance Impl_1
     let self : (Enumerate I) := {self with iter := tmp0};
     let ⟨self, hax_temp_output⟩ ←
       match out with
-        | (core_models.option.Option.Some  a) =>
+        | (core_models.option.Option.Some  a) => do
           let i : usize := (Enumerate.count self);
           let _ ←
             (hax_lib.assume
@@ -2630,7 +2630,7 @@ instance Impl_1
             self
             (core_models.option.Option.Some
               (rust_primitives.hax.Tuple2.mk i a))))
-        | (core_models.option.Option.None ) =>
+        | (core_models.option.Option.None ) => do
           (pure (rust_primitives.hax.Tuple2.mk
             self
             core_models.option.Option.None));
@@ -2720,14 +2720,14 @@ instance Impl_1
     let self : (Map I F) := {self with iter := tmp0};
     let hax_temp_output : (core_models.option.Option O) ←
       match out with
-        | (core_models.option.Option.Some  v) =>
+        | (core_models.option.Option.Some  v) => do
           (pure (core_models.option.Option.Some
             (← (core_models.ops.function.FnOnce.call_once
               F
               (core_models.iter.traits.iterator.Iterator.Item I)
               (Map.f self)
               v))))
-        | (core_models.option.Option.None ) =>
+        | (core_models.option.Option.None ) => do
           (pure core_models.option.Option.None);
     (pure (rust_primitives.hax.Tuple2.mk self hax_temp_output))
 
@@ -2756,14 +2756,15 @@ instance Impl_1
   where
   next := fun (self : (Take I)) => do
     let ⟨self, hax_temp_output⟩ ←
-      if (← (rust_primitives.hax.machine_int.ne (Take.n self) (0 : usize))) then
+      if
+      (← (rust_primitives.hax.machine_int.ne (Take.n self) (0 : usize))) then do
         let self : (Take I) :=
           {self with n := (← ((Take.n self) -? (1 : usize)))};
         let ⟨tmp0, out⟩ ←
           (core_models.iter.traits.iterator.Iterator.next I (Take.iter self));
         let self : (Take I) := {self with iter := tmp0};
         (pure (rust_primitives.hax.Tuple2.mk self out))
-      else
+      else do
         (pure (rust_primitives.hax.Tuple2.mk
           self
           core_models.option.Option.None));
@@ -3326,8 +3327,8 @@ def Impl.is_some_and
     (f : F) :
     RustM Bool := do
   match self with
-    | (Option.None ) => (pure false)
-    | (Option.Some  x) => (core_models.ops.function.FnOnce.call_once F T f x)
+    | (Option.None ) => do (pure false)
+    | (Option.Some  x) => do (core_models.ops.function.FnOnce.call_once F T f x)
 
 @[spec]
 def Impl.is_none_or
@@ -3348,8 +3349,8 @@ def Impl.is_none_or
     (f : F) :
     RustM Bool := do
   match self with
-    | (Option.None ) => (pure true)
-    | (Option.Some  x) => (core_models.ops.function.FnOnce.call_once F T f x)
+    | (Option.None ) => do (pure true)
+    | (Option.Some  x) => do (core_models.ops.function.FnOnce.call_once F T f x)
 
 @[spec]
 def Impl.unwrap_or_else
@@ -3373,8 +3374,8 @@ def Impl.unwrap_or_else
     (f : F) :
     RustM T := do
   match self with
-    | (Option.Some  x) => (pure x)
-    | (Option.None ) =>
+    | (Option.Some  x) => do (pure x)
+    | (Option.None ) => do
       (core_models.ops.function.FnOnce.call_once
         F
         rust_primitives.hax.Tuple0 f rust_primitives.hax.Tuple0.mk)
@@ -3399,10 +3400,10 @@ def Impl.map
     (f : F) :
     RustM (Option U) := do
   match self with
-    | (Option.Some  x) =>
+    | (Option.Some  x) => do
       (pure (Option.Some
         (← (core_models.ops.function.FnOnce.call_once F T f x))))
-    | (Option.None ) => (pure Option.None)
+    | (Option.None ) => do (pure Option.None)
 
 @[spec]
 def Impl.map_or
@@ -3425,8 +3426,8 @@ def Impl.map_or
     (f : F) :
     RustM U := do
   match self with
-    | (Option.Some  t) => (core_models.ops.function.FnOnce.call_once F T f t)
-    | (Option.None ) => (pure default)
+    | (Option.Some  t) => do (core_models.ops.function.FnOnce.call_once F T f t)
+    | (Option.None ) => do (pure default)
 
 @[spec]
 def Impl.map_or_else
@@ -3464,8 +3465,8 @@ def Impl.map_or_else
     (f : F) :
     RustM U := do
   match self with
-    | (Option.Some  t) => (core_models.ops.function.FnOnce.call_once F T f t)
-    | (Option.None ) =>
+    | (Option.Some  t) => do (core_models.ops.function.FnOnce.call_once F T f t)
+    | (Option.None ) => do
       (core_models.ops.function.FnOnce.call_once
         D
         rust_primitives.hax.Tuple0 default rust_primitives.hax.Tuple0.mk)
@@ -3494,8 +3495,8 @@ def Impl.map_or_default
     (f : F) :
     RustM U := do
   match self with
-    | (Option.Some  t) => (core_models.ops.function.FnOnce.call_once F T f t)
-    | (Option.None ) =>
+    | (Option.Some  t) => do (core_models.ops.function.FnOnce.call_once F T f t)
+    | (Option.None ) => do
       (core_models.default.Default.default U rust_primitives.hax.Tuple0.mk)
 
 @[spec]
@@ -3521,8 +3522,8 @@ def Impl.ok_or_else
     (err : F) :
     RustM (core_models.result.Result T E) := do
   match self with
-    | (Option.Some  v) => (pure (core_models.result.Result.Ok v))
-    | (Option.None ) =>
+    | (Option.Some  v) => do (pure (core_models.result.Result.Ok v))
+    | (Option.None ) => do
       (pure (core_models.result.Result.Err
         (← (core_models.ops.function.FnOnce.call_once
           F
@@ -3548,8 +3549,8 @@ def Impl.and_then
     (f : F) :
     RustM (Option U) := do
   match self with
-    | (Option.Some  x) => (core_models.ops.function.FnOnce.call_once F T f x)
-    | (Option.None ) => (pure Option.None)
+    | (Option.Some  x) => do (core_models.ops.function.FnOnce.call_once F T f x)
+    | (Option.None ) => do (pure Option.None)
 
 end core_models.option
 
@@ -3577,10 +3578,10 @@ def Impl.map
     (op : F) :
     RustM (Result U E) := do
   match self with
-    | (Result.Ok  t) =>
+    | (Result.Ok  t) => do
       (pure (Result.Ok
         (← (core_models.ops.function.FnOnce.call_once F T op t))))
-    | (Result.Err  e) => (pure (Result.Err e))
+    | (Result.Err  e) => do (pure (Result.Err e))
 
 @[spec]
 def Impl.map_or
@@ -3604,8 +3605,8 @@ def Impl.map_or
     (f : F) :
     RustM U := do
   match self with
-    | (Result.Ok  t) => (core_models.ops.function.FnOnce.call_once F T f t)
-    | (Result.Err  _e) => (pure default)
+    | (Result.Ok  t) => do (core_models.ops.function.FnOnce.call_once F T f t)
+    | (Result.Err  _e) => do (pure default)
 
 @[spec]
 def Impl.map_or_else
@@ -3641,8 +3642,8 @@ def Impl.map_or_else
     (f : F) :
     RustM U := do
   match self with
-    | (Result.Ok  t) => (core_models.ops.function.FnOnce.call_once F T f t)
-    | (Result.Err  e) =>
+    | (Result.Ok  t) => do (core_models.ops.function.FnOnce.call_once F T f t)
+    | (Result.Err  e) => do
       (core_models.ops.function.FnOnce.call_once D E default e)
 
 @[spec]
@@ -3666,8 +3667,8 @@ def Impl.map_err
     (op : O) :
     RustM (Result T F) := do
   match self with
-    | (Result.Ok  t) => (pure (Result.Ok t))
-    | (Result.Err  e) =>
+    | (Result.Ok  t) => do (pure (Result.Ok t))
+    | (Result.Err  e) => do
       (pure (Result.Err
         (← (core_models.ops.function.FnOnce.call_once O E op e))))
 
@@ -3692,8 +3693,8 @@ def Impl.and_then
     (op : F) :
     RustM (Result U E) := do
   match self with
-    | (Result.Ok  t) => (core_models.ops.function.FnOnce.call_once F T op t)
-    | (Result.Err  e) => (pure (Result.Err e))
+    | (Result.Ok  t) => do (core_models.ops.function.FnOnce.call_once F T op t)
+    | (Result.Err  e) => do (pure (Result.Err e))
 
 end core_models.result
 
@@ -3713,11 +3714,11 @@ instance Impl_2 (T : Type) :
       if
       (← (rust_primitives.hax.machine_int.eq
         (← (rust_primitives.sequence.seq_len T (Iter._0 self)))
-        (0 : usize))) then
+        (0 : usize))) then do
         (pure (rust_primitives.hax.Tuple2.mk
           self
           core_models.option.Option.None))
-      else
+      else do
         let res : T ← (rust_primitives.sequence.seq_first T (Iter._0 self));
         let self : (Iter T) :=
           {self
@@ -3743,15 +3744,15 @@ instance Impl_3 (T : Type) :
       if
       (← (rust_primitives.hax.machine_int.eq
         (← (rust_primitives.slice.slice_length T (Chunks.elements self)))
-        (0 : usize))) then
+        (0 : usize))) then do
         (pure (rust_primitives.hax.Tuple2.mk
           self
           core_models.option.Option.None))
-      else
+      else do
         if
         (← (rust_primitives.hax.machine_int.lt
           (← (rust_primitives.slice.slice_length T (Chunks.elements self)))
-          (Chunks.cs self))) then
+          (Chunks.cs self))) then do
           let res : (RustSlice T) := (Chunks.elements self);
           let self : (Chunks T) :=
             {self
@@ -3762,7 +3763,7 @@ instance Impl_3 (T : Type) :
           (pure (rust_primitives.hax.Tuple2.mk
             self
             (core_models.option.Option.Some res)))
-        else
+        else do
           let ⟨res, new_elements⟩ ←
             (rust_primitives.slice.slice_split_at T
               (Chunks.elements self)
@@ -3786,11 +3787,11 @@ instance Impl_4 (T : Type) :
       if
       (← (rust_primitives.hax.machine_int.lt
         (← (rust_primitives.slice.slice_length T (ChunksExact.elements self)))
-        (ChunksExact.cs self))) then
+        (ChunksExact.cs self))) then do
         (pure (rust_primitives.hax.Tuple2.mk
           self
           core_models.option.Option.None))
-      else
+      else do
         let ⟨res, new_elements⟩ ←
           (rust_primitives.slice.slice_split_at T
             (ChunksExact.elements self)

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -848,10 +848,10 @@ const _: () = {
                 } => {
                     if let Some(else_branch) = else_ {
                         docs![
-                            docs!["if", line!(), condition, reflow!(" then")].group(),
+                            docs!["if", line!(), condition, reflow!(" then do")].group(),
                             docs![line!(), then].nest(INDENT),
                             line!(),
-                            "else",
+                            reflow!("else do"),
                             docs![line!(), else_branch].nest(INDENT)
                         ]
                         .group()
@@ -1085,6 +1085,8 @@ const _: () = {
                     &arm.pat,
                     softline!(),
                     "=>",
+                    softline!(),
+                    "do",
                     line!(),
                     &arm.body
                 ]

--- a/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__cyclic-modules into-lean.snap
@@ -61,7 +61,7 @@ namespace cyclic_modules.typ_b
 
 @[spec]
 def T1_cast_to_repr (x : T1) : RustM isize := do
-  match x with | (T1.T1 ) => (pure (0 : isize))
+  match x with | (T1.T1 ) => do (pure (0 : isize))
 
 inductive T2 : Type
 | T2 : cyclic_modules.typ_a.T -> T2
@@ -155,7 +155,9 @@ inductive T : Type
 
 @[spec]
 def T_cast_to_repr (x : T) : RustM isize := do
-  match x with | (T.t1 ) => (pure (0 : isize)) | (T.t2 ) => (pure (1 : isize))
+  match x with
+    | (T.t1 ) => do (pure (0 : isize))
+    | (T.t2 ) => do (pure (1 : isize))
 
 end cyclic_modules.rec
 
@@ -354,7 +356,7 @@ namespace cyclic_modules.rec
 
 @[spec]
 def hf (x : T) : RustM T := do
-  match x with | (T.t1 ) => (hf T.t2) | (T.t2 ) => (pure x)
+  match x with | (T.t1 ) => do (hf T.t2) | (T.t2 ) => do (pure x)
 partial_fixpoint
 
 end cyclic_modules.rec
@@ -364,9 +366,9 @@ namespace cyclic_modules.rec2_same_name
 
 @[spec]
 def f (x : i32) : RustM i32 := do
-  if (← (rust_primitives.hax.machine_int.gt x (0 : i32))) then
+  if (← (rust_primitives.hax.machine_int.gt x (0 : i32))) then do
     (cyclic_modules.rec1_same_name.f (← (x -? (1 : i32))))
-  else
+  else do
     (pure (0 : i32))
 
 end cyclic_modules.rec2_same_name
@@ -445,11 +447,11 @@ namespace cyclic_modules.rec
 
 @[spec]
 def g2 (x : T) : RustM T := do
-  match x with | (T.t1 ) => (g1 x) | (T.t2 ) => (hf x)
+  match x with | (T.t1 ) => do (g1 x) | (T.t2 ) => do (hf x)
 
 @[spec]
 def g1 (x : T) : RustM T := do
-  match x with | (T.t1 ) => (g2 x) | (T.t2 ) => (pure T.t1)
+  match x with | (T.t1 ) => do (g2 x) | (T.t2 ) => do (pure T.t1)
 
 end cyclic_modules.rec
 

--- a/test-harness/src/snapshots/toolchain__lean-core-models into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-core-models into-lean.snap
@@ -308,8 +308,8 @@ def tests (_ : rust_primitives.hax.Tuple0) :
       (fun e =>
         (do
         match e with
-          | (E1.C1 ) => (pure E2.C1)
-          | (E1.C2  x) => (pure (E2.C2 (← (x +? (1 : u32))))) :
+          | (E1.C1 ) => do (pure E2.C1)
+          | (E1.C2  x) => do (pure (E2.C2 (← (x +? (1 : u32))))) :
         RustM E2)));
   let v9 : Bool ← (core_models.result.Impl.is_ok u32 E1 v1);
   let v10 : Bool ← (core_models.result.Impl.is_err u32 E1 v1);
@@ -338,14 +338,14 @@ def tests (_ : rust_primitives.hax.Tuple0) :
   match
     (← (core_models.result.Impl.map u32 E1 u32 (u32 -> RustM u32) v1 f))
   with
-    | (core_models.result.Result.Ok  hoist2) =>
+    | (core_models.result.Result.Ok  hoist2) => do
       match v2 with
-        | (core_models.result.Result.Ok  hoist1) =>
+        | (core_models.result.Result.Ok  hoist1) => do
           let v3 : u32 ← (hoist2 +? hoist1);
           (pure (core_models.result.Result.Ok v3))
-        | (core_models.result.Result.Err  err) =>
+        | (core_models.result.Result.Err  err) => do
           (pure (core_models.result.Result.Err err))
-    | (core_models.result.Result.Err  err) =>
+    | (core_models.result.Result.Err  err) => do
       (pure (core_models.result.Result.Err err))
 
 end lean_core_models.result

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -208,7 +208,7 @@ def C2 : u32 := RustM.of_isOk (do (C1 +? (1 : u32))) (by rfl)
 
 def C3 : u32 :=
   RustM.of_isOk
-    (do if true then (pure (890 : u32)) else ((9 : u32) /? (0 : u32)))
+    (do if true then do (pure (890 : u32)) else do ((9 : u32) /? (0 : u32)))
     (by rfl)
 
 @[spec]
@@ -319,19 +319,22 @@ namespace lean_tests.ite
 
 @[spec]
 def test1 (_ : rust_primitives.hax.Tuple0) : RustM i32 := do
-  let x : i32 ← if true then (pure (0 : i32)) else (pure (1 : i32));
-  if false then (pure (2 : i32)) else (pure (3 : i32))
+  let x : i32 ← if true then do (pure (0 : i32)) else do (pure (1 : i32));
+  if false then do (pure (2 : i32)) else do (pure (3 : i32))
 
 @[spec]
 def test2 (b : Bool) : RustM i32 := do
-  let x : i32 ← if b then (pure (0 : i32)) else (pure (9 : i32));
+  let x : i32 ← if b then do (pure (0 : i32)) else do (pure (9 : i32));
   let y : i32 := (0 : i32);
   let y : i32 ←
-    if true then ((← (y +? x)) +? (1 : i32)) else ((← (y -? x)) -? (1 : i32));
-  if b then
+    if true then do
+      ((← (y +? x)) +? (1 : i32))
+    else do
+      ((← (y -? x)) -? (1 : i32));
+  if b then do
     let z : i32 ← (y +? y);
     ((← (z +? y)) +? x)
-  else
+  else do
     let z : i32 ← (y -? x);
     ((← (z +? y)) +? x)
 
@@ -363,10 +366,10 @@ def loop2 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
       x
       (fun x i =>
         (do
-        if (← (rust_primitives.hax.machine_int.eq i (5 : u32))) then
+        if (← (rust_primitives.hax.machine_int.eq i (5 : u32))) then do
           (pure (core_models.ops.control_flow.ControlFlow.Break
             (core_models.ops.control_flow.ControlFlow.Break x)))
-        else
+        else do
           (pure (core_models.ops.control_flow.ControlFlow.Continue
             (← (x +? i)))) :
         RustM
@@ -376,8 +379,8 @@ def loop2 (_ : rust_primitives.hax.Tuple0) : RustM u32 := do
             (rust_primitives.hax.Tuple2 rust_primitives.hax.Tuple0 u32))
           u32)))))
   with
-    | (core_models.ops.control_flow.ControlFlow.Break  ret) => (pure ret)
-    | (core_models.ops.control_flow.ControlFlow.Continue  x) => (pure x)
+    | (core_models.ops.control_flow.ControlFlow.Break  ret) => do (pure ret)
+    | (core_models.ops.control_flow.ControlFlow.Continue  x) => do (pure x)
 
 def while_loop1 (s : u32) : RustM u32 := do
   let x : u32 := s;
@@ -426,11 +429,11 @@ def loop3 (_ : rust_primitives.hax.Tuple0) :
       x
       (fun x i =>
         (do
-        if (← (rust_primitives.hax.machine_int.eq i (5 : u32))) then
+        if (← (rust_primitives.hax.machine_int.eq i (5 : u32))) then do
           (pure (core_models.ops.control_flow.ControlFlow.Break
             (core_models.ops.control_flow.ControlFlow.Break
               (core_models.result.Result.Err Error.Foo))))
-        else
+        else do
           (pure (core_models.ops.control_flow.ControlFlow.Continue
             (← (x +? (5 : u32))))) :
         RustM
@@ -440,8 +443,8 @@ def loop3 (_ : rust_primitives.hax.Tuple0) :
             (rust_primitives.hax.Tuple2 rust_primitives.hax.Tuple0 u32))
           u32)))))
   with
-    | (core_models.ops.control_flow.ControlFlow.Break  ret) => (pure ret)
-    | (core_models.ops.control_flow.ControlFlow.Continue  x) =>
+    | (core_models.ops.control_flow.ControlFlow.Break  ret) => do (pure ret)
+    | (core_models.ops.control_flow.ControlFlow.Continue  x) => do
       (pure (core_models.result.Result.Ok x))
 
 @[spec]
@@ -464,11 +467,11 @@ def loop4 (_ : rust_primitives.hax.Tuple0) :
       e
       (fun e i =>
         (do
-        if (← (rust_primitives.hax.machine_int.gt i (10 : u32))) then
+        if (← (rust_primitives.hax.machine_int.gt i (10 : u32))) then do
           (pure (core_models.ops.control_flow.ControlFlow.Break
             (core_models.ops.control_flow.ControlFlow.Break
               (core_models.result.Result.Err (Error.Bar e)))))
-        else
+        else do
           (pure (core_models.ops.control_flow.ControlFlow.Continue
             (← (e +? i)))) :
         RustM
@@ -480,8 +483,8 @@ def loop4 (_ : rust_primitives.hax.Tuple0) :
             (rust_primitives.hax.Tuple2 rust_primitives.hax.Tuple0 u32))
           u32)))))
   with
-    | (core_models.ops.control_flow.ControlFlow.Break  ret) => (pure ret)
-    | (core_models.ops.control_flow.ControlFlow.Continue  e) =>
+    | (core_models.ops.control_flow.ControlFlow.Break  ret) => do (pure ret)
+    | (core_models.ops.control_flow.ControlFlow.Continue  e) => do
       (pure (core_models.result.Result.Ok (rust_primitives.hax.Tuple2.mk e e)))
 
 end lean_tests.loops.errors
@@ -492,12 +495,14 @@ namespace lean_tests.matching
 @[spec]
 def test_const_matching (x : u32) (c : Char) (s : String) (b : Bool) :
     RustM u32 := do
-  let x : u32 ← match x with | 0 => (pure (42 : u32)) | _ => (pure (0 : u32));
-  let c : u32 ← match c with | 'a' => (pure (42 : u32)) | _ => (pure (0 : u32));
+  let x : u32 ←
+    match x with | 0 => do (pure (42 : u32)) | _ => do (pure (0 : u32));
+  let c : u32 ←
+    match c with | 'a' => do (pure (42 : u32)) | _ => do (pure (0 : u32));
   let s : u32 ←
-    match s with | "Hello" => (pure (42 : u32)) | _ => (pure (0 : u32));
+    match s with | "Hello" => do (pure (42 : u32)) | _ => do (pure (0 : u32));
   let b : u32 ←
-    match b with | true => (pure (42 : u32)) | false => (pure (0 : u32));
+    match b with | true => do (pure (42 : u32)) | false => do (pure (0 : u32));
   ((← ((← (x +? c)) +? s)) +? b)
 
 @[spec]
@@ -505,10 +510,10 @@ def test_binding_subpattern_matching
     (x : (rust_primitives.hax.Tuple2 u8 (rust_primitives.hax.Tuple2 u8 u8))) :
     RustM u8 := do
   match x with
-    | ⟨0, pair@⟨a, b⟩⟩ =>
+    | ⟨0, pair@⟨a, b⟩⟩ => do
       ((← ((← (a +? b)) +? (rust_primitives.hax.Tuple2._0 pair)))
         +? (rust_primitives.hax.Tuple2._1 pair))
-    | _ => (pure (0 : u8))
+    | _ => do (pure (0 : u8))
 
 end lean_tests.matching
 
@@ -527,21 +532,22 @@ def test (_ : rust_primitives.hax.Tuple0) :
   let _ := (S.mk (f := (← ((9 : u32) +? (9 : u32)))));
   let _ := (S.f (S.mk (f := (← ((9 : u32) +? (9 : u32))))));
   let _ ← ((S.f (S.mk (f := (← ((9 : u32) +? (9 : u32)))))) +? (9 : u32));
-  let _ ← if true then ((3 : i32) +? (4 : i32)) else ((3 : i32) -? (4 : i32));
+  let _ ←
+    if true then do ((3 : i32) +? (4 : i32)) else do ((3 : i32) -? (4 : i32));
   let _ ←
     if
     (← (rust_primitives.hax.machine_int.eq
       (← ((9 : i32) +? (9 : i32)))
-      (0 : i32))) then
+      (0 : i32))) then do
       ((3 : i32) +? (4 : i32))
-    else
+    else do
       ((3 : i32) -? (4 : i32));
   let _ ←
-    if true then
+    if true then do
       let x : i32 := (9 : i32);
       let _ ← ((3 : i32) +? x);
       (pure rust_primitives.hax.Tuple0.mk)
-    else
+    else do
       let y : i32 := (19 : i32);
       let _ ← ((← ((3 : i32) +? y)) -? (4 : i32));
       (pure rust_primitives.hax.Tuple0.mk);
@@ -588,11 +594,12 @@ namespace lean_tests.nested_control_flow
 def nested_control_flow (_ : rust_primitives.hax.Tuple0) :
     RustM rust_primitives.hax.Tuple0 := do
   let x1 : i32 ←
-    ((1 : i32) +? (← if true then (pure (0 : i32)) else (pure (1 : i32))));
+    ((1 : i32)
+      +? (← if true then do (pure (0 : i32)) else do (pure (1 : i32))));
   let x2 : i32 ←
     ((1 : i32)
       +? (← match (rust_primitives.hax.Tuple2.mk (1 : i32) (2 : i32)) with
-        | _ => (pure (0 : i32))));
+        | _ => do (pure (0 : i32))));
   let x : i32 := (9 : i32);
   let x3 : i32 ← ((1 : i32) +? (← (x +? (1 : i32))));
   (pure rust_primitives.hax.Tuple0.mk)
@@ -600,11 +607,11 @@ def nested_control_flow (_ : rust_primitives.hax.Tuple0) :
 @[spec]
 def explicit_hoisting (_ : rust_primitives.hax.Tuple0) :
     RustM rust_primitives.hax.Tuple0 := do
-  let x1_tmp : i32 ← if true then (pure (0 : i32)) else (pure (1 : i32));
+  let x1_tmp : i32 ← if true then do (pure (0 : i32)) else do (pure (1 : i32));
   let x1 : i32 ← ((1 : i32) +? x1_tmp);
   let x2_tmp : i32 ←
     match (rust_primitives.hax.Tuple2.mk (1 : i32) (2 : i32)) with
-      | _ => (pure (0 : i32));
+      | _ => do (pure (0 : i32));
   let x2 : i32 ← ((1 : i32) +? x2_tmp);
   let x3_tmp_x : i32 := (9 : i32);
   let x3_tmp : i32 ← (x3_tmp_x +? (1 : i32));
@@ -619,38 +626,38 @@ def complex_nesting (_ : rust_primitives.hax.Tuple0) :
       rust_primitives.hax.Tuple0)
     := do
   let x1 : i32 ←
-    if true then
+    if true then do
       let y : i32 ←
-        if false then
+        if false then do
           let z : i32 ←
-            match rust_primitives.hax.Tuple0.mk with | _ => (pure (9 : i32));
+            match rust_primitives.hax.Tuple0.mk with | _ => do (pure (9 : i32));
           let z : i32 ← ((1 : i32) +? z);
           (z +? (1 : i32))
-        else
+        else do
           let z : i32 := (9 : i32);
           let z : i32 ← (z +? (1 : i32));
           (pure z);
       let y : i32 ← (y +? (1 : i32));
       (y +? (1 : i32))
-    else
+    else do
       (pure (0 : i32));
   let x1 : i32 ← (x1 +? (1 : i32));
   let x2 : i32 ←
     match (core_models.option.Option.Some (89 : i32)) with
-      | (core_models.option.Option.Some  a) =>
+      | (core_models.option.Option.Some  a) => do
         let y : i32 ← ((1 : i32) +? a);
         let y : i32 ← (y +? (1 : i32));
-        if (← (rust_primitives.hax.machine_int.eq y (0 : i32))) then
+        if (← (rust_primitives.hax.machine_int.eq y (0 : i32))) then do
           let z : i32 := (9 : i32);
           let z : i32 ← ((← (z +? y)) +? (1 : i32));
           (pure z)
-        else
+        else do
           (pure (10 : i32))
-      | (core_models.option.Option.None ) =>
+      | (core_models.option.Option.None ) => do
         let y : i32 ←
-          if false then
+          if false then do
             (pure (9 : i32))
-          else
+          else do
             let z : i32 := (9 : i32);
             let z : i32 ← (z +? (1 : i32));
             (z +? (9 : i32));
@@ -903,15 +910,15 @@ def tuple_structs (_ : rust_primitives.hax.Tuple0) :
   let _ := (T2._0 (T2._1 (T3p._1 t3p)));
   let _ := (T2._0 (T3p._1 t3p));
   let _ := (T2._1 (T3p._1 t3p));
-  let _ ← match t0 with | ⟨⟩ => (pure rust_primitives.hax.Tuple0.mk);
-  let _ ← match t1 with | ⟨u1⟩ => (pure rust_primitives.hax.Tuple0.mk);
-  let _ ← match t2 with | ⟨u2, u3⟩ => (pure rust_primitives.hax.Tuple0.mk);
+  let _ ← match t0 with | ⟨⟩ => do (pure rust_primitives.hax.Tuple0.mk);
+  let _ ← match t1 with | ⟨u1⟩ => do (pure rust_primitives.hax.Tuple0.mk);
+  let _ ← match t2 with | ⟨u2, u3⟩ => do (pure rust_primitives.hax.Tuple0.mk);
   let _ ←
     match t3 with
-      | ⟨⟨⟩, ⟨u1⟩, ⟨u2, u3⟩⟩ => (pure rust_primitives.hax.Tuple0.mk);
+      | ⟨⟨⟩, ⟨u1⟩, ⟨u2, u3⟩⟩ => do (pure rust_primitives.hax.Tuple0.mk);
   let _ ←
     match t3p with
-      | ⟨⟨⟩, ⟨⟨u1⟩, ⟨u2, u3⟩⟩⟩ => (pure rust_primitives.hax.Tuple0.mk);
+      | ⟨⟨⟩, ⟨⟨u1⟩, ⟨u2, u3⟩⟩⟩ => do (pure rust_primitives.hax.Tuple0.mk);
   (pure rust_primitives.hax.Tuple0.mk)
 
 structure S1 where
@@ -967,17 +974,17 @@ def normal_structs (_ : rust_primitives.hax.Tuple0) :
       (S3._theorem s3));
   let _ ←
     match s1 with
-      | {f1 := f1, f2 := f2} => (pure rust_primitives.hax.Tuple0.mk);
+      | {f1 := f1, f2 := f2} => do (pure rust_primitives.hax.Tuple0.mk);
   let _ ←
     match s2 with
-      | {f1 := {f1 := f1, f2 := other_name_for_f2}, f2 := f2} =>
+      | {f1 := {f1 := f1, f2 := other_name_for_f2}, f2 := f2} => do
         (pure rust_primitives.hax.Tuple0.mk);
   match s3 with
     | {_end := _end,
        _def := _def,
        _theorem := _theorem,
        _structure := _structure,
-       _inductive := _inductive} =>
+       _inductive := _inductive} => do
       (pure rust_primitives.hax.Tuple0.mk)
 
 end lean_tests.structs
@@ -995,9 +1002,9 @@ def test_tuples (_ : rust_primitives.hax.Tuple0) :
   let constr : S := (S.mk (f := (42 : i32)));
   let proj : i32 := (S.f constr);
   let ite : (rust_primitives.hax.Tuple2 i32 i32) ←
-    if true then
+    if true then do
       (pure (rust_primitives.hax.Tuple2.mk (1 : i32) (2 : i32)))
-    else
+    else do
       let z : i32 ← ((1 : i32) +? (2 : i32));
       (pure (rust_primitives.hax.Tuple2.mk z z));
   (pure (rust_primitives.hax.Tuple2.mk (1 : i32) (2 : i32)))
@@ -1357,7 +1364,7 @@ instance Impl_2 : T1 (S usize) where
 
 instance Impl_3 : T1 (S Bool) where
   f1 := fun (self : (S Bool)) => do
-    if (S._1 self) then (pure (S._0 self)) else (pure (9 : usize))
+    if (S._1 self) then do (pure (S._0 self)) else do (pure (9 : usize))
   f2 := fun (self : (S Bool)) => do ((S._0 self) +? (1 : usize))
 
 @[reducible] instance Impl_4.AssociatedTypes :
@@ -1663,9 +1670,9 @@ namespace lean_tests.recursion
 
 @[spec]
 def factorial (n : u32) : RustM u32 := do
-  if (← (rust_primitives.hax.machine_int.eq n (0 : u32))) then
+  if (← (rust_primitives.hax.machine_int.eq n (0 : u32))) then do
     (pure (1 : u32))
-  else
+  else do
     (n *? (← (factorial (← (n -? (1 : u32))))))
 partial_fixpoint
 
@@ -1848,16 +1855,16 @@ def enums (_ : rust_primitives.hax.Tuple0) :
   let cons_2_1 : (MyList usize) :=
     (MyList.Cons (hd := (2 : usize)) (tl := cons_1));
   match e_v1 with
-    | (E.V1 ) => (pure rust_primitives.hax.Tuple0.mk)
-    | (E.V2 ) => (pure rust_primitives.hax.Tuple0.mk)
-    | (E.V3  _) => (pure rust_primitives.hax.Tuple0.mk)
-    | (E.V4  x1 x2 x3) =>
+    | (E.V1 ) => do (pure rust_primitives.hax.Tuple0.mk)
+    | (E.V2 ) => do (pure rust_primitives.hax.Tuple0.mk)
+    | (E.V3  _) => do (pure rust_primitives.hax.Tuple0.mk)
+    | (E.V4  x1 x2 x3) => do
       let y1 : usize ← (x1 +? x2);
       let y2 : usize ← (y1 -? x2);
       let y3 : usize ← (y2 +? x3);
       (pure rust_primitives.hax.Tuple0.mk)
-    | (E.V5  (f1 := f1) (f2 := f2)) => (pure rust_primitives.hax.Tuple0.mk)
-    | (E.V6  (f1 := f1) (f2 := other_name_for_f2)) =>
+    | (E.V5  (f1 := f1) (f2 := f2)) => do (pure rust_primitives.hax.Tuple0.mk)
+    | (E.V6  (f1 := f1) (f2 := other_name_for_f2)) => do
       (pure rust_primitives.hax.Tuple0.mk)
 
 end lean_tests.enums


### PR DESCRIPTION
Fixes #1741

I've asked on the Lean Zulip about this issue:
[#lean4 > &#96;←&#96; inside if-then-else](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/.60.E2.86.90.60.20inside.20if-then-else/with/574271429)
But it seems that one needs to add a `do` to be able to use the `<-` notation inside if-then-else.

[skip changelog]