### PR TITLE
fix(lean): Remove unnecessary noncomputable tags

### DIFF
--- a/hax-lib/proof-libs/lean/Hax/rust_primitives/RustM.lean
+++ b/hax-lib/proof-libs/lean/Hax/rust_primitives/RustM.lean
@@ -120,9 +120,9 @@ open Lean.Order
 
 instance {α} : PartialOrder (RustM α) := inferInstanceAs (PartialOrder (FlatOrder RustM.div))
 
-noncomputable instance {α} : CCPO (RustM α) := inferInstanceAs (CCPO (FlatOrder RustM.div))
+instance {α} : CCPO (RustM α) := inferInstanceAs (CCPO (FlatOrder RustM.div))
 
-noncomputable instance : MonoBind RustM where
+instance : MonoBind RustM where
   bind_mono_left h := by
     cases h
     · exact FlatOrder.rel.bot

--- a/hax-lib/proof-libs/lean/Hax/rust_primitives/hax/while_loop.lean
+++ b/hax-lib/proof-libs/lean/Hax/rust_primitives/hax/while_loop.lean
@@ -16,7 +16,7 @@ open Lean
   extra arguments to store a termination measure and an invariant, which can be used to verify the
   program. The arguments `pureInv` and `pureTermination` are usually not provided explicitly and
   derived by the default tactic given below. -/
-noncomputable def rust_primitives.hax.while_loop {β : Type}
+def rust_primitives.hax.while_loop {β : Type}
     (inv: β → RustM Prop)
     (cond: β → RustM Bool)
     (termination : β -> RustM hax_lib.int.Int)


### PR DESCRIPTION
I had added the `noncomputable` tags when upgrading the Lean version. This broke the support for while loops (see #1969). It turns out that the `noncomputable` tags were not necessary after all.

Fixes #1969

[skip changelog]