### PR TITLE
add bitwise OR trait to `core_models::ops::bit` 

### DIFF
--- a/hax-lib/core-models/src/core/ops.rs
+++ b/hax-lib/core-models/src/core/ops.rs
@@ -82,6 +82,10 @@ pub mod bit {
         type Output;
         fn bitand(self, rhs: Rhs) -> Self::Output;
     }
+    trait BitOr<Rhs = Self> {
+        type Output;
+        fn bitor(self, rhs: Rhs) -> Self::Output;
+    }
 }
 
 pub mod control_flow {

--- a/hax-lib/proof-libs/fstar/core/Core_models.Ops.Bit.fsti
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Ops.Bit.fsti
@@ -34,3 +34,11 @@ class t_BitAnd (v_Self: Type0) (v_Rhs: Type0) = {
   f_bitand:x0: v_Self -> x1: v_Rhs
     -> Prims.Pure f_Output (f_bitand_pre x0 x1) (fun result -> f_bitand_post x0 x1 result)
 }
+
+class t_BitOr (v_Self: Type0) (v_Rhs: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_Output:Type0;
+  f_bitor_pre:v_Self -> v_Rhs -> Type0;
+  f_bitor_post:v_Self -> v_Rhs -> f_Output -> Type0;
+  f_bitor:x0: v_Self -> x1: v_Rhs
+    -> Prims.Pure f_Output (f_bitor_pre x0 x1) (fun result -> f_bitor_post x0 x1 result)
+}


### PR DESCRIPTION
This PR adds a missing bitwise OR trait to `core_models::ops::bit`, and generates the corresponding F* typeclass

cc @maximebuyse 