### PR TITLE
fix: report errors in `driver_for_rust_engine`

### DIFF
--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -328,7 +328,13 @@ let driver_for_rust_engine () : unit =
   in
   Concrete_ident.ImplInfoStore.init
     (Concrete_ident_generated.impl_infos @ query.impl_infos);
-  let response = driver_for_rust_engine_inner query in
+  let response, diagnostics =
+    Diagnostics.capture (fun () -> driver_for_rust_engine_inner query)
+  in
+  List.iter
+    ~f:(fun diag ->
+      Diagnostic (Diagnostics.to_thir_diagnostic diag) |> Hax_io.write)
+    diagnostics;
   send_debug_strings ();
   Hax_io.write_json ([%yojson_of: Rust_engine_types.response] response);
   Hax_io.write_json ([%yojson_of: Types.from_engine] Exit)


### PR DESCRIPTION
Fixes #1978

I heavily relied on Claude to implement this fix. I removed some unrelated changes that Claude tried to make, but what's left looks good to me.

[skip changelog]