### PR TITLE
fix: remove monad_extract_simplify

### DIFF
--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -505,11 +505,15 @@ const _: () = {
         /// Turns an expression of type `RustM T` into one of type `T` (out of the monad), providing
         /// reflexivity as a proof witness.
         fn monad_extract<A: 'static + Clone>(&self, expr: &Expr) -> DocBuilder<A> {
-            if let ExprKind::Literal(_) | ExprKind::GlobalId(_) | ExprKind::LocalId(_) = expr.kind()
+            if let ExprKind::App { head, args, .. } = expr.kind()
+                && let ExprKind::GlobalId(PURE) = head.kind()
+                && let [pure_expr] = &args[..]
+                && let ExprKind::Literal(_) | ExprKind::GlobalId(_) | ExprKind::LocalId(_) =
+                    pure_expr.kind()
             {
                 // Pure values are displayed directly. Note that constructors, while pure, may
                 // contain sub-expressions that are not, so they must be wrapped in a do-block
-                docs![expr]
+                docs![pure_expr]
             } else {
                 // All other expressions are wrapped in a do-block, and extracted out of the monad
                 docs![
@@ -521,18 +525,6 @@ const _: () = {
                 ]
                 .group()
                 .nest(INDENT)
-            }
-        }
-
-        /// When possible, unwraps the `pure` surrounding an expression to simplify it
-        fn monad_extract_simplify<A: 'static + Clone>(&self, expr: &Expr) -> DocBuilder<A> {
-            if let ExprKind::App { head, args, .. } = expr.kind()
-                && let ExprKind::GlobalId(PURE) = head.kind()
-                && let [pure_expr] = &args[..]
-            {
-                self.monad_extract(pure_expr)
-            } else {
-                self.monad_extract(expr)
             }
         }
 
@@ -592,7 +584,7 @@ const _: () = {
                         .group(),
                         line!(),
                         if params.is_empty() {
-                            self.monad_extract_simplify(body)
+                            self.monad_extract(body)
                         } else {
                             docs![body]
                         },
@@ -869,7 +861,7 @@ const _: () = {
         fn generic_value(&self, generic_value: &GenericValue) -> DocBuilder<A> {
             match generic_value {
                 GenericValue::Ty(ty) => docs![ty],
-                GenericValue::Expr(expr) => docs![self.monad_extract(expr)].parens(),
+                GenericValue::Expr(expr) => docs![expr].parens(),
                 GenericValue::Lifetime => unreachable_by_invariant!(Drop_references),
             }
         }
@@ -1893,7 +1885,7 @@ const _: () = {
                         ]
                         .group(),
                         line!(),
-                        self.monad_extract_simplify(body),
+                        self.monad_extract(body),
                     ]
                     .group()
                     .nest(INDENT),
@@ -1974,7 +1966,7 @@ const _: () = {
                         softline!(),
                         ":=",
                         softline!(),
-                        self.monad_extract_simplify(body)
+                        self.monad_extract(body)
                     ]
                 }
                 ImplItemKind::Error(err) => docs!(err),

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -322,6 +322,17 @@ def computation (x : u32) : RustM u32 := do ((← (x +? x)) +? (1 : u32))
 
 def C4 : u32 := RustM.of_isOk (do ((← (computation C1)) +? C2)) (by rfl)
 
+def C5 : (rust_primitives.hax.Tuple2 u32 u32) :=
+  RustM.of_isOk
+    (do
+    (pure (rust_primitives.hax.Tuple2.mk
+      (← ((0 : u32) +? (0 : u32)))
+      (0 : u32))))
+    (by rfl)
+
+def C6 : (RustArray u32 1) :=
+  RustM.of_isOk (do (pure (RustArray.ofVec #v[(0 : u32)]))) (by rfl)
+
 @[spec]
 def test (_ : rust_primitives.hax.Tuple0) :
     RustM rust_primitives.hax.Tuple0 := do
@@ -1628,7 +1639,7 @@ class Foo (Self : Type)
   [associatedTypes : outParam (Foo.AssociatedTypes (Self : Type))]
   where
   f (Self) : Bool
-  x (Self) : u8
+  x (Self) :u8 := (0 : u8)
 
 structure Bar where
   -- no fields

--- a/test-harness/src/snapshots/toolchain__literals into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__literals into-lean.snap
@@ -151,7 +151,8 @@ structure Foo where
   core_models.cmp.Eq Foo :=
   by constructor <;> exact Inhabited.default
 
-def CONSTANT : Foo := RustM.of_isOk (do (Foo.mk (field := (3 : u8)))) (by rfl)
+def CONSTANT : Foo :=
+  RustM.of_isOk (do (pure (Foo.mk (field := (3 : u8))))) (by rfl)
 
 @[spec]
 def numeric (_ : rust_primitives.hax.Tuple0) :

--- a/tests/lean-tests/src/constants.rs
+++ b/tests/lean-tests/src/constants.rs
@@ -11,6 +11,8 @@ const fn computation(x: u32) -> u32 {
 }
 
 const C4: u32 = computation(C1) + C2;
+const C5: (u32, u32) = (0 + 0, 0);
+const C6: [u32; 1] = [0];
 
 fn test() {
     let x = C1 + 1;

--- a/tests/lean-tests/src/traits.rs
+++ b/tests/lean-tests/src/traits.rs
@@ -325,9 +325,9 @@ mod trait_with_constraints {
 }
 
 mod associated_constant {
-    pub trait Foo { 
+    pub trait Foo {
         const f: bool;
-        const x: u8;
+        const x: u8 = 0;
     }
 
     pub struct Bar;
@@ -339,10 +339,10 @@ mod associated_constant {
 
     // https://github.com/cryspen/hax/issues/1940
     trait Baz {
-        const One : u32 = 1;
+        const One: u32 = 1;
     }
 
-    fn foo<F: Baz> (n : u32) -> u32 {
+    fn foo<F: Baz>(n: u32) -> u32 {
         n + F::One
     }
 }


### PR DESCRIPTION
Fixes #1990

This bug was triggered by me removing the `RustM a` to `a` conversion. Still, I believe removing it was the right call since it will help Lean to infer types more easily.

Here's what went wrong as a result in the Lean printer: When defining a Rust `const` such as `const A: [u32; 1] = [0];`, the Lean printer receives an expression of the form `pure (RustArray.ofVec ...)` to print. Before this PR, the Lean printer would call `monad_extract_simplify`, which would remove the `pure`. Then, `monad_extract` would see that `RustArray.ofVec ...` might potentially contain monadic computation and wrap it into `RustM.of_isOk`. But `RustM.of_isOk` expects a monadic argument, so it was a mistake to remove the `pure`.

I have now merged `monad_extract_simplify` and `monad_extract` into a single function, which will not remove the `pure` in the problematic case. This will do the right thing in all places where we previously called `monad_extract_simplify`.

But there is also one case where we called `monad_extract` directly: in generic arguments of functions. I don't think this is necessary at all, so I removed the function call there.

[skip changelog]