### PR TITLE
refactor: redefine RustM monad using ExceptT Error Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes to hax-lib:
  - Lean lib: For-loops for all unsigned integers (#1951)
  - Lean lib: Upgrade to Lean v4.29.0-rc1 (#1962)
  - Lean lib: Add support for Int128 and UInt128 while waiting for upstream in Lean (#1968)
+ - Lean lib: Refactor `RustM` as `ExceptT Error Option` (#1994)
 
 Changes to the Lean backend:
  - Add `hax_zify` and `hax_construct_pure` tactics (#1888)

--- a/hax-lib/proof-libs/lean/Hax/rust_primitives/BVDecide.lean
+++ b/hax-lib/proof-libs/lean/Hax/rust_primitives/BVDecide.lean
@@ -18,44 +18,46 @@ structure BVRustM (α : Type) where
   err : BitVec 3
 
 /-- Encodes `RustM` values into `BVRustM` to be able to run `bv_decide`. -/
-def RustM.toBVRustM {α} [Inhabited α] : RustM α → BVRustM α
-| ok v                      => ⟨ true, v, 0 ⟩
-| fail .assertionFailure    => ⟨ false, default, 0 ⟩
-| fail .integerOverflow     => ⟨ false, default, 1 ⟩
-| fail .divisionByZero      => ⟨ false, default, 2 ⟩
-| fail .arrayOutOfBounds    => ⟨ false, default, 3 ⟩
-| fail .maximumSizeExceeded => ⟨ false, default, 4 ⟩
-| fail .panic               => ⟨ false, default, 5 ⟩
-| fail .undef               => ⟨ false, default, 6 ⟩
-| div                       => ⟨ false, default, 7 ⟩
+def RustM.toBVRustM {α : Type} [Inhabited α] : RustM α → BVRustM α
+| .ok v                      => ⟨ true, v, 0 ⟩
+| .fail .assertionFailure    => ⟨ false, default, 0 ⟩
+| .fail .integerOverflow     => ⟨ false, default, 1 ⟩
+| .fail .divisionByZero      => ⟨ false, default, 2 ⟩
+| .fail .arrayOutOfBounds    => ⟨ false, default, 3 ⟩
+| .fail .maximumSizeExceeded => ⟨ false, default, 4 ⟩
+| .fail .panic               => ⟨ false, default, 5 ⟩
+| .fail .undef               => ⟨ false, default, 6 ⟩
+| .div                       => ⟨ false, default, 7 ⟩
 
-attribute [hax_bv_decide] Coe.coe bind pure
+attribute [hax_bv_decide] Coe.coe
 
-@[hax_bv_decide] theorem RustM.toBVRustM_ok {α} [Inhabited α] {v : α} :
+@[hax_bv_decide] theorem RustM.toBVRustM_pure {α : Type} [Inhabited α] {v : α} :
+    (pure v : RustM α).toBVRustM = ⟨ true, v, 0 ⟩ := rfl
+@[hax_bv_decide] theorem RustM.toBVRustM_ok {α : Type} [Inhabited α] {v : α} :
     (RustM.ok v).toBVRustM = ⟨ true, v, 0 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_assertionFailure {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_assertionFailure {α : Type} [Inhabited α] :
     (RustM.fail .assertionFailure : RustM α).toBVRustM = ⟨ false, default, 0 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_integerOverflow {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_integerOverflow {α : Type} [Inhabited α] :
     (RustM.fail .integerOverflow : RustM α).toBVRustM = ⟨ false, default, 1 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_divisionByZero {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_divisionByZero {α : Type} [Inhabited α] :
     (RustM.fail .divisionByZero : RustM α).toBVRustM = ⟨ false, default, 2 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_arrayOutOfBounds {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_arrayOutOfBounds {α : Type} [Inhabited α] :
     (RustM.fail .arrayOutOfBounds : RustM α).toBVRustM = ⟨ false, default, 3 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_maximumSizeExceeded {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_maximumSizeExceeded {α : Type} [Inhabited α] :
     (RustM.fail .maximumSizeExceeded: RustM α).toBVRustM = ⟨ false, default, 4 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_panic {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_panic {α : Type} [Inhabited α] :
     (RustM.fail .panic : RustM α).toBVRustM = ⟨ false, default, 5 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_undef {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_undef {α : Type} [Inhabited α] :
     (RustM.fail .undef : RustM α).toBVRustM = ⟨ false, default, 6 ⟩ := rfl
-@[hax_bv_decide] theorem RustM.toBVRustM_div {α} [Inhabited α] :
+@[hax_bv_decide] theorem RustM.toBVRustM_div {α : Type} [Inhabited α] :
     (RustM.div : RustM α ).toBVRustM = ⟨ false, default, 7 ⟩ := rfl
 
 @[hax_bv_decide]
-theorem RustM.toBVRustM_ite {α} [Inhabited α] {c : Prop} [Decidable c]  (x y : RustM α) :
+theorem RustM.toBVRustM_ite {α : Type} [Inhabited α] {c : Prop} [Decidable c]  (x y : RustM α) :
     (if c then x else y).toBVRustM = (if c then x.toBVRustM else y.toBVRustM) := by grind
 
 @[hax_bv_decide]
-theorem RustM.beq_iff_toBVRustM_eq {α} [Inhabited α] [DecidableEq α] (x y : RustM α) :
+theorem RustM.beq_iff_toBVRustM_eq {α : Type} [Inhabited α] [DecidableEq α] (x y : RustM α) :
     decide (x = y) =
       (x.toBVRustM.ok == y.toBVRustM.ok &&
        x.toBVRustM.val == y.toBVRustM.val &&
@@ -68,15 +70,16 @@ theorem RustM.beq_iff_toBVRustM_eq {α} [Inhabited α] [DecidableEq α] (x y : R
     grind [toBVRustM]
 
 @[hax_bv_decide]
-theorem RustM.toBVRustM_bind {α β} [Inhabited α] [Inhabited β] (x : RustM α) (f : α → RustM β) :
-  (x.bind f).toBVRustM =
+theorem RustM.toBVRustM_bind {α β : Type} [Inhabited α] [Inhabited β] (x : RustM α) (f : α → RustM β) :
+  (x >>= f).toBVRustM =
     if x.toBVRustM.ok
     then (f x.toBVRustM.val).toBVRustM
     else {x.toBVRustM with val := default} := by
-  apply RustM.toBVRustM.match_1.splitter _ x <;> simp [bind, toBVRustM]
+  cases x using RustM.toBVRustM.match_1 <;>
+    simp [toBVRustM, Bind.bind, ExceptT.bind, ExceptT.bindCont, ExceptT.mk]
 
 @[hax_bv_decide]
-theorem RustM.Triple_iff_BitVec {α} [Inhabited α]
+theorem RustM.Triple_iff_BitVec {α : Type} [Inhabited α]
     (a : Prop) [Decidable a] (b : α → Prop) (x : RustM α) [Decidable (b x.toBVRustM.val)] :
     ⦃ ⌜ a ⌝ ⦄ x ⦃ ⇓ r => ⌜ b r ⌝ ⦄ ↔
       (!decide a || (x.toBVRustM.ok && decide (b x.toBVRustM.val))) := by

--- a/hax-lib/proof-libs/lean/Hax/rust_primitives/RustM.lean
+++ b/hax-lib/proof-libs/lean/Hax/rust_primitives/RustM.lean
@@ -31,86 +31,68 @@ inductive Error where
 deriving Repr, BEq, DecidableEq
 open Error
 
+
 /--
   RustM monad (corresponding to Aeneas's `Result` monad), representing
-  possible results of rust computations
+  possible results of rust computations.
+
+  Defined as `ExceptT Error Option`, i.e. `Option (Except Error α)`.
+  The `Option` layer models divergence and the `Except Error` layer models
+  Rust panics. The `ExceptT` transformer ensures that once a program has
+  paniced, it can not diverge any more (and vice versa).
 -/
-inductive RustM.{u} (α : Type u) where
-  | ok (v: α): RustM α
-  | fail (e: Error): RustM α
-  | div
-deriving Repr, BEq, DecidableEq, Inhabited
+def RustM (α : Type) := ExceptT Error Option α
 
 namespace RustM
 
-@[hax_bv_decide, reducible, simp]
-instance instPure: Pure RustM where
-  pure x := .ok x
+-- These `Except` instances are missing in Lean's library.
+-- We use them to derive the corresponding `RustM` instances below.
+deriving instance BEq, DecidableEq for Except
 
-def bind {α β : Type} (x: RustM α) (f: α -> RustM β) := match x with
-  | .ok v => f v
-  | .fail e => .fail e
-  | .div => .div
+instance instBEq {α : Type} [BEq α] : BEq (RustM α) :=
+  inferInstanceAs (BEq (Option (Except Error α)))
+instance instDecidableEq {α : Type} [DecidableEq α] : DecidableEq (RustM α) :=
+  inferInstanceAs (DecidableEq (Option (Except Error α)))
+instance instInhabited {α : Type} : Inhabited (RustM α) :=
+  inferInstanceAs (Inhabited (Option (Except Error α)))
+instance instMonad : Monad RustM :=
+  inferInstanceAs (Monad (ExceptT Error Option))
+instance instLawfulMonad : LawfulMonad RustM :=
+  inferInstanceAs (LawfulMonad (ExceptT Error Option))
 
-def ofOption {α} (x:Option α) (e: Error) : RustM α := match x with
+@[reducible, match_pattern] def ok {α : Type} (v : α) : RustM α := some (.ok v)
+@[reducible, match_pattern] def fail {α : Type} (e : Error) : RustM α := some (.error e)
+@[reducible, match_pattern] def div {α : Type} : RustM α := none
+
+instance {α : Type} [Repr α] : Repr (RustM α) where
+  reprPrec x prec := match x with
+    | .ok v   => Repr.addAppParen (f!"RustM.ok {reprArg v}") prec
+    | .fail e => Repr.addAppParen (f!"RustM.fail {reprArg e}") prec
+    | .div    => "RustM.div"
+
+def ofOption {α : Type} (x : Option α) (e : Error) : RustM α :=
+  match x with
   | .some v => pure v
   | .none => .fail e
 
 @[reducible]
-def isOk {α : Type} (x: RustM α) : Bool := match x with
-| .ok _ => true
-| _ => false
+def isOk {α : Type} (x : RustM α) : Bool :=
+  match x with
+  | .ok _ => true
+  | _ => false
 
 @[reducible, specset bv, hax_bv_decide]
-def of_isOk {α : Type} (x: RustM α) (h: RustM.isOk x): α :=
+def of_isOk {α : Type} (x : RustM α) (h : RustM.isOk x) : α :=
   match x with
   | .ok v => v
 
 @[simp, spec]
-def ok_of_isOk {α : Type} (v : α) (h: isOk (ok v)): (ok v).of_isOk h = v := by rfl
+def ok_of_isOk {α : Type} (v : α) (h : isOk (ok v)) : (ok v).of_isOk h = v := by rfl
 
-@[hax_bv_decide]
-instance instMonad : Monad RustM where
-  pure := pure
-  bind := RustM.bind
-
-instance instLawfulMonad : LawfulMonad RustM where
-  id_map x := by
-    dsimp [id, Functor.map, RustM.bind, instPure]
-    cases x;
-    all_goals grind
-  map_const := by
-    intros α β
-    dsimp [Functor.map, Functor.mapConst]
-  seqLeft_eq x y := by
-    dsimp [Functor.map, SeqLeft.seqLeft, Seq.seq, pure, bind]
-    cases x ; all_goals cases y
-    all_goals try simp
-  seqRight_eq x y := by
-    dsimp [Functor.map, SeqRight.seqRight, Seq.seq, pure, bind]
-    cases x ; all_goals cases y
-    all_goals try simp
-  pure_seq g x := by
-    dsimp [Functor.map, Seq.seq, pure, bind]
-  bind_pure_comp f x := by
-    dsimp [Functor.map, pure, bind, instMonad, Bind.bind]
-  bind_map f x := by
-    dsimp [Functor.map, bind, pure, Seq.seq, instMonad, Bind.bind]
-  pure_bind x f := by
-    dsimp [pure, bind, instMonad, Bind.bind]
-  bind_assoc x f g := by
-    dsimp [pure, bind, instMonad, Bind.bind]
-    cases x; all_goals simp
-
-instance instWP : WP RustM (.except Error .pure) where
-  wp x := match x with
-  | .ok v => wp (Pure.pure v : Except Error _)
-  | .fail e => wp (throw e : Except Error _)
-  | .div => PredTrans.const ⌜False⌝
-
-instance instWPMonad : WPMonad RustM (.except Error .pure) where
-  wp_pure := by intros; ext Q; rfl
-  wp_bind x f := by ext Q; cases x <;> rfl
+instance instWP : WP RustM (.except Error (.except PUnit .pure)) :=
+  inferInstanceAs (WP (ExceptT Error Option) _)
+instance instWPMonad : WPMonad RustM (.except Error (.except PUnit .pure)) :=
+  inferInstanceAs (WPMonad (ExceptT Error Option) _)
 
 section Order
 
@@ -118,20 +100,9 @@ open Lean.Order
 
 /- These instances are required to use `partial_fixpoint` in the `RustM` monad. -/
 
-instance {α} : PartialOrder (RustM α) := inferInstanceAs (PartialOrder (FlatOrder RustM.div))
-
-instance {α} : CCPO (RustM α) := inferInstanceAs (CCPO (FlatOrder RustM.div))
-
-instance : MonoBind RustM where
-  bind_mono_left h := by
-    cases h
-    · exact FlatOrder.rel.bot
-    · exact FlatOrder.rel.refl
-  bind_mono_right h := by
-    cases ‹RustM _›
-    · exact h _
-    · exact FlatOrder.rel.refl
-    · exact FlatOrder.rel.refl
+instance {α : Type} : PartialOrder (RustM α) := inferInstanceAs (PartialOrder (ExceptT Error Option α))
+instance {α : Type} : CCPO (RustM α) := inferInstanceAs (CCPO (ExceptT Error Option α))
+instance : MonoBind RustM := inferInstanceAs (MonoBind (ExceptT Error Option))
 
 open Lean Order in
 /-- `Loop.MonoLoopCombinator` is used to implement while loops in `RustM`: -/


### PR DESCRIPTION
This PR redefines the `RustM` monad as `ExceptT Error Option`. The `Option` models divergence. This changes the semantics of `mayThrow` Hoare triples: They are now allowed to diverge.

The `match_pattern` attributes allow us to continue pattern matching on `ok`/`fail`/`div` as before.

Claude did most of the work here.
