### PR TITLE
feat(lean): add resugaring for ellipsis in pattern-matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Changes to the Lean backend:
  - Prettier proof_mode annotations (#1943)
  - Detect recursive functions and mark them partial_fixpoint (#1946)
  - Add more binops (#1963)
+ - Add a resugaring for ellipsis patterns (#2002)
 
 Miscellaneous:
 

--- a/rust-engine/src/ast/resugared.rs
+++ b/rust-engine/src/ast/resugared.rs
@@ -71,7 +71,17 @@ pub enum ResugaredExprKind {
 
 /// Resugared variants for patterns. This represent extra printing-only patterns, see [`super::PatKind::Resugared`].
 #[derive_group_for_ast]
-pub enum ResugaredPatKind {}
+pub enum ResugaredPatKind {
+    /// A record constructor pattern where wildcard fields are replaced by `..`.
+    ConstructWithEllipsis {
+        /// The identifier of the constructor we are matching.
+        constructor: GlobalId,
+        /// Is this a struct? (meaning, *not* a variant from an enum)
+        is_struct: bool,
+        /// Only the explicitly-bound (non-wildcard) fields.
+        fields: Vec<(GlobalId, Pat)>,
+    },
+}
 
 /// Resugared variants for types. This represent extra printing-only types, see [`super::TyKind::Resugared`].
 #[derive_group_for_ast]

--- a/rust-engine/src/backends/lean.rs
+++ b/rust-engine/src/backends/lean.rs
@@ -192,6 +192,7 @@ impl Backend for LeanBackend {
             Box::new(RecursiveFunctions),
             Box::new(FunctionsToConstants),
             Box::new(LetPure),
+            Box::new(RecordEllipsis),
         ]
     }
 
@@ -1211,7 +1212,7 @@ const _: () = {
                             .align()
                             .group()
                         } else {
-                            // Structure-like structure, using named arguments
+                            // Record-like structure, using named arguments
                             docs![intersperse!(
                                 fields.iter().map(|(id, pat)| {
                                     docs![self.render_last(id), reflow!(" :="), line!(), pat]
@@ -1235,8 +1236,51 @@ const _: () = {
                         .nest(INDENT)
                     }
                 }
-                PatKind::Resugared(_) => {
-                    unreachable!("This backend does not use resugarings on patterns")
+                PatKind::Resugared(ResugaredPatKind::ConstructWithEllipsis {
+                    constructor,
+                    is_struct,
+                    fields,
+                }) => {
+                    if *is_struct {
+                        // Struct: render as `{f1 := pat, f2 := pat, ..}` or `_`
+                        if fields.is_empty() {
+                            docs!["_"]
+                        } else {
+                            docs![intersperse!(
+                                fields
+                                    .iter()
+                                    .map(|(id, pat)| {
+                                        docs![self.render_last(id), reflow!(" :="), line!(), pat]
+                                            .group()
+                                    })
+                                    .chain(std::iter::once(docs![".."])),
+                                docs![",", line!()]
+                            )]
+                            .align()
+                            .braces()
+                            .group()
+                        }
+                    } else {
+                        // Enum variant with named fields: (f1 := pat) (f2 := pat) ..
+                        let record_part = if fields.is_empty() {
+                            docs!["_"]
+                        } else {
+                            docs![intersperse!(
+                                fields.iter().map(|(id, pat)| {
+                                    docs![self.render_last(id), reflow!(" :="), line!(), pat]
+                                        .group()
+                                        .parens()
+                                }),
+                                line!()
+                            )]
+                            .align()
+                            .group()
+                        };
+                        docs![constructor, line!(), record_part, " .."]
+                            .parens()
+                            .group()
+                            .nest(INDENT)
+                    }
                 }
                 PatKind::Error(_) => {
                     // TODO : Should be made unreachable by https://github.com/cryspen/hax/pull/1672

--- a/rust-engine/src/resugarings.rs
+++ b/rust-engine/src/resugarings.rs
@@ -186,3 +186,41 @@ impl Resugaring for RecursiveFunctions {
         "recursive-functions".to_string()
     }
 }
+
+/// Record ellipsis resugaring. Identifies record-like `Construct` patterns where
+/// some fields are wildcards and resugars them into `ConstructWithEllipsis`,
+/// dropping the wildcard fields so the printer can emit `..`.
+pub struct RecordEllipsis;
+
+impl AstVisitorMut for RecordEllipsis {
+    fn enter_pat_kind(&mut self, x: &mut PatKind) {
+        let PatKind::Construct {
+            constructor,
+            is_record: true,
+            is_struct,
+            fields,
+        } = x
+        else {
+            return;
+        };
+        let non_wild: Vec<_> = fields
+            .iter()
+            .filter(|(_, pat)| !matches!(&*pat.kind, PatKind::Wild))
+            .cloned()
+            .collect();
+        if non_wild.len() < fields.len() {
+            *x = ResugaredPatKind::ConstructWithEllipsis {
+                constructor: *constructor,
+                is_struct: *is_struct,
+                fields: non_wild,
+            }
+            .into();
+        }
+    }
+}
+
+impl Resugaring for RecordEllipsis {
+    fn name(&self) -> String {
+        "record-ellipsis".to_string()
+    }
+}

--- a/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
+++ b/test-harness/src/snapshots/toolchain__lean-tests into-lean.snap
@@ -679,24 +679,18 @@ def test_ellipsis_records (_ : rust_primitives.hax.Tuple0) :
       (f3 := (3 : u8))
       (f4 := (4 : u8)));
   let _ ←
-    match c with
-      | (test_ellipsis_records.E.C  (f1 := _) (f2 := _) (f3 := _) (f4 := _)) =>
-        do
-        (hax_lib.assert true);
+    match c with | (test_ellipsis_records.E.C _ ..) => do (hax_lib.assert true);
   let _ ←
     match c with
-      | (test_ellipsis_records.E.C  (f1 := f1) (f2 := _) (f3 := _) (f4 := _)) =>
-        do
+      | (test_ellipsis_records.E.C (f1 := f1) ..) => do
         (hax_lib.assert (← (f1 ==? (1 : u8))));
   let _ ←
     match c with
-      | (test_ellipsis_records.E.C  (f1 := f1) (f2 := f2) (f3 := _) (f4 := _))
-        => do
+      | (test_ellipsis_records.E.C (f1 := f1) (f2 := f2) ..) => do
         (hax_lib.assert (← ((← (f1 ==? (1 : u8))) &&? (← (f2 ==? (2 : u8))))));
   let _ ←
     match c with
-      | (test_ellipsis_records.E.C  (f1 := _) (f2 := f2) (f3 := _) (f4 := f4))
-        => do
+      | (test_ellipsis_records.E.C (f2 := f2) (f4 := f4) ..) => do
         (hax_lib.assert (← ((← (f2 ==? (2 : u8))) &&? (← (f4 ==? (4 : u8))))));
   let _ ←
     match c with
@@ -723,20 +717,16 @@ def test_ellipsis_structs (_ : rust_primitives.hax.Tuple0) :
       (f2 := (2 : u8))
       (f3 := (3 : u8))
       (f4 := (4 : u8)));
+  let _ ← match c with | _ => do (hax_lib.assert true);
+  let _ ←
+    match c with | {f1 := f1, ..} => do (hax_lib.assert (← (f1 ==? (1 : u8))));
   let _ ←
     match c with
-      | {f1 := _, f2 := _, f3 := _, f4 := _} => do (hax_lib.assert true);
-  let _ ←
-    match c with
-      | {f1 := f1, f2 := _, f3 := _, f4 := _} => do
-        (hax_lib.assert (← (f1 ==? (1 : u8))));
-  let _ ←
-    match c with
-      | {f1 := f1, f2 := f2, f3 := _, f4 := _} => do
+      | {f1 := f1, f2 := f2, ..} => do
         (hax_lib.assert (← ((← (f1 ==? (1 : u8))) &&? (← (f2 ==? (2 : u8))))));
   let _ ←
     match c with
-      | {f1 := _, f2 := f2, f3 := _, f4 := f4} => do
+      | {f2 := f2, f4 := f4, ..} => do
         (hax_lib.assert (← ((← (f2 ==? (2 : u8))) &&? (← (f4 ==? (4 : u8))))));
   let _ ←
     match c with


### PR DESCRIPTION
While #2001 adds patterns for every field of records and tuples, this PR introduces a resugaring that remove those empty patterns in favor of Lean's ellipsis, when possible. For instance: 

```rust 
match c {
  E::C {f1, ..} => assert!(f1 == 1);
}
```

was extracted as 

```lean 
    match c with
      | {f1 := f1, f2 := _, f3 := _, f4 := _} => do
        (hax_lib.assert (← (f1 ==? (1 : u8))));
```

and now is 

```lean 
    match c with | {f1 := f1, ..} => do (hax_lib.assert (← (f1 ==? (1 : u8))));
``` 