### PR TITLE
fix(lean): make the proof of RustM.toBVRustM_bind compatible with Lean 4.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changes to hax-lib:
  - Lean lib: Add support for Int128 and UInt128 while waiting for upstream in Lean (#1968)
  - Lean lib: Refactor `RustM` as `ExceptT Error Option` (#1994)
  - Lean lib: Add Repr instance for tuples (#2000)
+ - Lean lib: Make the proof of `RustM.toBVRustM_bind` compatible with Lean 4.29.0 (#2005)
 
 Changes to the Lean backend:
  - Add `hax_zify` and `hax_construct_pure` tactics (#1888)

--- a/hax-lib/proof-libs/lean/Hax/rust_primitives/BVDecide.lean
+++ b/hax-lib/proof-libs/lean/Hax/rust_primitives/BVDecide.lean
@@ -75,8 +75,7 @@ theorem RustM.toBVRustM_bind {α β : Type} [Inhabited α] [Inhabited β] (x : R
     if x.toBVRustM.ok
     then (f x.toBVRustM.val).toBVRustM
     else {x.toBVRustM with val := default} := by
-  cases x using RustM.toBVRustM.match_1 <;>
-    simp [toBVRustM, Bind.bind, ExceptT.bind, ExceptT.bindCont, ExceptT.mk]
+  cases x using RustM.toBVRustM.match_1 <;> rfl
 
 @[hax_bv_decide]
 theorem RustM.Triple_iff_BitVec {α : Type} [Inhabited α]


### PR DESCRIPTION
Lean 4.29.0 fails to verify the proof of `RustM.toBVRustM_bind`, as it seems a proposition is missing in `simp` to make it work (cf. https://github.com/cryspen/hax/issues/2004#issue-4220917198 for more details). Use `rfl` instead, as it works fine and it is compatible with Lean 4.28.0 too.

Fixes: https://github.com/cryspen/hax/issues/2004