### PR TITLE
fix(frontend): Fix multiple crashes in the frontend/import_thir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ Changes to the Rust Engine:
  - Apply resugarings to linked items (pre/post conditions) (#1961)
  - Add new import_thir implemented in Rust and using `FullDef`, activated with `--experimental-full-def` (#1967)
 
+Changes to the engine:
+ - Omit type aliases whose body has unresolvable trait bounds instead of crashing (#2014)
+ - Report let-chains (`if let .. && let ..`) as a soft error instead of panicking (#2014)
+
 Changes to the frontend:
  - Fix support for ellipsis: add wildcard for every field (based on type info
    rather than number of subpatterns) (#2001)
+ - Fix panic on constants of type `&[&T]` (e.g. `&[&str]`) caused by a wrong type for the synthesized array length (#2014)
 
 Changes to cargo-hax:
 

--- a/engine/lib/import_ast.ml
+++ b/engine/lib/import_ast.ml
@@ -21,6 +21,8 @@ end
 module U = Ast_utils.Make (F)
 module Build = Ast_builder.Make (F)
 
+exception Item_translation_failure of string
+
 let from_error_node (error_node : Types.error_node) : string =
   match (error_node.fragment, error_node.diagnostics) with
   | ( Unknown "OCamlEngineError",
@@ -174,7 +176,7 @@ and dimpl_expr_kind (i : A.impl_expr_kind) : B.impl_expr_kind =
       B.ImplApp { impl = dimpl_expr impl_; args = List.map ~f:dimpl_expr args }
   | A.Dyn -> B.Dyn
   | A.Builtin tr -> B.Builtin (dtrait_goal tr)
-  | A.Error _ -> failwith "Error node in ImplExprKind"
+  | A.Error s -> raise (Item_translation_failure (from_error_node s))
 
 and dgeneric_value (generic_value : A.generic_value) : B.generic_value =
   match generic_value with
@@ -640,14 +642,17 @@ let ditem' (item : A.item_kind) : B.item' option =
   | A.RustModule -> None
 
 let ditem (i : A.item) : B.item list =
-  match ditem' i.kind with
-  | Some v ->
-      [
-        {
-          ident = dconcrete_ident i.ident;
-          v;
-          span = dspan i.meta.span;
-          attrs = dattributes i.meta.attributes;
-        };
-      ]
-  | _ -> []
+  try
+    match ditem' i.kind with
+    | Some v ->
+        [
+          {
+            ident = dconcrete_ident i.ident;
+            v;
+            span = dspan i.meta.span;
+            attrs = dattributes i.meta.attributes;
+          };
+        ]
+    | _ -> []
+  with Item_translation_failure msg ->
+    [ B.make_hax_error_item (dspan i.meta.span) (dconcrete_ident i.ident) msg ]

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -631,8 +631,8 @@ end) : EXPR = struct
           let arms = List.map ~f:c_arm arms in
           Match { scrutinee; arms }
       | Let _ ->
-          assertion_failure [ e.span ]
-            "`Let` nodes are supposed to be pre-processed"
+          unimplemented ~issue_id:2018 [ e.span ]
+            "Let-chains (e.g. `if let .. && let ..`) are not supported."
       | Block { expr; span; stmts; safety_mode; _ } ->
           let { e; _ } = c_block ~expr ~span ~stmts ~ty:e.ty ~safety_mode in
           e

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1235,7 +1235,9 @@ end) : EXPR = struct
     | Dyn -> Dyn
     | SelfImpl { path; _ } -> List.fold ~init:Self ~f:browse_path path
     | Builtin _ -> Builtin goal
-    | Error str -> failwith @@ "impl_expr_atom: Error " ^ str
+    | Error str ->
+        unimplemented ~issue_id:707 [ span ]
+          ("Could not resolve trait reference: " ^ str)
 
   and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) : generic_value
       =

--- a/frontend/exporter/src/constant_utils/uneval.rs
+++ b/frontend/exporter/src/constant_utils/uneval.rs
@@ -246,7 +246,7 @@ pub(crate) fn valtree_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
                         .s_unwrap(s);
                         let valtree = rustc_middle::ty::ValTree::from_scalar_int(tcx, size);
                         let value = rustc_middle::ty::Value {
-                            ty: *inner_ty,
+                            ty: tcx.types.usize,
                             valtree,
                         };
                         let len = tcx.mk_ct_from_kind(rustc_middle::ty::ConstKind::Value(value));

--- a/rust-engine/src/import_thir.rs
+++ b/rust-engine/src/import_thir.rs
@@ -1150,9 +1150,11 @@ impl Import<ast::Expr> for frontend::Expr {
                     })
                     .collect(),
             },
-            frontend::ExprKind::Let { expr: _, pat: _ } => {
-                panic!("Let nodes are preprocessed (those are the ones contained in `if let ...`)")
-            }
+            frontend::ExprKind::Let { expr: _, pat: _ } => ast::ExprKind::Error(unsupported(
+                "Let-chains (e.g. `if let .. && let ..`) are not supported.",
+                2018,
+                span,
+            )),
             frontend::ExprKind::Block { block } => {
                 return import_block_expr(context, block, ty, span, attributes.clone());
             }

--- a/rust-engine/src/import_thir.rs
+++ b/rust-engine/src/import_thir.rs
@@ -1934,9 +1934,7 @@ fn import_impl_expr_atom(
         }
         frontend::ImplExprAtom::Dyn => ast::ImplExprKind::Dyn,
         frontend::ImplExprAtom::Builtin { .. } => ast::ImplExprKind::Builtin(goal),
-        frontend::ImplExprAtom::Error(msg) => {
-            ast::ImplExprKind::Error(assertion_failure(msg, span))
-        }
+        frontend::ImplExprAtom::Error(msg) => ast::ImplExprKind::Error(unsupported(msg, 707, span)),
     }
 }
 


### PR DESCRIPTION
Fixes #2013 

The bug triggers with any constant of type `&[&str]` because the frontend recreates an AST node for the length, typing it with the type of the slice content instead of `usize`. Example of reproducer (simpler than the original one)

```rust
const _: &[&str] = &["foo"];
```

Also fixes https://github.com/cryspen/hax/issues/2017 (by omitting the type alias when there is a bound issue)

And fixes a panic on https://github.com/cryspen/hax/issues/2018 (replacing by a recoverable error)