### PR TITLE
F* Makefiles with separate cache dirs.

### DIFF
--- a/docs/manual/fstar/quick_start.md
+++ b/docs/manual/fstar/quick_start.md
@@ -20,7 +20,7 @@ what you are looking for!
 
  - <input type="checkbox" class="user-checkable"/> Create the folder `proofs/fstar/extraction`folder, right next to the `Cargo.toml` of the crate you want to verify.  
    <span style="margin-right:30px;"></span>🪄 `mkdir -p proofs/fstar/extraction`
- - <input type="checkbox" class="user-checkable"/> Copy [this makefile](https://gist.github.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3) to `proofs/fstar/extraction/Makefile`  
+ - <input type="checkbox" class="user-checkable"/> Copy [this makefile](https://gist.github.com/maximebuyse/95a60c848b199c38eb93a41cfede34bf) to `proofs/fstar/extraction/Makefile`  
    <span style="margin-right:30px;"></span>🪄 `curl -o proofs/fstar/extraction/Makefile https://gist.githubusercontent.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3/raw/Makefile`
  - <input type="checkbox" class="user-checkable"/> Add `hax-lib` as a dependency to your crate, enabled only when using hax.  
    <span style="margin-right:30px;"></span>🪄 `cargo add --target 'cfg(hax)' --git https://github.com/hacspec/hax hax-lib`  


### PR DESCRIPTION
Our F* Makefile caches in the same cache regardless of the F* flags. This means that a file can be cached as checked for a run with `--admit_smt_queries true` or `--lax`, and it will be considered already verified for a subsequent full type-checking F* invocation. 

I updated the Makefile to use separate cache directories for each F* command line to avoid this issue. This PR updates the Makefile link in the documentation, to link the fixed Makeifle instead of the old one.

[skip changelog]