### PR TITLE
docs: update `curl` command to fetch new Makefile from @maximbuyse

### DIFF
--- a/docs/manual/fstar/quick_start.md
+++ b/docs/manual/fstar/quick_start.md
@@ -21,7 +21,7 @@ what you are looking for!
  - <input type="checkbox" class="user-checkable"/> Create the folder `proofs/fstar/extraction`folder, right next to the `Cargo.toml` of the crate you want to verify.  
    <span style="margin-right:30px;"></span>🪄 `mkdir -p proofs/fstar/extraction`
  - <input type="checkbox" class="user-checkable"/> Copy [this makefile](https://gist.github.com/maximebuyse/95a60c848b199c38eb93a41cfede34bf) to `proofs/fstar/extraction/Makefile`  
-   <span style="margin-right:30px;"></span>🪄 `curl -o proofs/fstar/extraction/Makefile https://gist.githubusercontent.com/W95Psp/4c304132a1f85c5af4e4959dd6b356c3/raw/Makefile`
+   <span style="margin-right:30px;"></span>🪄 `curl -o proofs/fstar/extraction/Makefile https://gist.githubusercontent.com/maximebuyse/95a60c848b199c38eb93a41cfede34bf/raw/Makefile`
  - <input type="checkbox" class="user-checkable"/> Add `hax-lib` as a dependency to your crate, enabled only when using hax.  
    <span style="margin-right:30px;"></span>🪄 `cargo add --target 'cfg(hax)' --git https://github.com/hacspec/hax hax-lib`  
    <span style="margin-right:30px;"></span><span style="opacity: 0;">🪄</span> *(`hax-lib` is not mandatory, but this guide assumes it is present)*


### PR DESCRIPTION
This just propagates the new link from #2034's a5c35d9a7c23e781ddff0e97044eb0ed331c4d86 into the suggested `curl` command for fetching it.

Thanks again for the quick fix.  :-)

[skip changelog]