### PR TITLE
feat: use hax_lib::ensures in aeneas-lean loop_example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Changes to the Lean backend:
 
 Miscellaneous:
  - New testing framework for the engine(s) (cryspen/hax-evit/135, cryspen/hax-evit/167)
- - Three examples for the new Aeneas/Lean backend (cryspen/hax-evit/190, cryspen/hax-evit/191, cryspen/hax-evit/192, #2058)
+ - Three examples for the new Aeneas/Lean backend (cryspen/hax-evit/190, cryspen/hax-evit/191, cryspen/hax-evit/192, #2058, #2059)
  - Update flags for the charon/aeneas pipeline (#2051)
 
 ## 0.3.7

--- a/examples/loop_equivalence/Makefile
+++ b/examples/loop_equivalence/Makefile
@@ -1,16 +1,11 @@
 .PHONY: default clean
 default:
 	cargo hax into aeneas-lean --aeneas-args="-core-models-lib"
-	sed -i \
-		'/^open Aeneas /c\open core_models Aeneas\nopen Aeneas.Std hiding namespace core alloc\nopen Result ControlFlow Error' \
-		proofs/aeneas-lean/LoopEquivalence/Extraction/Funs.lean
-	sed -i \
-		's/import Aeneas/import CoreModels/' \
-		proofs/aeneas-lean/LoopEquivalence/Extraction/Funs.lean
 	(cd proofs/aeneas-lean && \
    elan default v4.30.0-rc2 && \
    lake exe cache get && \
    lake build)
 
 clean:
+	-find proofs/aeneas-lean/LoopEquivalence/Extraction -type f ! -name FunsExternal.lean -delete
 	-cd proofs/aeneas-lean && lake clean

--- a/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence.lean
+++ b/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence.lean
@@ -1,1 +1,1 @@
-import LoopEquivalence.Spec
+import LoopEquivalence.Proofs.Proofs

--- a/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence/Proofs/MissingSpecs.lean
+++ b/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence/Proofs/MissingSpecs.lean
@@ -1,6 +1,6 @@
-import LoopEquivalence.Extraction.Funs
+-- Missing core model specs, to upstream
+import LoopEquivalence.Extraction.Specs
 import Hax
-import Lean
 open CoreModels Aeneas
 open Aeneas.Std hiding namespace core alloc
 open Result ControlFlow Error
@@ -8,7 +8,6 @@ open Std.Do
 open Std.Tactic
 
 set_option mvcgen.warning false
-set_option linter.unusedVariables false
 
 namespace loop_equivalence
 
@@ -213,71 +212,5 @@ theorem forLoopWithInvariant_spec {β : Type}
           core.Usize.Insts.CoreCmpPartialOrdUsize, core.mkUPartialOrd,
           Triple, WP.wp, Result.holds] at hh ⊢
     exact hh
-
--- Local automation configuration
-attribute [local spec] g f op g_loop g_loop.body f_loop f_loop.body g_loop_inv f_loop_inv g_post
-attribute [local spec] core.Array.Insts.CoreCloneClone.clone
-
-set_option maxHeartbeats 1000000
-theorem g_spec {N : Usize} (arr : Array U64 N) :
-    ⦃ ⌜ True ⌝ ⦄
-    g arr
-    ⦃ ⇓ future_arr => ⌜(do let x ← f arr; pure (future_arr == x) : Result Bool).holds ⌝ ⦄ := by
-  unfold g g_loop g_loop.body f f_loop f_loop.body
-  for_loop_with_invariant
-    fun i r =>
-      pure
-        (∀ (j : Usize),
-          (do
-              let a ← g_loop_inv r arr i j
-              pure (a = true)).holds)
-  for_loop_with_invariant
-    fun i r =>
-      pure
-        (∀ (j : Usize),
-          (do
-              let a ← f_loop_inv r arr i j
-              pure (a = true)).holds)
-  hax_mvcgen
-  all_goals try grind
-  · -- [g] loop step (j < i'): g_loop_inv branch 1.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_19 j <;> grind [UScalar.ofNatCore_val_eq ]
-  · -- [g] loop step (¬j < i' ∧ j < N): g_loop_inv branch 2.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_19 j <;> grind
-  · -- [f] loop step in N%2>0 branch (j < i'): f_loop_inv branch 1.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_21 j <;> grind
-  · -- [f] loop step in N%2>0 branch (¬j < i' ∧ j < N): f_loop_inv branch 2.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_22 j <;> grind
-  · -- N%2>0 post: g's update at N-1 vs f_loop's full result.
-    simp at *; try subst_vars
-    apply Subtype.ext
-    rw [Array.set_val_eq]
-    apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
-    simp only [List.getElem_set]
-    expose_names
-    split
-    · -- i = N-1: use f_loop_inv at j = r_3 (= N-1) and g_loop_inv to relate r_1[N-1] and arr[N-1].
-      apply h_8 r_3 <;>
-        (first | grind | (intros; apply h_6 r_3 <;> grind))
-    · -- i ≠ N-1: use g_loop_inv at j = i and f_loop_inv to relate.
-      apply h_6 (Usize.ofNatCore i (by grind)) <;>
-        (first | grind | (intros; apply h_8 (Usize.ofNatCore i (by grind)) <;> grind))
-  · -- [f] loop step in N%2=0 branch (j < i'): f_loop_inv branch 1.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_16 j <;> grind
-  · -- [f] loop step in N%2=0 branch (¬j < i' ∧ j < N): f_loop_inv branch 2.
-    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
-    apply h_17 j <;> grind
-  · -- N%2=0 post: direct element-wise equality.
-    simp at *
-    apply Subtype.ext
-    apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
-    expose_names
-    apply h_4 (Usize.ofNatCore i (by grind)) <;>
-      (first | grind | (intros; apply h_6 (Usize.ofNatCore i (by grind)) <;> grind))
 
 end loop_equivalence

--- a/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence/Proofs/Proofs.lean
+++ b/examples/loop_equivalence/proofs/aeneas-lean/LoopEquivalence/Proofs/Proofs.lean
@@ -1,0 +1,81 @@
+import LoopEquivalence.Extraction.Funs
+import LoopEquivalence.Proofs.MissingSpecs
+import Hax
+open CoreModels Aeneas
+open Aeneas.Std hiding namespace core alloc
+open Result ControlFlow Error
+open Std.Do
+open Std.Tactic
+
+set_option mvcgen.warning false
+set_option hax_mvcgen.warnings false
+
+namespace loop_equivalence
+
+-- Local automation configuration
+attribute [local spec] g f op g_loop g_loop.body f_loop f_loop.body g_loop_inv f_loop_inv g.post
+attribute [local spec] core.Array.Insts.CoreCloneClone.clone
+
+set_option maxHeartbeats 1000000
+theorem g_spec {N : Usize} (arr : Array U64 N) :
+    ⦃ ⌜ True ⌝ ⦄
+    g arr
+    ⦃ ⇓ future_arr => ⌜(do let x ← f arr; pure (future_arr == x) : Result Bool).holds ⌝ ⦄ := by
+  unfold g g_loop g_loop.body f f_loop f_loop.body
+  for_loop_with_invariant
+    fun i r =>
+      pure
+        (∀ (j : Usize),
+          (do
+              let a ← g_loop_inv r arr i j
+              pure (a = true)).holds)
+  for_loop_with_invariant
+    fun i r =>
+      pure
+        (∀ (j : Usize),
+          (do
+              let a ← f_loop_inv r arr i j
+              pure (a = true)).holds)
+  hax_mvcgen
+  all_goals try grind
+  · -- [g] loop step (j < i'): g_loop_inv branch 1.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_19 j <;> grind [UScalar.ofNatCore_val_eq ]
+  · -- [g] loop step (¬j < i' ∧ j < N): g_loop_inv branch 2.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_19 j <;> grind
+  · -- [f] loop step in N%2>0 branch (j < i'): f_loop_inv branch 1.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_21 j <;> grind
+  · -- [f] loop step in N%2>0 branch (¬j < i' ∧ j < N): f_loop_inv branch 2.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_22 j <;> grind
+  · -- N%2>0 post: g's update at N-1 vs f_loop's full result.
+    simp at *; try subst_vars
+    apply Subtype.ext
+    rw [Array.set_val_eq]
+    apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
+    simp only [List.getElem_set]
+    expose_names
+    split
+    · -- i = N-1: use f_loop_inv at j = r_3 (= N-1) and g_loop_inv to relate r_1[N-1] and arr[N-1].
+      apply h_8 r_3 <;>
+        (first | grind | (intros; apply h_6 r_3 <;> grind))
+    · -- i ≠ N-1: use g_loop_inv at j = i and f_loop_inv to relate.
+      apply h_6 (Usize.ofNatCore i (by grind)) <;>
+        (first | grind | (intros; apply h_8 (Usize.ofNatCore i (by grind)) <;> grind))
+  · -- [f] loop step in N%2=0 branch (j < i'): f_loop_inv branch 1.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_16 j <;> grind
+  · -- [f] loop step in N%2=0 branch (¬j < i' ∧ j < N): f_loop_inv branch 2.
+    try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
+    apply h_17 j <;> grind
+  · -- N%2=0 post: direct element-wise equality.
+    simp at *
+    apply Subtype.ext
+    apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
+    expose_names
+    apply h_4 (Usize.ofNatCore i (by grind)) <;>
+      (first | grind | (intros; apply h_6 (Usize.ofNatCore i (by grind)) <;> grind))
+
+end loop_equivalence

--- a/examples/loop_equivalence/src/lib.rs
+++ b/examples/loop_equivalence/src/lib.rs
@@ -28,6 +28,9 @@ fn f<const N: usize>(mut arr: [u64; N]) -> [u64; N] {
 
 /// Unrolled loop: processes two elements per iteration, then handles the
 /// leftover element when `N` is odd. This computes the same result as [`f`].
+///
+/// Postcondition: its output equals the result of `f` on the same input.
+#[hax_lib::ensures(|_| future(arr) == &f(*arr))]
 fn g<const N: usize>(arr: &mut [u64; N]) {
     let initial = arr.clone();
 
@@ -62,9 +65,4 @@ fn g_loop_inv<const N: usize>(arr: &[u64; N], _initial: &[u64; N], i: usize, j: 
     } else {
         true
     }
-}
-
-// Postcondition for `g`: its output equals the result of `f` on the same input.
-fn g_post<const N: usize>(arr: &[u64; N], future_arr: &[u64; N]) -> bool {
-    future_arr == &f(*arr)
 }


### PR DESCRIPTION
The `hax into aeneas-lean` backend now supports `hax_lib::ensures` annotations. This PR makes the `loop_equivalence` use that new feature by attaching the postcondition of `g` directly to the function. Unfortunately, loop invariants are not yet supported, so they need to stay in stand-alone functions.

The proof works pretty much unchanged, but I split the proof file into two parts: A part that we eventually need to upstream elsewhere and a part that contains the actual proof.

The `sed`-commands in the Makefile are no longer needed. Aeneas does that correctly now.