### PR TITLE
ci: reactivate aeneas install

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Run `setup.sh`
       run: |
         export OPAMERRLOGLEN=0
-        ./setup.sh --no-aeneas
+        ./setup.sh
     - run: cargo hax --version
     - name: Test an extraction
       run: |


### PR DESCRIPTION
I had deactivated the aeneas setup CI because it failed for previous aeneas versions. With the new version it succeeds:

https://github.com/cryspen/hax/actions/runs/28599157933

Fixes #2055

[skip changelog]