### PR TITLE
feat: use generated spec in loop_equivalence example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Changes to the Lean backend:
 Miscellaneous:
  - New testing framework for the engine(s) (cryspen/hax-evit/135, cryspen/hax-evit/167)
  - Four examples for the new Aeneas/Lean backend (cryspen/hax-evit/190, cryspen/hax-evit/191,
-   cryspen/hax-evit/192, #2058, #2059, #2070)
+   cryspen/hax-evit/192, #2058, #2059, #2070, #2061)
  - Update flags for the charon/aeneas pipeline (#2051)
 
 ## 0.3.7

--- a/examples/loop_equivalence/proofs/lean/LoopEquivalence/Proofs/MissingSpecs.lean
+++ b/examples/loop_equivalence/proofs/lean/LoopEquivalence/Proofs/MissingSpecs.lean
@@ -213,4 +213,144 @@ theorem forLoopWithInvariant_spec {β : Type}
           Triple, WP.wp, Result.holds] at hh ⊢
     exact hh
 
+private theorem array_index_U64_eq {N : Usize} (a : Array U64 N) (i : Usize)
+    (h : i.val < N.val) :
+    rust_primitives.slice.array_index a i = .ok a.val[i.val]! := by
+  have hSpec : (rust_primitives.slice.array_index a i) ⦃ x => x = a.val[i.val]! ⦄ := by
+    show Aeneas.Std.WP.spec (Slice.index_usize (Array.to_slice a) i) _
+    have h' : i.val < a.val.length := by rw [a.property]; exact h
+    apply Aeneas.Std.WP.spec_mono (Slice.index_usize_spec _ i (by simp; exact h))
+    intro x hx
+    simp only [hx, Array.val_to_slice, getElem!_pos a.val i.val h']
+  obtain ⟨y, hy, hyVal⟩ := Aeneas.Std.WP.spec_imp_exists hSpec
+  rw [hy, hyVal]
+
+private theorem list_eq_of_pointwise {α} [Inhabited α] [DecidableEq α] (xs ys : List α)
+    (hLen : xs.length = ys.length)
+    (h : ∀ k, k < xs.length → xs[k]! = ys[k]!) :
+    xs = ys := by
+  induction xs generalizing ys with
+  | nil =>
+    cases ys with
+    | nil => rfl
+    | cons _ _ => simp at hLen
+  | cons x xs ih =>
+    cases ys with
+    | nil => simp at hLen
+    | cons y ys =>
+      have h0 := h 0 (by simp)
+      simp only [List.getElem!_cons_zero] at h0
+      have hLen' : xs.length = ys.length := by simp at hLen; omega
+      have ih' := ih ys hLen' (by
+        intro k hk
+        have := h (k + 1) (by simp; omega)
+        simp only [List.getElem!_cons_succ] at this
+        exact this)
+      simp [h0, ih']
+
+private theorem add_one_usize (j : Usize) (h : j.val + 1 ≤ Usize.max) :
+    ∃ k : Usize, (j + 1#usize : Result Usize) = .ok k ∧ k.val = j.val + 1 := by
+  have hSpec : (j + 1#usize : Result Usize) ⦃ k => k.val = j.val + 1#usize.val ⦄ := by
+    apply UScalar.add_spec.step_spec
+    scalar_tac
+  obtain ⟨k, hk, hkVal⟩ := Aeneas.Std.WP.spec_imp_exists hSpec
+  refine ⟨k, hk, ?_⟩
+  rw [hkVal]; rfl
+
+private theorem eq_loop_correct {N : Usize} (a0 a1 : Array U64 N) (i : Usize)
+    (hi : i.val ≤ N.val)
+    (hPrev : ∀ k, k < i.val → a0.val[k]! = a1.val[k]!) :
+    Aeneas.Std.WP.spec
+      (core.Array.Insts.CoreCmpPartialEqArray.eq_loop
+        core.U64.Insts.CoreCmpPartialEqU64 a0 a1 i)
+      (fun r => r = (a0.val == a1.val)) := by
+  unfold core.Array.Insts.CoreCmpPartialEqArray.eq_loop
+  refine Aeneas.Std.loop.spec_decr_nat
+    (measure := fun (j : Usize) => N.val - j.val)
+    (inv := fun (j : Usize) => j.val ≤ N.val ∧ ∀ k, k < j.val → a0.val[k]! = a1.val[k]!)
+    (post := fun r => r = (a0.val == a1.val))
+    (hBody := ?_) (hInv := ⟨hi, hPrev⟩)
+  rintro j ⟨hjN, hPrevJ⟩
+  unfold core.Array.Insts.CoreCmpPartialEqArray.eq_loop.body
+  by_cases hjLt : j.val < N.val
+  · -- j < N case
+    have hjLt' : (j < N : Prop) := hjLt
+    rw [if_pos hjLt']
+    rw [array_index_U64_eq a0 j hjLt]
+    show Aeneas.Std.WP.spec (do
+      let t1 ← rust_primitives.slice.array_index a1 j
+      let b ← core.U64.Insts.CoreCmpPartialEqU64.eq a0.val[j.val]! t1
+      if b then let i1 ← j + 1#usize; Result.ok (ControlFlow.cont i1)
+      else Result.ok (ControlFlow.done false)) _
+    rw [array_index_U64_eq a1 j hjLt]
+    show Aeneas.Std.WP.spec (do
+      let b ← core.U64.Insts.CoreCmpPartialEqU64.eq a0.val[j.val]! a1.val[j.val]!
+      if b then let i1 ← j + 1#usize; Result.ok (ControlFlow.cont i1)
+      else Result.ok (ControlFlow.done false)) _
+    have hcmp : core.U64.Insts.CoreCmpPartialEqU64.eq a0.val[j.val]! a1.val[j.val]!
+        = .ok (a0.val[j.val]! == a1.val[j.val]!) := rfl
+    rw [hcmp]
+    show Aeneas.Std.WP.spec
+      (if (a0.val[j.val]! == a1.val[j.val]!)
+       then (do let i1 ← j + 1#usize; Result.ok (ControlFlow.cont i1))
+       else Result.ok (ControlFlow.done false)) _
+    have hj1Bound : j.val + 1 ≤ Usize.max := by
+      have hN := N.hBounds
+      have : N.val ≤ Usize.max := by scalar_tac
+      omega
+    by_cases hbeq : a0.val[j.val]! = a1.val[j.val]!
+    · -- equal
+      have hbeq' : (a0.val[j.val]! == a1.val[j.val]!) = true := beq_iff_eq.mpr hbeq
+      rw [if_pos hbeq']
+      obtain ⟨jp1, hjp1Eq, hjp1Val⟩ := add_one_usize j hj1Bound
+      rw [hjp1Eq]
+      refine ⟨⟨?_, ?_⟩, ?_⟩
+      · rw [hjp1Val]; omega
+      · intro k hk
+        rw [hjp1Val] at hk
+        by_cases hkj : k < j.val
+        · exact hPrevJ k hkj
+        · have : k = j.val := by omega
+          subst this; exact hbeq
+      · show N.val - jp1.val < N.val - j.val
+        rw [hjp1Val]; omega
+    · -- not equal
+      have hbeq' : (a0.val[j.val]! == a1.val[j.val]!) = false := beq_eq_false_iff_ne.mpr hbeq
+      rw [if_neg (by rw [hbeq']; simp)]
+      show (false : Bool) = (a0.val == a1.val)
+      have hne : a0.val ≠ a1.val := fun hEq => hbeq (by rw [hEq])
+      simp [hne]
+  · -- j ≥ N: j = N
+    have hjLt' : ¬ (j < N : Prop) := hjLt
+    rw [if_neg hjLt']
+    simp only [Aeneas.Std.WP.spec_ok]
+    have hjEq : j.val = N.val := by omega
+    have hLen0 : a0.val.length = N.val := a0.property
+    have hLen1 : a1.val.length = N.val := a1.property
+    have hListEq : a0.val = a1.val := by
+      apply list_eq_of_pointwise
+      · rw [hLen0, hLen1]
+      · intro k hk
+        rw [hLen0] at hk
+        apply hPrevJ; rw [hjEq]; exact hk
+    simp [hListEq]
+
+open Std.Do in
+@[spec]
+theorem array.equality.PartialEqArray.eq_spec {N : Usize} (a0 : Array U64 N) (a1 : Array U64 N)
+    (h : (Q.1 (a0.val == a1.val)).down) :
+    ⦃ ⌜ True ⌝ ⦄
+    core.Array.Insts.CoreCmpPartialEqArray.eq core.U64.Insts.CoreCmpPartialEqU64 a0 a1
+    ⦃ Q ⦄ := by
+  have hSpec : Aeneas.Std.WP.spec
+      (core.Array.Insts.CoreCmpPartialEqArray.eq
+        core.U64.Insts.CoreCmpPartialEqU64 a0 a1)
+      (fun r => r = (a0.val == a1.val)) := by
+    unfold core.Array.Insts.CoreCmpPartialEqArray.eq
+    apply eq_loop_correct a0 a1 0#usize (by simp) (fun k hk => by simp at hk)
+  obtain ⟨b, hx, hb⟩ := Aeneas.Std.WP.spec_imp_exists hSpec
+  rw [hx]
+  apply Result.ok_spec
+  rw [hb]; exact h
+
 end loop_equivalence

--- a/examples/loop_equivalence/proofs/lean/LoopEquivalence/Proofs/Proofs.lean
+++ b/examples/loop_equivalence/proofs/lean/LoopEquivalence/Proofs/Proofs.lean
@@ -17,11 +17,8 @@ attribute [local spec] g f op g_loop g_loop.body f_loop f_loop.body g_loop_inv f
 attribute [local spec] core.Array.Insts.CoreCloneClone.clone
 
 set_option maxHeartbeats 1000000
-theorem g_spec {N : Usize} (arr : Array U64 N) :
-    ⦃ ⌜ True ⌝ ⦄
-    g arr
-    ⦃ ⇓ future_arr => ⌜(do let x ← f arr; pure (future_arr == x) : Result Bool).holds ⌝ ⦄ := by
-  unfold g g_loop g_loop.body f f_loop f_loop.body
+theorem g.spec.proof {N : Std.Usize} (arr : Array Std.U64 N) : g.spec arr := by
+  unfold spec g g_loop g_loop.body post f f_loop f_loop.body
   for_loop_with_invariant fun i r =>
     pure (∀ (j : Usize), (do let a ← g_loop_inv r arr i j; pure (a = true)).holds)
   for_loop_with_invariant fun i r =>
@@ -41,18 +38,15 @@ theorem g_spec {N : Usize} (arr : Array U64 N) :
     expose_names
     apply (‹∀ (j : Usize) (p : Prop), _ → _ → _ → p›) j <;> grind
   · -- N%2>0 post: g's update at N-1 vs f_loop's full result.
-    simp only [beq_iff_eq]; try subst_vars
-    apply Subtype.ext
-    rw [Array.set_val_eq]
+    simp at *; try subst_vars
     apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
     simp only [List.getElem_set]
     expose_names
     split
     · apply h_8 r_3 <;>
-        (first | grind | (intros; apply h_7 r_3 <;> simp <;> grind))
+        (first | grind | (intros; apply h_7 r_3 <;> grind))
     · apply h_7 (Usize.ofNatCore i (by grind)) <;>
-        (first | grind | (intros; apply h_8 (Usize.ofNatCore i (by grind))
-          <;> simp only [UScalar.ofNatCore_val_eq] at * <;> grind))
+        (first | grind | (intros; apply h_8 (Usize.ofNatCore i (by grind)) <;> grind))
   · -- [f] loop step in N%2=0 branch (j < i'): f_loop_inv branch 1.
     try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
     apply (‹∀ (j : Usize) (p : Prop), _ → _ → _ → p›) j <;> grind
@@ -60,12 +54,10 @@ theorem g_spec {N : Usize} (arr : Array U64 N) :
     try (simp only [UScalar.ofNatCore_val_eq] at *); expose_names
     apply (‹∀ (j : Usize) (p : Prop), _ → _ → _ → p›) j <;> grind
   · -- N%2=0 post: direct element-wise equality.
-    simp only [beq_iff_eq]
-    apply Subtype.ext
+    simp at *
     apply List.ext_getElem (by grind) fun i hi1 hi2 => ?_
     expose_names
     apply h_4 (Usize.ofNatCore i (by grind)) <;>
-      (first | grind | (intros; apply h_3 (Usize.ofNatCore i (by grind))
-      <;> simp only [UScalar.ofNatCore_val_eq] <;> grind))
+      (first | grind | (intros; apply h_3 (Usize.ofNatCore i (by grind)) <;> grind))
 
 end loop_equivalence


### PR DESCRIPTION
This PR makes the loop equivalence example actually use the generated `g.spec`.

To this end, we need a spec for array equality, which unfortunately is a bit hard to prove. That is where all of the material in MissingSpecs.lean is coming from. I just copied that from the sha3 example. This will soon be part of the `hax-lean` library (see https://github.com/cryspen/rust-core-models/pull/7, which I need to make a hax PR for).