### PR TITLE
ci: update workflows to work on hax-evit

### DIFF
--- a/.github/workflows/bertie.yml
+++ b/.github/workflows/bertie.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/clippy_rust_engine.yml
+++ b/.github/workflows/clippy_rust_engine.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   clippy:

--- a/.github/workflows/core_models.yml
+++ b/.github/workflows/core_models.yml
@@ -2,13 +2,13 @@ name: core-models
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'hax-lib/core-models/**'
       - 'hax-lib/proof-libs/aeneas-lean/**'
       - '.github/workflows/core_models.yml'
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'hax-lib/core-models/**'
       - 'hax-lib/proof-libs/aeneas-lean/**'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   ocamlformat:

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   # Build job
   build:
+    if: github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +22,7 @@ jobs:
           path: result/
   # Deploy job
   deploy:
+    if: github.repository == 'cryspen/hax'
     needs: build
     permissions:
       pages: write      # to deploy to Pages

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   tests:

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   tests:

--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
+    if: github.repository == 'cryspen/hax'
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-js:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,7 +26,7 @@ jobs:
         files: hacspec_js.tar.gz
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Workspace
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
     
 jobs:
   docker:

--- a/.github/workflows/verify_extraction.yml
+++ b/.github/workflows/verify_extraction.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   tests:


### PR DESCRIPTION
This is an attempt to make CI compatible with `hax-evit`. The same workflow files should work for both `hax` and `hax-evit`.

What I am not sure about are the `push` triggers. Since we have a merge queue on `hax`, I don't think we need them. On `hax-evit`, they might be useful though because we will regularly force-push to `dev` after a rebase, and failures might occur then. So maybe
```
push:
  branches: [dev]
```
would be better?

[skip changelog]