### PR TITLE
Use core::ops::Deref instead of std::ops::Deref for `refinement_type`

### DIFF
--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -1236,7 +1236,7 @@ pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::
             }
 
             #[::hax_lib::exclude]
-            impl #generics ::std::ops::Deref for #ident <#generics_args> {
+            impl #generics ::core::ops::Deref for #ident <#generics_args> {
                 type Target = #inner_ty;
                 fn deref(&self) -> &Self::Target {
                     &self.0


### PR DESCRIPTION
Closes #2021  cc @maximebuyse 

Replace `std::ops::Deref` with `core::ops::Deref` in implementation.rs.  

In a local no_std crate I reproduced the issue  (also encountered this in securedrop-protocol)

```
error[E0433]: failed to resolve: could not find `std` in the list of imported crates
  --> example-crate/src/example.rs:56:17
   |
56 | #[cfg_attr(hax, hax_lib::refinement_type(|x| x > 0))]
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `std` in the list of imported crates
   |
   = help: consider importing this module:
           core::ops
   = note: this error originates in the attribute macro `hax_lib::refinement_type` (in Nightly builds, run with -Z macro-backtrace for more info)
```

When I instead use a version of hax pinned to this commit, I can extract cleanly. `cargo test` passes although test is minimal. I performed no other testing.

[skip changelog]