### PR TITLE
fix(cargo-hax): set --cfg hax for target deps in aeneas-lean backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes to cargo-hax:
  - Manage aeneas and charon versions with `cargo hax tools` (`install`, `list`, `show`), pinned via a committed `hax.toml` and installed from pre-built binaries verified against a shipped manifest and cached under `$XDG_CACHE_HOME/hax/tools/`
  - Resolve aeneas and charon from the version manifest instead of `PATH`; use a `path` entry in `hax.toml` to point at a local build
  - Check that the `hax-lib` version in scope matches the `cargo-hax` version before processing
+ - Fix `into lean` failing to build crates with `cfg(hax)`-gated dependencies: set `--cfg hax` for the target build via `RUSTFLAGS` (not only host builds), so `[target.'cfg(hax)'.dependencies]` resolve and dependency spec code compiles against the real (non-dummy) hax-lib (#2069)
 
 Changes to hax-lib:
  - Basis of core model testing infrastructure (cryspen/hax-evit/160, cryspen/hax-evit/164)

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -286,6 +286,16 @@ pub fn run(
         "--config",
         r#"host.rustflags=["--cfg","hax"]"#,
     ]);
+    // Target-side `--cfg hax`: cargo applies `RUSTFLAGS` to every *target* crate —
+    // the root crate AND all its dependencies — and uses it to resolve
+    // `[target.'cfg(hax)'.dependencies]`. The `host.rustflags` above only reaches
+    // host (proc-macro) builds; without this, dependencies compile with their
+    // `#[hax_lib::…]` spec code active but hax-lib in its non-`hax` (dummy) mode.
+    // Concretely a dep like libcrux strips its `#[cfg(hax)] use hax_lib::int::*`
+    // while its `requires`/`ensures` predicates still reference `int!`/`to_int`,
+    // and fails to compile. This mirrors the main frontend (`cargo_hax::rustflags`).
+    let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    charon_cmd.env("RUSTFLAGS", format!("{rustflags} --cfg hax"));
     if verbose > 0 {
         HaxMessage::SubprocessOutput {
             prefix: "cmd".into(),


### PR DESCRIPTION
## Problem

`cargo hax into aeneas-lean` fails to build any crate whose dependencies use `cfg(hax)` (typically for specs). On such a project (e.g. one depending on libcrux), charon aborts before producing any LLBC with ~144 rustc errors like:

```
error: cannot find macro `int` in this scope
error[E0599]: no method named `to_int` found for type `usize`
error[E0425]: cannot find function `from_bool` in this scope
error: could not compile `libcrux-sha3` (lib) due to 144 previous errors
error: hax: charon exited with non-zero code 101
```

## Root cause

The backend delivers its two cfgs by different mechanisms with different reach:

| cfg | mechanism | reaches |
|---|---|---|
| `hax_compilation` | `--rustc-arg=--cfg=hax_compilation` | only the primary crate charon instruments |
| `hax` | `--config host.rustflags=["--cfg","hax"]` | only **host** (proc-macro) builds |

Nothing set `--cfg hax` for the **target dependency** crates. hax-lib picks its API by cfg:

```rust
#[cfg(not(hax))] core::include!("dummy.rs");
#[cfg(hax)]      core::include!("implementation.rs");
```

So a dependency compiled *without* `--cfg hax` ends up inconsistent: its `#[hax_lib::requires/ensures]` predicates still reference `int!` / `to_int` / `from_bool`, but its `#[cfg(hax)] use hax_lib::int::*` import is stripped and hax-lib links in `dummy` mode where those names aren't in scope — hence the errors. The main frontend never hits this because `cargo_hax::rustflags()` sets `--cfg hax` globally via `RUSTFLAGS`.

## Fix

Set `--cfg hax` on the charon subprocess via `RUSTFLAGS`, mirroring the frontend:

```rust
let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
charon_cmd.env("RUSTFLAGS", format!("{rustflags} --cfg hax"));
```

cargo applies `RUSTFLAGS` to every *target* crate (root + deps) and uses it to resolve `[target.'cfg(hax)'.dependencies]` — a per-crate `--rustc-arg` does neither. The existing `host.rustflags` line stays, covering proc-macro builds; together, every crate now sees `cfg(hax)` consistently.

## Verification

Reproduced on a crate depending on libcrux/hpke. Before: 144 errors, `charon exited 101`, no LLBC. After (rebuilt `cargo-hax`, no environment workaround): the dependency tree and the crate compile, charon emits the `.llbc`, and aeneas runs. A local test for this would require multiple crates.

This issue was diagnosed and fix with Claude