### PR TITLE
Exclude/Opaque for Lean, internally using charon's attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)
 - Lean library for the new Lean/Aeneas backend (cryspen/hax-evit/188, #2080)
 - Support for hax_lib::int and hax_lib::prop (#2130)
+- Honor `hax_lib::opaque` / `hax_lib::exclude` in the new lean (charon/aeneas) backend, by emitting charon's native `charon::opaque` / `charon::exclude` attributes; scope to this backend with `#[cfg_attr(hax_backend_lean, ...)]` (#2071)
 
 Miscellaneous:
  - Update the required OCaml version to 5.4.1 (#2137)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)
 - Lean library for the new Lean/Aeneas backend (cryspen/hax-evit/188, #2080)
 - Support for hax_lib::int and hax_lib::prop (#2130)
-- Honor `hax_lib::opaque` / `hax_lib::exclude` in the new lean (charon/aeneas) backend, by emitting charon's native `charon::opaque` / `charon::exclude` attributes; scope to this backend with `#[cfg_attr(hax_backend_lean, ...)]` (#2071)
+- Honor `hax_lib::opaque` and `hax_lib::exclude`, by emitting charon's own `charon::opaque` / `charon::exclude` attributes. Scope a marker to this backend with `#[cfg_attr(hax_backend_lean, ...)]` (#2071)
 
 Miscellaneous:
  - Update the required OCaml version to 5.4.1 (#2137)

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -268,35 +268,38 @@ pub fn run(
         "--preset=aeneas",
         "--dest-file",
         llbc_file.to_str().expect("non-UTF8 path"),
-        // Compile the crate as hax does: set `--cfg=hax_compilation` (so hax-lib
-        // proc macros emit their verification artifacts) and register the `_hax`
-        // tool attribute namespace.
+        // Compile the crate as hax does: `--cfg=hax_compilation` makes hax-lib proc
+        // macros emit their verification artifacts, and `hax_backend_lean` follows the
+        // engine's `hax_backend_<name>` convention, so a crate can scope a marker to
+        // this backend with `#[cfg_attr(hax_backend_lean, hax_lib::opaque)]`.
         "--rustc-arg=--cfg=hax_compilation",
-        "--rustc-arg=-Zcrate-attr=feature(register_tool)",
-        "--rustc-arg=-Zcrate-attr=register_tool(_hax)",
-        // Enable charon's native tool-attribute namespace and the `charon` cfg, so
-        // hax-lib markers (`hax_lib::opaque`/`exclude`) that emit a gated
-        // `#[cfg_attr(charon, charon::opaque)]` take effect here. This lane bypasses
-        // the hax engine, so charon's own attributes are how opacity reaches aeneas.
-        "--rustc-arg=--cfg=charon",
-        "--rustc-arg=-Zcrate-attr=register_tool(charon)",
-        // Backend identifier for per-backend scoping, matching the engine's
-        // `hax_backend_<name>` convention (e.g. `hax_backend_fstar`). Lets crates
-        // write `#[cfg_attr(hax_backend_lean, hax_lib::opaque)]` to target only this
-        // backend; the bare `cfg(hax)` form still applies to all backends.
         "--rustc-arg=--cfg=hax_backend_lean",
     ]);
     // User-supplied charon flags go before the `--` cargo separator.
     charon_cmd.args(&user_charon_args);
     // Everything after `--` is forwarded to cargo: build the host (proc-macro)
-    // crates with `--cfg hax` too, so hax-lib macros expand consistently.
+    // crates with `--cfg hax` too, so hax-lib macros expand consistently. `--cfg
+    // charon` additionally makes them emit charon's own `charon::opaque`/`exclude`
+    // markers: this lane bypasses the engine, so those are how a `hax_lib::opaque`
+    // reaches aeneas.
     charon_cmd.args([
         "--",
         "-Zhost-config",
         "-Ztarget-applies-to-host",
         "--config",
-        r#"host.rustflags=["--cfg","hax"]"#,
+        r#"host.rustflags=["--cfg","hax","--cfg","charon"]"#,
     ]);
+    // Register the tool-attribute namespaces through `RUSTFLAGS`, which cargo applies
+    // to every target crate. `--rustc-arg` only reaches the crate charon instruments,
+    // so markers in dependencies would fail to resolve.
+    let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    charon_cmd.env(
+        "RUSTFLAGS",
+        format!(
+            "{rustflags} -Zcrate-attr=feature(register_tool) \
+             -Zcrate-attr=register_tool(_hax) -Zcrate-attr=register_tool(charon)"
+        ),
+    );
     if verbose > 0 {
         HaxMessage::SubprocessOutput {
             prefix: "cmd".into(),

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -274,6 +274,17 @@ pub fn run(
         "--rustc-arg=--cfg=hax_compilation",
         "--rustc-arg=-Zcrate-attr=feature(register_tool)",
         "--rustc-arg=-Zcrate-attr=register_tool(_hax)",
+        // Enable charon's native tool-attribute namespace and the `charon` cfg, so
+        // hax-lib markers (`hax_lib::opaque`/`exclude`) that emit a gated
+        // `#[cfg_attr(charon, charon::opaque)]` take effect here. This lane bypasses
+        // the hax engine, so charon's own attributes are how opacity reaches aeneas.
+        "--rustc-arg=--cfg=charon",
+        "--rustc-arg=-Zcrate-attr=register_tool(charon)",
+        // Backend identifier for per-backend scoping, matching the engine's
+        // `hax_backend_<name>` convention (e.g. `hax_backend_fstar`). Lets crates
+        // write `#[cfg_attr(hax_backend_lean, hax_lib::opaque)]` to target only this
+        // backend; the bare `cfg(hax)` form still applies to all backends.
+        "--rustc-arg=--cfg=hax_backend_lean",
     ]);
     // User-supplied charon flags go before the `--` cargo separator.
     charon_cmd.args(&user_charon_args);

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -291,13 +291,16 @@ pub fn run(
     ]);
     // Register the tool-attribute namespaces through `RUSTFLAGS`, which cargo applies
     // to every target crate. `--rustc-arg` only reaches the crate charon instruments,
-    // so markers in dependencies would fail to resolve.
-    let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    // so markers in dependencies would fail to resolve. `RUSTFLAGS` replaces (never
+    // merges with) `build.rustflags` from `.cargo/config.toml`, so it must carry
+    // `--cfg hax` itself: without it `hax-lib` builds its no-op `dummy` half and the
+    // specifications the macros just emitted no longer resolve.
     charon_cmd.env(
         "RUSTFLAGS",
         format!(
-            "{rustflags} -Zcrate-attr=feature(register_tool) \
-             -Zcrate-attr=register_tool(_hax) -Zcrate-attr=register_tool(charon)"
+            "{} -Zcrate-attr=feature(register_tool) \
+             -Zcrate-attr=register_tool(_hax) -Zcrate-attr=register_tool(charon)",
+            super::rustflags()
         ),
     );
     if verbose > 0 {

--- a/cli/cargo-hax/src/cargo_hax.rs
+++ b/cli/cargo-hax/src/cargo_hax.rs
@@ -75,7 +75,7 @@ fn rust_log_style() -> String {
 /// We set `cfg(hax)` so that client crates can include dependencies
 /// or cfg-gate pieces of code.
 const RUSTFLAGS: &str = "RUSTFLAGS";
-fn rustflags() -> String {
+pub fn rustflags() -> String {
     let rustflags = std::env::var(RUSTFLAGS).unwrap_or("".into());
     [rustflags, "--cfg hax".into()].join(" ")
 }

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -25,4 +25,4 @@ quote = { workspace = true }
 hax-lib = { path = ".." }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(doc_cfg)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(charon)', 'cfg(doc_cfg)'] }

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -217,7 +217,14 @@ pub fn exclude(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream 
     let item: TokenStream = item.into();
     let _ = parse_macro_input!(attr as parse::Nothing);
     let attr = AttrPayload::ItemStatus(ItemStatus::Excluded { modeled_by: None });
-    quote! {#attr #item}.into()
+    // See `opaque`: also emit charon's native marker for the charon+aeneas (lean)
+    // backend, gated on `cfg(charon)` (set only by that backend).
+    quote! {
+        #attr
+        #[cfg_attr(charon, charon::exclude)]
+        #item
+    }
+    .into()
 }
 
 /*
@@ -877,7 +884,16 @@ pub fn opaque_type(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStr
 pub fn opaque(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: Item = parse_macro_input!(item);
     let attr = AttrPayload::Erased;
-    quote! {#attr #item}.into()
+    // Also emit charon's native opacity marker, so the charon+aeneas (lean) backend
+    // (which bypasses the hax engine and thus never sees `#attr`) makes the body
+    // opaque too. Gated on `cfg(charon)`, which only that backend sets — normal
+    // builds and `into fstar` never see it.
+    quote! {
+        #attr
+        #[cfg_attr(charon, charon::opaque)]
+        #item
+    }
+    .into()
 }
 
 /// Mark an item transparent: the extraction will not

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -202,6 +202,13 @@ pub fn fstar_postprocess_with(attr: pm::TokenStream, item: pm::TokenStream) -> p
     quote! {#[::hax_lib::fstar::before(#payload)] #item}.into()
 }
 
+/// Emit one of charon's native `charon::*` markers. The lean backend drives charon
+/// directly, bypassing the engine, so it is the only one to set `cfg(charon)` on this
+/// crate's build; every other backend gets nothing.
+fn charon_attr(name: TokenStream) -> Option<TokenStream> {
+    cfg!(charon).then(|| quote! {#[charon::#name]})
+}
+
 /// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
 #[proc_macro_attribute]
 pub fn include(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
@@ -217,14 +224,8 @@ pub fn exclude(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream 
     let item: TokenStream = item.into();
     let _ = parse_macro_input!(attr as parse::Nothing);
     let attr = AttrPayload::ItemStatus(ItemStatus::Excluded { modeled_by: None });
-    // See `opaque`: also emit charon's native marker for the charon+aeneas (lean)
-    // backend, gated on `cfg(charon)` (set only by that backend).
-    quote! {
-        #attr
-        #[cfg_attr(charon, charon::exclude)]
-        #item
-    }
-    .into()
+    let charon = charon_attr(quote! {exclude});
+    quote! {#attr #charon #item}.into()
 }
 
 /*
@@ -884,16 +885,8 @@ pub fn opaque_type(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStr
 pub fn opaque(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: Item = parse_macro_input!(item);
     let attr = AttrPayload::Erased;
-    // Also emit charon's native opacity marker, so the charon+aeneas (lean) backend
-    // (which bypasses the hax engine and thus never sees `#attr`) makes the body
-    // opaque too. Gated on `cfg(charon)`, which only that backend sets — normal
-    // builds and `into fstar` never see it.
-    quote! {
-        #attr
-        #[cfg_attr(charon, charon::opaque)]
-        #item
-    }
-    .into()
+    let charon = charon_attr(quote! {opaque});
+    quote! {#attr #charon #item}.into()
 }
 
 /// Mark an item transparent: the extraction will not


### PR DESCRIPTION
Exclude/Opaque for Lean, internally using charon's attributes.

## What

The aeneas-lean backend bypasses the hax engine (rustc → charon → aeneas), so it never honored `hax_lib::opaque` / `hax_lib::exclude`: bodies the user marked opaque were translated anyway, tripping aeneas on constructs it can't handle (e.g. iterator combinators, `&'static` returns).

charon already exposes native tool attributes (`charon::opaque` / `charon::exclude`). This wires the hax markers to them, so **user code keeps a single hax-namespace attribute** — no `charon::` in source:

- **hax-lib macros**: `opaque`/`exclude` additionally emit `#[cfg_attr(charon, charon::opaque|exclude)]`, gated on `cfg(charon)` so normal builds and `into fstar` never see it (the engine still reads its own marker).
- **aeneas-lean backend** (`aeneas.rs`): enable `--cfg charon` + `register_tool(charon)` (so the emitted marker resolves), and set `--cfg hax_backend_lean`.

## Backend scoping (default = all backends)

Reuses the existing `hax_backend_<name>` convention, so nothing new in the attribute surface:

| attribute | effect |
| --- | --- |
| `#[cfg_attr(hax, hax_lib::opaque)]` | all backends (default) |
| `#[cfg_attr(hax_backend_lean, hax_lib::opaque)]` | aeneas-lean only |
| `#[cfg_attr(hax_backend_fstar, hax_lib::opaque)]` | F\* only (unchanged) |

Verified on a minimal crate: `hax_backend_lean` and `hax` produce `axiom` (opaque) in the Lean output, while `hax_backend_fstar` does not leak into the aeneas lane. `cargo build` and the engine backends are unaffected (the charon marker is gated off).

Draft: opening for early feedback on the approach (reusing charon's own attributes vs. teaching charon about hax's `_hax` attributes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
