### PR TITLE
Make -core-models-lib a default aeneas-lean arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes to cargo-hax:
  - Add Lean/Aeneas as a new backend (cryspen/hax-evit/184, cryspen/hax-evit/186, cryspen/hax-evit/189)
  - Unify pining mechanism for aeneas, charon, lean and hax-lib (#2050)
  - rename `lean` backend to `legacy-lean` and `aeneas-lean` to `lean` (#2064)
+ - Make Aeneas option `-core-models-lib` the default for the new lean backend (#2075)
 
 Changes to hax-lib:
  - Basis of core model testing infrastructure (cryspen/hax-evit/160, cryspen/hax-evit/164)

--- a/cli/subcommands/src/aeneas.rs
+++ b/cli/subcommands/src/aeneas.rs
@@ -406,7 +406,8 @@ pub fn run(
     }
     .report(message_format, None);
 
-    // We run aeneas with `-split-files` so it emits the function and type files
+    // We run aeneas with `-core-models-lib` so it uses hax's core models library
+    // for the translation, `-split-files` so it emits the function and type files
     // (`Funs.lean`/`Types.lean`, and any proof-obligation / external-template
     // files) separately, and `-subdir <PkgName>/Extraction` so they land in
     // `<lean_dir>/<PkgName>/Extraction/` with import paths prefixed by
@@ -416,6 +417,7 @@ pub fn run(
     aeneas_cmd.args([
         "-backend",
         "lean",
+        "-core-models-lib",
         "-split-files",
         "-specs",
         "hax",

--- a/examples/lean_barrett/Makefile
+++ b/examples/lean_barrett/Makefile
@@ -1,7 +1,7 @@
 .PHONY:  lean clean
 
 lean:
-	cargo hax into lean --aeneas-args="-core-models-lib"
+	cargo hax into lean
 	(cd proofs/lean && \
    lake exe cache get && \
    lake build)

--- a/examples/loop_equivalence/Makefile
+++ b/examples/loop_equivalence/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default clean
 default:
-	cargo hax into lean --aeneas-args="-core-models-lib"
+	cargo hax into lean
 	(cd proofs/lean && \
    elan default v4.30.0-rc2 && \
    lake exe cache get && \

--- a/examples/sha3/Makefile
+++ b/examples/sha3/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default clean
 default:
-	cargo hax into lean --aeneas-args="-core-models-lib"
+	cargo hax into lean
 	(cd proofs/lean && \
 		elan default v4.30.0-rc2 && \
 		lake exe cache get && \


### PR DESCRIPTION
This PR makes -core-models-lib the default.

I used Claude to implement this, and verified that it didn't miss any obsolete `-core-model-lib` arguments.