### PR TITLE
ci: Free disk space by removing preinstalled packages

### DIFF
--- a/.github/workflows/verify_extraction.yml
+++ b/.github/workflows/verify_extraction.yml
@@ -58,6 +58,8 @@ jobs:
           - adc
     steps:
     - uses: actions/checkout@v4
+    - name: Free disk space by removing preinstalled packages
+      uses: jlumbroso/free-disk-space@main
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: cachix/cachix-action@v15
       with:


### PR DESCRIPTION
The runners are regularly running out of disk space. I think it's because of mathlib. There is this trick to gain some disk space.

[skip changelog]