### PR TITLE
chore: bump hax-lean pin

### DIFF
--- a/pins.toml
+++ b/pins.toml
@@ -30,5 +30,5 @@ toolchain = "leanprover/lean4:v4.31.0"
 
 [hax-lean-lib]
 # Hax library emitted as the `require Hax` of generated lakefiles
-version = "v0.1.0"
+version = "v0.2.0"
 repo = "https://github.com/cryspen/hax-lean"


### PR DESCRIPTION
I created a new tag for `hax-lean`, so that `cargo hax into lean --lakefile` produces a working setup again.

We need to find a better way to do this: I opened https://github.com/cryspen/hax/issues/2083 for discussion

[skip changelog]