### PR TITLE
feat(core-models): add `overflowing_pow` and `checked_pow` to integer models

### DIFF
--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -114,6 +114,20 @@ macro_rules! uint_impl {
             pub fn pow(x: $Self, exp: core::primitive::u32) -> $Self {
                 paste! { [<pow_ $Name>](x, exp) }
             }
+            /// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+            pub fn overflowing_pow(x: $Self, exp: core::primitive::u32) -> ($Self, bool) {
+                paste! { [<overflowing_pow_ $Name>](x, exp) }
+            }
+            /// See [`std::primitive::u8::checked_pow`] (and similar for other integer types)
+            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
+            pub fn checked_pow(x: $Self, exp: core::primitive::u32) -> Option<$Self> {
+                let (result, overflowed) = Self::overflowing_pow(x, exp);
+                if overflowed {
+                    Option::None
+                } else {
+                    Option::Some(result)
+                }
+            }
             /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
             pub fn count_ones(x: $Self) -> core::primitive::u32 {
                 paste! { [<count_ones_ $Name>](x) }
@@ -355,6 +369,20 @@ macro_rules! iint_impl {
             /// See [`std::primitive::u8::pow`] (and similar for other integer types)
             pub fn pow(x: $Self, exp: core::primitive::u32) -> $Self {
                 paste! { [<pow_ $Name>](x, exp) }
+            }
+            /// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+            pub fn overflowing_pow(x: $Self, exp: core::primitive::u32) -> ($Self, bool) {
+                paste! { [<overflowing_pow_ $Name>](x, exp) }
+            }
+            /// See [`std::primitive::u8::checked_pow`] (and similar for other integer types)
+            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
+            pub fn checked_pow(x: $Self, exp: core::primitive::u32) -> Option<$Self> {
+                let (result, overflowed) = Self::overflowing_pow(x, exp);
+                if overflowed {
+                    Option::None
+                } else {
+                    Option::Some(result)
+                }
             }
             /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
             pub fn count_ones(x: $Self) -> core::primitive::u32 {
@@ -729,6 +757,16 @@ mod tests {
                         #[test]
                         fn [<test_ $t _checked_mul>](x in any::<$t>(), y in any::<$t>()) {
                             prop_assert_eq!(super::$t::checked_mul(x.inject(), y.inject()), x.checked_mul(y).inject());
+                        }
+
+                        #[test]
+                        fn [<test_ $t _overflowing_pow>](x in any::<$t>(), exp in 0u32..=140) {
+                            prop_assert_eq!(super::$t::overflowing_pow(x.inject(), exp), x.overflowing_pow(exp));
+                        }
+
+                        #[test]
+                        fn [<test_ $t _checked_pow>](x in any::<$t>(), exp in 0u32..=140) {
+                            prop_assert_eq!(super::$t::checked_pow(x.inject(), exp), x.checked_pow(exp).inject());
                         }
 
                         #[test]

--- a/hax-lib/core-models/rust_primitives/src/lib.rs
+++ b/hax-lib/core-models/rust_primitives/src/lib.rs
@@ -177,6 +177,9 @@ pub mod arithmetic {
                 pub fn [<pow_ $Self>](x: $Self, exp: u32) -> $Self {
                     x.pow(exp)
                 }
+                pub fn [<overflowing_pow_ $Self>](x: $Self, exp: u32) -> ($Self, bool) {
+                    x.overflowing_pow(exp)
+                }
                 pub fn [<count_ones_ $Self>](x: $Self) -> u32 {
                     x.count_ones()
                 }

--- a/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
+++ b/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
@@ -500,6 +500,119 @@ pub fn test_i8_pow_neg_base() -> bool {
 }
 
 // =============================================================================
+// overflowing_pow
+// =============================================================================
+
+// TODO(tuple-eq-extraction: `<T>::overflowing_*` returns `(T, bool)` and our tests compare with `== (_, _)`; `core_models.Pair.PartialEq.eq` is not in the Lean library.)
+/*
+#[rust_lean_test]
+pub fn test_u8_overflowing_pow_no_overflow() -> bool {
+    2u8.overflowing_pow(3u32) == (8u8, false)
+}
+*/
+
+// TODO(tuple-eq-extraction: `<T>::overflowing_*` returns `(T, bool)` and our tests compare with `== (_, _)`; `core_models.Pair.PartialEq.eq` is not in the Lean library.)
+/*
+#[rust_lean_test]
+pub fn test_u8_overflowing_pow_overflow() -> bool {
+    // 4^4 = 256 wraps to 0.
+    4u8.overflowing_pow(4u32) == (0u8, true)
+}
+*/
+
+// TODO(tuple-eq-extraction: `<T>::overflowing_*` returns `(T, bool)` and our tests compare with `== (_, _)`; `core_models.Pair.PartialEq.eq` is not in the Lean library.)
+/*
+#[rust_lean_test]
+pub fn test_u8_overflowing_pow_zero_exp() -> bool {
+    u8::MAX.overflowing_pow(0u32) == (1u8, false)
+}
+*/
+
+// TODO(tuple-eq-extraction: `<T>::overflowing_*` returns `(T, bool)` and our tests compare with `== (_, _)`; `core_models.Pair.PartialEq.eq` is not in the Lean library.)
+/*
+#[rust_lean_test]
+pub fn test_i8_overflowing_pow_neg_base() -> bool {
+    (-2i8).overflowing_pow(2u32) == (4i8, false)
+}
+*/
+
+// TODO(tuple-eq-extraction: `<T>::overflowing_*` returns `(T, bool)` and our tests compare with `== (_, _)`; `core_models.Pair.PartialEq.eq` is not in the Lean library.)
+/*
+#[rust_lean_test]
+pub fn test_i8_overflowing_pow_overflow() -> bool {
+    // (-2)^7 = -128 fits; (-2)^8 = 256 wraps to 0 with overflow.
+    (-2i8).overflowing_pow(8u32) == (0i8, true)
+}
+*/
+
+// =============================================================================
+// checked_pow
+// =============================================================================
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_basic() -> bool {
+    2u8.checked_pow(3u32).unwrap_or(0) == 8u8
+}
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_zero_exp() -> bool {
+    u8::MAX.checked_pow(0u32).unwrap_or(0) == 1u8
+}
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_zero_base() -> bool {
+    0u8.checked_pow(3u32).unwrap_or(1) == 0u8
+}
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_at_max() -> bool {
+    // 2^7 = 128 fits, 2^8 = 256 does not.
+    2u8.checked_pow(7u32).unwrap_or(0) == 128u8
+}
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_overflow() -> bool {
+    2u8.checked_pow(8u32).is_none()
+}
+
+#[rust_lean_test]
+pub fn test_u8_checked_pow_max_base_overflow() -> bool {
+    u8::MAX.checked_pow(2u32).is_none()
+}
+
+#[rust_lean_test]
+pub fn test_u32_checked_pow_basic() -> bool {
+    10u32.checked_pow(9u32).unwrap_or(0) == 1_000_000_000u32
+}
+
+#[rust_lean_test]
+pub fn test_u32_checked_pow_overflow() -> bool {
+    10u32.checked_pow(10u32).is_none()
+}
+
+#[rust_lean_test]
+pub fn test_i8_checked_pow_neg_base() -> bool {
+    (-2i8).checked_pow(2u32).unwrap_or(0) == 4i8
+}
+
+#[rust_lean_test]
+pub fn test_i8_checked_pow_neg_base_odd_exp() -> bool {
+    (-2i8).checked_pow(3u32).unwrap_or(0) == -8i8
+}
+
+#[rust_lean_test]
+pub fn test_i8_checked_pow_at_min() -> bool {
+    // (-2)^7 = -128 = i8::MIN fits exactly.
+    (-2i8).checked_pow(7u32).unwrap_or(0) == i8::MIN
+}
+
+#[rust_lean_test]
+pub fn test_i8_checked_pow_overflow() -> bool {
+    // (-2)^8 = 256 > i8::MAX.
+    (-2i8).checked_pow(8u32).is_none()
+}
+
+// =============================================================================
 // count_ones
 // =============================================================================
 

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -253,6 +253,10 @@ let impl_6__overflowing_mul (x y: u8) : (u8 & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_6__pow (x: u8) (exp: u32) : u8 = Rust_primitives.Arithmetic.pow_u8 x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_6__overflowing_pow (x: u8) (exp: u32) : (u8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_u8 x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_6__count_ones (x: u8) : u32 = Rust_primitives.Arithmetic.count_ones_u8 x
 
@@ -405,6 +409,10 @@ let impl_7__overflowing_mul (x y: u16) : (u16 & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_7__pow (x: u16) (exp: u32) : u16 = Rust_primitives.Arithmetic.pow_u16 x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_7__overflowing_pow (x: u16) (exp: u32) : (u16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_u16 x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_7__count_ones (x: u16) : u32 = Rust_primitives.Arithmetic.count_ones_u16 x
@@ -559,6 +567,10 @@ let impl_8__overflowing_mul (x y: u32) : (u32 & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_8__pow (x exp: u32) : u32 = Rust_primitives.Arithmetic.pow_u32 x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_8__overflowing_pow (x exp: u32) : (u32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_u32 x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_8__count_ones (x: u32) : u32 = Rust_primitives.Arithmetic.count_ones_u32 x
 
@@ -712,6 +724,10 @@ let impl_9__overflowing_mul (x y: u64) : (u64 & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_9__pow (x: u64) (exp: u32) : u64 = Rust_primitives.Arithmetic.pow_u64 x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_9__overflowing_pow (x: u64) (exp: u32) : (u64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_u64 x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_9__count_ones (x: u64) : u32 = Rust_primitives.Arithmetic.count_ones_u64 x
 
@@ -864,6 +880,10 @@ let impl_10__overflowing_mul (x y: u128) : (u128 & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_10__pow (x: u128) (exp: u32) : u128 = Rust_primitives.Arithmetic.pow_u128 x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_10__overflowing_pow (x: u128) (exp: u32) : (u128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_u128 x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_10__count_ones (x: u128) : u32 = Rust_primitives.Arithmetic.count_ones_u128 x
@@ -1023,6 +1043,10 @@ let impl_11__overflowing_mul (x y: usize) : (usize & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_11__pow (x: usize) (exp: u32) : usize = Rust_primitives.Arithmetic.pow_usize x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_11__overflowing_pow (x: usize) (exp: u32) : (usize & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_usize x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_11__count_ones (x: usize) : u32 = Rust_primitives.Arithmetic.count_ones_usize x
 
@@ -1176,6 +1200,10 @@ let impl_12__overflowing_mul (x y: i8) : (i8 & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_12__pow (x: i8) (exp: u32) : i8 = Rust_primitives.Arithmetic.pow_i8 x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_12__overflowing_pow (x: i8) (exp: u32) : (i8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_i8 x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_12__count_ones (x: i8) : u32 = Rust_primitives.Arithmetic.count_ones_i8 x
@@ -1357,6 +1385,10 @@ let impl_13__overflowing_mul (x y: i16) : (i16 & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_13__pow (x: i16) (exp: u32) : i16 = Rust_primitives.Arithmetic.pow_i16 x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_13__overflowing_pow (x: i16) (exp: u32) : (i16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_i16 x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_13__count_ones (x: i16) : u32 = Rust_primitives.Arithmetic.count_ones_i16 x
@@ -1540,6 +1572,10 @@ let impl_14__overflowing_mul (x y: i32) : (i32 & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_14__pow (x: i32) (exp: u32) : i32 = Rust_primitives.Arithmetic.pow_i32 x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_14__overflowing_pow (x: i32) (exp: u32) : (i32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_i32 x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_14__count_ones (x: i32) : u32 = Rust_primitives.Arithmetic.count_ones_i32 x
 
@@ -1722,6 +1758,10 @@ let impl_15__overflowing_mul (x y: i64) : (i64 & bool) =
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_15__pow (x: i64) (exp: u32) : i64 = Rust_primitives.Arithmetic.pow_i64 x exp
 
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_15__overflowing_pow (x: i64) (exp: u32) : (i64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_i64 x exp
+
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_15__count_ones (x: i64) : u32 = Rust_primitives.Arithmetic.count_ones_i64 x
 
@@ -1903,6 +1943,10 @@ let impl_16__overflowing_mul (x y: i128) : (i128 & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_16__pow (x: i128) (exp: u32) : i128 = Rust_primitives.Arithmetic.pow_i128 x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_16__overflowing_pow (x: i128) (exp: u32) : (i128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_i128 x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_16__count_ones (x: i128) : u32 = Rust_primitives.Arithmetic.count_ones_i128 x
@@ -2088,6 +2132,10 @@ let impl_17__overflowing_mul (x y: isize) : (isize & bool) =
 
 /// See [`std::primitive::u8::pow`] (and similar for other integer types)
 let impl_17__pow (x: isize) (exp: u32) : isize = Rust_primitives.Arithmetic.pow_isize x exp
+
+/// See [`std::primitive::u8::overflowing_pow`] (and similar for other integer types)
+let impl_17__overflowing_pow (x: isize) (exp: u32) : (isize & bool) =
+  Rust_primitives.Arithmetic.overflowing_pow_isize x exp
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_17__count_ones (x: isize) : u32 = Rust_primitives.Arithmetic.count_ones_isize x

--- a/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
@@ -43,6 +43,8 @@ include Core_models.Bundle {impl_6__rem_euclid as impl_u8__rem_euclid}
 
 include Core_models.Bundle {impl_6__pow as impl_u8__pow}
 
+include Core_models.Bundle {impl_6__overflowing_pow as impl_u8__overflowing_pow}
+
 include Core_models.Bundle {impl_6__count_ones as impl_u8__count_ones}
 
 include Core_models.Bundle {impl_6__rotate_right as impl_u8__rotate_right}
@@ -116,6 +118,8 @@ include Core_models.Bundle {impl_7__unchecked_mul as impl_u16__unchecked_mul}
 include Core_models.Bundle {impl_7__rem_euclid as impl_u16__rem_euclid}
 
 include Core_models.Bundle {impl_7__pow as impl_u16__pow}
+
+include Core_models.Bundle {impl_7__overflowing_pow as impl_u16__overflowing_pow}
 
 include Core_models.Bundle {impl_7__count_ones as impl_u16__count_ones}
 
@@ -191,6 +195,8 @@ include Core_models.Bundle {impl_8__rem_euclid as impl_u32__rem_euclid}
 
 include Core_models.Bundle {impl_8__pow as impl_u32__pow}
 
+include Core_models.Bundle {impl_8__overflowing_pow as impl_u32__overflowing_pow}
+
 include Core_models.Bundle {impl_8__count_ones as impl_u32__count_ones}
 
 include Core_models.Bundle {impl_8__rotate_right as impl_u32__rotate_right}
@@ -264,6 +270,8 @@ include Core_models.Bundle {impl_9__unchecked_mul as impl_u64__unchecked_mul}
 include Core_models.Bundle {impl_9__rem_euclid as impl_u64__rem_euclid}
 
 include Core_models.Bundle {impl_9__pow as impl_u64__pow}
+
+include Core_models.Bundle {impl_9__overflowing_pow as impl_u64__overflowing_pow}
 
 include Core_models.Bundle {impl_9__count_ones as impl_u64__count_ones}
 
@@ -339,6 +347,8 @@ include Core_models.Bundle {impl_10__rem_euclid as impl_u128__rem_euclid}
 
 include Core_models.Bundle {impl_10__pow as impl_u128__pow}
 
+include Core_models.Bundle {impl_10__overflowing_pow as impl_u128__overflowing_pow}
+
 include Core_models.Bundle {impl_10__count_ones as impl_u128__count_ones}
 
 include Core_models.Bundle {impl_10__rotate_right as impl_u128__rotate_right}
@@ -412,6 +422,8 @@ include Core_models.Bundle {impl_11__unchecked_mul as impl_usize__unchecked_mul}
 include Core_models.Bundle {impl_11__rem_euclid as impl_usize__rem_euclid}
 
 include Core_models.Bundle {impl_11__pow as impl_usize__pow}
+
+include Core_models.Bundle {impl_11__overflowing_pow as impl_usize__overflowing_pow}
 
 include Core_models.Bundle {impl_11__count_ones as impl_usize__count_ones}
 
@@ -491,6 +503,8 @@ include Core_models.Bundle {impl_12__rem_euclid as impl_i8__rem_euclid}
 
 include Core_models.Bundle {impl_12__pow as impl_i8__pow}
 
+include Core_models.Bundle {impl_12__overflowing_pow as impl_i8__overflowing_pow}
+
 include Core_models.Bundle {impl_12__count_ones as impl_i8__count_ones}
 
 include Core_models.Bundle {impl_12__abs as impl_i8__abs}
@@ -568,6 +582,8 @@ include Core_models.Bundle {impl_13__unchecked_mul as impl_i16__unchecked_mul}
 include Core_models.Bundle {impl_13__rem_euclid as impl_i16__rem_euclid}
 
 include Core_models.Bundle {impl_13__pow as impl_i16__pow}
+
+include Core_models.Bundle {impl_13__overflowing_pow as impl_i16__overflowing_pow}
 
 include Core_models.Bundle {impl_13__count_ones as impl_i16__count_ones}
 
@@ -647,6 +663,8 @@ include Core_models.Bundle {impl_14__rem_euclid as impl_i32__rem_euclid}
 
 include Core_models.Bundle {impl_14__pow as impl_i32__pow}
 
+include Core_models.Bundle {impl_14__overflowing_pow as impl_i32__overflowing_pow}
+
 include Core_models.Bundle {impl_14__count_ones as impl_i32__count_ones}
 
 include Core_models.Bundle {impl_14__abs as impl_i32__abs}
@@ -724,6 +742,8 @@ include Core_models.Bundle {impl_15__unchecked_mul as impl_i64__unchecked_mul}
 include Core_models.Bundle {impl_15__rem_euclid as impl_i64__rem_euclid}
 
 include Core_models.Bundle {impl_15__pow as impl_i64__pow}
+
+include Core_models.Bundle {impl_15__overflowing_pow as impl_i64__overflowing_pow}
 
 include Core_models.Bundle {impl_15__count_ones as impl_i64__count_ones}
 
@@ -803,6 +823,8 @@ include Core_models.Bundle {impl_16__rem_euclid as impl_i128__rem_euclid}
 
 include Core_models.Bundle {impl_16__pow as impl_i128__pow}
 
+include Core_models.Bundle {impl_16__overflowing_pow as impl_i128__overflowing_pow}
+
 include Core_models.Bundle {impl_16__count_ones as impl_i128__count_ones}
 
 include Core_models.Bundle {impl_16__abs as impl_i128__abs}
@@ -880,6 +902,8 @@ include Core_models.Bundle {impl_17__unchecked_mul as impl_isize__unchecked_mul}
 include Core_models.Bundle {impl_17__rem_euclid as impl_isize__rem_euclid}
 
 include Core_models.Bundle {impl_17__pow as impl_isize__pow}
+
+include Core_models.Bundle {impl_17__overflowing_pow as impl_isize__overflowing_pow}
 
 include Core_models.Bundle {impl_17__count_ones as impl_isize__count_ones}
 

--- a/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
+++ b/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
@@ -18,6 +18,7 @@ val saturating_mul_u8 : u8 -> u8 -> u8
 let overflowing_mul_u8 : u8 -> u8 -> u8 & bool = mul_overflow
 let rem_euclid_u8 (x: u8) (y: u8 {v y <> 0}): u8 = x %! y
 val pow_u8 : u8 -> u32 -> u8
+val overflowing_pow_u8 : u8 -> u32 -> u8 & bool
 val count_ones_u8 : u8 -> r:u32{v r <= 8}
 unfold 
 let rotate_left_u8 = rotate_left_u #U8
@@ -37,6 +38,7 @@ val saturating_mul_u16 : u16 -> u16 -> u16
 let overflowing_mul_u16 : u16 -> u16 -> u16 & bool = mul_overflow
 let rem_euclid_u16 (x: u16) (y: u16 {v y <> 0}): u16 = x %! y
 val pow_u16 : x:u16 -> y:u32 -> result : u16 {v x == 2 /\ v y < 16 ==> result == mk_u16 (pow2 (v y))}
+val overflowing_pow_u16 : u16 -> u32 -> u16 & bool
 val count_ones_u16 : u16 -> r:u32{v r <= 16}
 unfold 
 let rotate_left_u16 = rotate_left_u #U16
@@ -56,6 +58,7 @@ val saturating_mul_u32 : u32 -> u32 -> u32
 let overflowing_mul_u32 : u32 -> u32 -> u32 & bool = mul_overflow
 let rem_euclid_u32 (x: u32) (y: u32 {v y <> 0}): u32 = x %! y
 val pow_u32 : x:u32 -> y:u32 -> result : u32 {v x == 2 /\ v y <= 16 ==> result == mk_u32 (pow2 (v y))}
+val overflowing_pow_u32 : u32 -> u32 -> u32 & bool
 val count_ones_u32 : u32 -> r:u32{v r <= 32}
 unfold 
 let rotate_left_u32 = rotate_left_u #U32
@@ -75,6 +78,7 @@ val saturating_mul_u64 : u64 -> u64 -> u64
 let overflowing_mul_u64 : u64 -> u64 -> u64 & bool = mul_overflow
 let rem_euclid_u64 (x: u64) (y: u64 {v y <> 0}): u64 = x %! y
 val pow_u64 : u64 -> u32 -> u64
+val overflowing_pow_u64 : u64 -> u32 -> u64 & bool
 val count_ones_u64 : u64 -> r:u32{v r <= 64}
 unfold 
 let rotate_left_u64 = rotate_left_u #U64
@@ -94,6 +98,7 @@ val saturating_mul_u128 : u128 -> u128 -> u128
 let overflowing_mul_u128 : u128 -> u128 -> u128 & bool = mul_overflow
 let rem_euclid_u128 (x: u128) (y: u128 {v y <> 0}): u128 = x %! y
 val pow_u128 : u128 -> u32 -> u128
+val overflowing_pow_u128 : u128 -> u32 -> u128 & bool
 val count_ones_u128 : u128 -> r:u32{v r <= 128}
 unfold 
 let rotate_left_u128 = rotate_left_u #U128
@@ -113,6 +118,7 @@ val saturating_mul_usize : usize -> usize -> usize
 let overflowing_mul_usize : usize -> usize -> usize & bool = mul_overflow
 let rem_euclid_usize (x: usize) (y: usize {v y <> 0}): usize = x %! y
 val pow_usize : usize -> u32 -> usize
+val overflowing_pow_usize : usize -> u32 -> usize & bool
 val count_ones_usize : usize -> r:u32{v r <= size_bits}
 unfold 
 let rotate_left_usize = rotate_left_u #USIZE
@@ -128,6 +134,7 @@ val saturating_mul_i8 : i8 -> i8 -> i8
 let overflowing_mul_i8 : i8 -> i8 -> i8 & bool = mul_overflow
 let rem_euclid_i8 (x: i8) (y: i8 {v y <> 0}): i8 = x %! y
 val pow_i8 : i8 -> u32 -> i8
+val overflowing_pow_i8 : i8 -> u32 -> i8 & bool
 val count_ones_i8 : i8 -> r:u32{v r <= 8}
 val abs_i8 : i8 -> i8
 
@@ -142,6 +149,7 @@ val saturating_mul_i16 : i16 -> i16 -> i16
 let overflowing_mul_i16 : i16 -> i16 -> i16 & bool = mul_overflow
 let rem_euclid_i16 (x: i16) (y: i16 {v y <> 0}): i16 = x %! y
 val pow_i16 : x: i16 -> y:u32 -> result: i16 {v x == 2 /\ v y < 15 ==> (Math.Lemmas.pow2_lt_compat 15 (v y); result == mk_i16 (pow2 (v y)))}
+val overflowing_pow_i16 : i16 -> u32 -> i16 & bool
 val count_ones_i16 : i16 -> r:u32{v r <= 16}
 val abs_i16 : i16 -> i16
 
@@ -156,6 +164,7 @@ val saturating_mul_i32 : i32 -> i32 -> i32
 let overflowing_mul_i32 : i32 -> i32 -> i32 & bool = mul_overflow
 let rem_euclid_i32 (x: i32) (y: i32 {v y <> 0}): i32 = x %! y
 val pow_i32 : x : i32 -> y:u32 -> result: i32 {v x == 2 /\ v y <= 16 ==> result == mk_i32 (pow2 (v y))}
+val overflowing_pow_i32 : i32 -> u32 -> i32 & bool
 val count_ones_i32 : i32 -> r:u32{v r <= 32}
 val abs_i32 : i32 -> i32
 
@@ -170,6 +179,7 @@ val saturating_mul_i64 : i64 -> i64 -> i64
 let overflowing_mul_i64 : i64 -> i64 -> i64 & bool = mul_overflow
 let rem_euclid_i64 (x: i64) (y: i64 {v y <> 0}): i64 = x %! y
 val pow_i64 : i64 -> u32 -> i64
+val overflowing_pow_i64 : i64 -> u32 -> i64 & bool
 val count_ones_i64 : i64 -> r:u32{v r <= 64}
 val abs_i64 : i64 -> i64
 
@@ -184,6 +194,7 @@ val saturating_mul_i128 : i128 -> i128 -> i128
 let overflowing_mul_i128 : i128 -> i128 -> i128 & bool = mul_overflow
 let rem_euclid_i128 (x: i128) (y: i128 {v y <> 0}): i128 = x %! y
 val pow_i128 : i128 -> u32 -> i128
+val overflowing_pow_i128 : i128 -> u32 -> i128 & bool
 val count_ones_i128 : i128 -> r:u32{v r <= 128}
 val abs_i128 : i128 -> i128
 
@@ -198,6 +209,7 @@ val saturating_mul_isize : isize -> isize -> isize
 let overflowing_mul_isize : isize -> isize -> isize & bool = mul_overflow
 let rem_euclid_isize (x: isize) (y: isize {v y <> 0}): isize = x %! y
 val pow_isize : isize -> u32 -> isize
+val overflowing_pow_isize : isize -> u32 -> isize & bool
 val count_ones_isize : isize -> r:u32{v r <= size_bits}
 val abs_isize : isize -> isize
 

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -1844,14 +1844,14 @@ def U64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MAX : Std.I8 := 127#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MIN : Std.I8 := (-128)#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1904,14 +1904,14 @@ def I8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MAX : Std.I16 := 32767#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MIN : Std.I16 := (-32768)#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1991,14 +1991,14 @@ def I16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MAX : Std.I32 := 2147483647#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MIN : Std.I32 := (-2147483648)#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2030,7 +2030,7 @@ def I32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
@@ -2038,7 +2038,7 @@ def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MIN : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MIN
@@ -2148,7 +2148,7 @@ def I32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MAX : Std.I64 := 9223372036854775807#i64
@@ -2156,7 +2156,7 @@ def num.I64.MAX : Std.I64 := 9223372036854775807#i64
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MIN : Std.I64 := (-9223372036854775808)#i64
@@ -2674,7 +2674,7 @@ def I64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
+    Source: 'core-models/src/core/num/mod.rs', lines 264:12-264:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MAX : Std.I128 := 170141183460469231731687303715884105727#i128
@@ -5385,14 +5385,14 @@ def option.Option.unwrap {T : Type} (self : option.Option T) : Result T := do
   | option.Option.None => panicking.internal.panic T
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I8.overflowing_add
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.I8.checked_add_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5413,14 +5413,14 @@ def I8.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I16.overflowing_add
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.I16.checked_add_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5441,14 +5441,14 @@ def I16.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I32.overflowing_add
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.I32.checked_add_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5469,14 +5469,14 @@ def I32.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I64.overflowing_add
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.I64.checked_add_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5497,14 +5497,14 @@ def I64.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.Isize.overflowing_add
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.Isize.checked_add_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5525,14 +5525,14 @@ def Isize.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I128.overflowing_add
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
+    Source: 'core-models/src/core/num/mod.rs', lines 319:12-328:13
     Visibility: public -/
 def num.I128.checked_add_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5553,14 +5553,14 @@ def I128.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I8.overflowing_sub
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.I8.checked_sub_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5581,14 +5581,14 @@ def I8.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I16.overflowing_sub
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.I16.checked_sub_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5609,14 +5609,14 @@ def I16.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I32.overflowing_sub
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.I32.checked_sub_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5637,14 +5637,14 @@ def I32.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I64.overflowing_sub
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.I64.checked_sub_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5665,14 +5665,14 @@ def I64.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.Isize.overflowing_sub
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.Isize.checked_sub_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5693,14 +5693,14 @@ def Isize.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I128.overflowing_sub
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 330:12-337:13
     Visibility: public -/
 def num.I128.checked_sub_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5926,7 +5926,7 @@ def U8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I8.wrapping_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_add_i8 x y
@@ -5990,7 +5990,7 @@ def U16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I16.wrapping_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_add_i16 x y
@@ -6054,7 +6054,7 @@ def U32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I32.wrapping_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_add_i32 x y
@@ -6118,7 +6118,7 @@ def U64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I64.wrapping_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_add_i64 x y
@@ -6184,7 +6184,7 @@ def Usize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.Isize.wrapping_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6249,7 +6249,7 @@ def U128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.I128.checked_add
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -6310,7 +6310,7 @@ def U8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.I8.wrapping_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_sub_i8 x y
@@ -6374,7 +6374,7 @@ def U16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.I16.wrapping_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_sub_i16 x y
@@ -6438,7 +6438,7 @@ def U32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.I32.wrapping_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_sub_i32 x y
@@ -6502,7 +6502,7 @@ def U64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.I64.wrapping_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_sub_i64 x y
@@ -6568,7 +6568,7 @@ def Usize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.Isize.wrapping_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6633,7 +6633,7 @@ def U128.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.I128.checked_sub
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -7702,190 +7702,292 @@ def num.U128.pow (x : Std.U128) (exp : Std.U32) : Result Std.U128 := do
 def num.Usize.pow (x : Std.Usize) (exp : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.pow_usize x exp
 
-/-- [core_models::num::{core_models::num::u8}::count_ones]:
+/-- [core_models::num::{core_models::num::u8}::overflowing_pow]:
     Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.U8.overflowing_pow
+  (x : Std.U8) (exp : Std.U32) : Result (Std.U8 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_u8 x exp
+
+/-- [core_models::num::{core_models::num::u16}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.U16.overflowing_pow
+  (x : Std.U16) (exp : Std.U32) : Result (Std.U16 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_u16 x exp
+
+/-- [core_models::num::{core_models::num::u32}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.U32.overflowing_pow
+  (x : Std.U32) (exp : Std.U32) : Result (Std.U32 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_u32 x exp
+
+/-- [core_models::num::{core_models::num::u64}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.U64.overflowing_pow
+  (x : Std.U64) (exp : Std.U32) : Result (Std.U64 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_u64 x exp
+
+/-- [core_models::num::{core_models::num::u128}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.U128.overflowing_pow
+  (x : Std.U128) (exp : Std.U32) : Result (Std.U128 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_u128 x exp
+
+/-- [core_models::num::{core_models::num::usize}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Visibility: public -/
+def num.Usize.overflowing_pow
+  (x : Std.Usize) (exp : Std.U32) : Result (Std.Usize × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_usize x exp
+
+/-- [core_models::num::{core_models::num::u8}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.U8.checked_pow
+  (x : Std.U8) (exp : Std.U32) : Result (option.Option Std.U8) := do
+  let (result, overflowed) ← num.U8.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::u16}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.U16.checked_pow
+  (x : Std.U16) (exp : Std.U32) : Result (option.Option Std.U16) := do
+  let (result, overflowed) ← num.U16.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::u32}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.U32.checked_pow
+  (x : Std.U32) (exp : Std.U32) : Result (option.Option Std.U32) := do
+  let (result, overflowed) ← num.U32.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::u64}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.U64.checked_pow
+  (x : Std.U64) (exp : Std.U32) : Result (option.Option Std.U64) := do
+  let (result, overflowed) ← num.U64.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::u128}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.U128.checked_pow
+  (x : Std.U128) (exp : Std.U32) : Result (option.Option Std.U128) := do
+  let (result, overflowed) ← num.U128.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::usize}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Visibility: public -/
+def num.Usize.checked_pow
+  (x : Std.Usize) (exp : Std.U32) : Result (option.Option Std.Usize) := do
+  let (result, overflowed) ← num.Usize.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::u8}::count_ones]:
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.U8.count_ones (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.U16.count_ones (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.U32.count_ones (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.U64.count_ones (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.U128.count_ones (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
     Visibility: public -/
 def num.Usize.count_ones (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_usize x
 
 /-- [core_models::num::{core_models::num::u8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.U8.rotate_right (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_right_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.U16.rotate_right (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_right_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.U32.rotate_right (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_right_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.U64.rotate_right (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_right_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.U128.rotate_right (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_right_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
     Visibility: public -/
 def num.Usize.rotate_right
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_right_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.U8.rotate_left (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_left_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.U16.rotate_left (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_left_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.U32.rotate_left (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_left_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.U64.rotate_left (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_left_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.U128.rotate_left (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_left_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
     Visibility: public -/
 def num.Usize.rotate_left
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_left_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.U8.leading_zeros (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.U16.leading_zeros (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.U32.leading_zeros (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.U64.leading_zeros (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.U128.leading_zeros (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
     Visibility: public -/
 def num.Usize.leading_zeros (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_usize x
 
 /-- [core_models::num::{core_models::num::u8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.U8.ilog2 (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.U16.ilog2 (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.U32.ilog2 (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.U64.ilog2 (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.U128.ilog2 (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
     Visibility: public -/
 def num.Usize.ilog2 (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_usize x
 
 /-- [core_models::num::{core_models::num::u8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.U8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7894,7 +7996,7 @@ def num.U8.from_str_radix
   panicking.internal.panic (result.Result Std.U8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.U16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7903,7 +8005,7 @@ def num.U16.from_str_radix
   panicking.internal.panic (result.Result Std.U16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.U32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7912,7 +8014,7 @@ def num.U32.from_str_radix
   panicking.internal.panic (result.Result Std.U32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.U64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7921,7 +8023,7 @@ def num.U64.from_str_radix
   panicking.internal.panic (result.Result Std.U64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.U128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7930,7 +8032,7 @@ def num.U128.from_str_radix
   panicking.internal.panic (result.Result Std.U128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::usize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
+    Source: 'core-models/src/core/num/mod.rs', lines 157:12-162:13
     Visibility: public -/
 def num.Usize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7939,159 +8041,159 @@ def num.Usize.from_str_radix
   panicking.internal.panic (result.Result Std.Usize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.Usize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.Usize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.U8.to_be_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.U16.to_be_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.U32.to_be_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.U64.to_be_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.U128.to_be_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-177:13
     Visibility: public -/
 def num.Usize.to_be_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.U8.to_le_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.U16.to_le_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.U32.to_le_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.U64.to_le_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.U128.to_le_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
+    Source: 'core-models/src/core/num/mod.rs', lines 180:12-182:13
     Visibility: public -/
 def num.Usize.to_le_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.U8.checked_div
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8101,7 +8203,7 @@ def num.U8.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.U16.checked_div
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8111,7 +8213,7 @@ def num.U16.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.U32.checked_div
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8121,7 +8223,7 @@ def num.U32.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.U64.checked_div
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8131,7 +8233,7 @@ def num.U64.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.U128.checked_div
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8141,7 +8243,7 @@ def num.U128.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-190:13
     Visibility: public -/
 def num.Usize.checked_div
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8151,45 +8253,45 @@ def num.Usize.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.U8.unchecked_div (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.U16.unchecked_div (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.U32.unchecked_div (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.U64.unchecked_div (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.U128.unchecked_div
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 193:12-195:13
     Visibility: public -/
 def num.Usize.unchecked_div
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x / y
 
 /-- [core_models::num::{core_models::num::u8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.U8.checked_rem
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8199,7 +8301,7 @@ def num.U8.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.U16.checked_rem
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8209,7 +8311,7 @@ def num.U16.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.U32.checked_rem
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8219,7 +8321,7 @@ def num.U32.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.U64.checked_rem
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8229,7 +8331,7 @@ def num.U64.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.U128.checked_rem
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8239,7 +8341,7 @@ def num.U128.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
+    Source: 'core-models/src/core/num/mod.rs', lines 197:12-203:13
     Visibility: public -/
 def num.Usize.checked_rem
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8249,45 +8351,45 @@ def num.Usize.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.U8.unchecked_rem (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.U16.unchecked_rem (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.U32.unchecked_rem (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.U64.unchecked_rem (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.U128.unchecked_rem
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
+    Source: 'core-models/src/core/num/mod.rs', lines 206:12-208:13
     Visibility: public -/
 def num.Usize.unchecked_rem
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x % y
 
 /-- [core_models::num::{core_models::num::u8}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   if x != 0#u8
@@ -8297,7 +8399,7 @@ def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u16}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   if x != 0#u16
@@ -8307,7 +8409,7 @@ def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u32}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   if x != 0#u32
@@ -8317,7 +8419,7 @@ def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u64}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   if x != 0#u64
@@ -8327,7 +8429,7 @@ def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u128}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   if x != 0#u128
@@ -8337,7 +8439,7 @@ def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::usize}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 210:12-212:13
     Visibility: public -/
 def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   if x != 0#usize
@@ -8347,7 +8449,7 @@ def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   let d ← x / y
@@ -8357,7 +8459,7 @@ def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   let d ← x / y
@@ -8367,7 +8469,7 @@ def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   let d ← x / y
@@ -8377,7 +8479,7 @@ def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   let d ← x / y
@@ -8387,7 +8489,7 @@ def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   let d ← x / y
@@ -8397,7 +8499,7 @@ def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::usize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
+    Source: 'core-models/src/core/num/mod.rs', lines 215:12-219:13
     Visibility: public -/
 def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   let d ← x / y
@@ -8407,7 +8509,7 @@ def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u8}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
   if y = 0#u8
@@ -8416,7 +8518,7 @@ def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
        ok (i = 0#u8)
 
 /-- [core_models::num::{core_models::num::u16}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
   if y = 0#u16
@@ -8425,7 +8527,7 @@ def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
        ok (i = 0#u16)
 
 /-- [core_models::num::{core_models::num::u32}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
   if y = 0#u32
@@ -8434,7 +8536,7 @@ def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
        ok (i = 0#u32)
 
 /-- [core_models::num::{core_models::num::u64}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
   if y = 0#u64
@@ -8443,7 +8545,7 @@ def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
        ok (i = 0#u64)
 
 /-- [core_models::num::{core_models::num::u128}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
   if y = 0#u128
@@ -8452,7 +8554,7 @@ def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
        ok (i = 0#u128)
 
 /-- [core_models::num::{core_models::num::usize}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
+    Source: 'core-models/src/core/num/mod.rs', lines 221:12-227:13
     Visibility: public -/
 def num.Usize.is_multiple_of
   (x : Std.Usize) (y : Std.Usize) : Result Bool := do
@@ -8463,89 +8565,89 @@ def num.Usize.is_multiple_of
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
+    Source: 'core-models/src/core/num/mod.rs', lines 262:12-262:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MIN : Std.I128 := (-170141183460469231731687303715884105728)#i128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-- [core_models::num::{core_models::num::i8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::i16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::i32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::i64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::i128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::isize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
+    Source: 'core-models/src/core/num/mod.rs', lines 266:12-266:57
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.BITS : Result Std.U32 := rust_primitives.arithmetic.SIZE_BITS
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I128.wrapping_add (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.I8.saturating_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.I16.saturating_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.I32.saturating_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.I64.saturating_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.I128.saturating_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_add_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
+    Source: 'core-models/src/core/num/mod.rs', lines 271:12-273:13
     Visibility: public -/
 def num.Isize.saturating_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_add_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.I8.checked_add
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8555,7 +8657,7 @@ def num.I8.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.I16.checked_add
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8565,7 +8667,7 @@ def num.I16.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.I32.checked_add
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8575,7 +8677,7 @@ def num.I32.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.I64.checked_add
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8585,7 +8687,7 @@ def num.I64.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-286:13
     Visibility: public -/
 def num.Isize.checked_add
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8595,89 +8697,89 @@ def num.Isize.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.I8.unchecked_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.I16.unchecked_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.I32.unchecked_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.I64.unchecked_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.I128.unchecked_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x + y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
+    Source: 'core-models/src/core/num/mod.rs', lines 289:12-291:13
     Visibility: public -/
 def num.Isize.unchecked_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 293:12-295:13
     Visibility: public -/
 def num.I128.wrapping_sub (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.I8.saturating_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.I16.saturating_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.I32.saturating_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.I64.saturating_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.I128.saturating_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 297:12-299:13
     Visibility: public -/
 def num.Isize.saturating_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_sub_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.I8.checked_sub
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8687,7 +8789,7 @@ def num.I8.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.I16.checked_sub
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8697,7 +8799,7 @@ def num.I16.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.I32.checked_sub
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8707,7 +8809,7 @@ def num.I32.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.I64.checked_sub
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8717,7 +8819,7 @@ def num.I64.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-312:13
     Visibility: public -/
 def num.Isize.checked_sub
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8727,162 +8829,162 @@ def num.Isize.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.I8.unchecked_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.I16.unchecked_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.I32.unchecked_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.I64.unchecked_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.I128.unchecked_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x - y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 315:12-317:13
     Visibility: public -/
 def num.Isize.unchecked_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x - y
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I8.wrapping_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I16.wrapping_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I32.wrapping_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I64.wrapping_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I128.wrapping_mul (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.Isize.wrapping_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.wrapping_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I8.saturating_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I16.saturating_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I32.saturating_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I64.saturating_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I128.saturating_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.Isize.saturating_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I8.overflowing_mul
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I16.overflowing_mul
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I32.overflowing_mul
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I64.overflowing_mul
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I128.overflowing_mul
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.Isize.overflowing_mul
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I8.checked_mul
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8892,7 +8994,7 @@ def num.I8.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I16.checked_mul
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8902,7 +9004,7 @@ def num.I16.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I32.checked_mul
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8912,7 +9014,7 @@ def num.I32.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I64.checked_mul
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8922,7 +9024,7 @@ def num.I64.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I128.checked_mul
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -8932,7 +9034,7 @@ def num.I128.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.Isize.checked_mul
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8942,336 +9044,438 @@ def num.Isize.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.I8.unchecked_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.I16.unchecked_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.I32.unchecked_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.I64.unchecked_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.I128.unchecked_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
+    Source: 'core-models/src/core/num/mod.rs', lines 361:12-363:13
     Visibility: public -/
 def num.Isize.unchecked_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x * y
 
 /-- [core_models::num::{core_models::num::i8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.I8.rem_euclid (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.rem_euclid_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.I16.rem_euclid (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.rem_euclid_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.I32.rem_euclid (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.rem_euclid_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.I64.rem_euclid (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.rem_euclid_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.I128.rem_euclid (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.rem_euclid_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
+    Source: 'core-models/src/core/num/mod.rs', lines 366:12-368:13
     Visibility: public -/
 def num.Isize.rem_euclid
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.rem_euclid_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I8.pow (x : Std.I8) (exp : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.pow_i8 x exp
 
 /-- [core_models::num::{core_models::num::i16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I16.pow (x : Std.I16) (exp : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.pow_i16 x exp
 
 /-- [core_models::num::{core_models::num::i32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I32.pow (x : Std.I32) (exp : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.pow_i32 x exp
 
 /-- [core_models::num::{core_models::num::i64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I64.pow (x : Std.I64) (exp : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.pow_i64 x exp
 
 /-- [core_models::num::{core_models::num::i128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I128.pow (x : Std.I128) (exp : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.pow_i128 x exp
 
 /-- [core_models::num::{core_models::num::isize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.Isize.pow (x : Std.Isize) (exp : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.pow_isize x exp
 
+/-- [core_models::num::{core_models::num::i8}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.I8.overflowing_pow
+  (x : Std.I8) (exp : Std.U32) : Result (Std.I8 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_i8 x exp
+
+/-- [core_models::num::{core_models::num::i16}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.I16.overflowing_pow
+  (x : Std.I16) (exp : Std.U32) : Result (Std.I16 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_i16 x exp
+
+/-- [core_models::num::{core_models::num::i32}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.I32.overflowing_pow
+  (x : Std.I32) (exp : Std.U32) : Result (Std.I32 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_i32 x exp
+
+/-- [core_models::num::{core_models::num::i64}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.I64.overflowing_pow
+  (x : Std.I64) (exp : Std.U32) : Result (Std.I64 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_i64 x exp
+
+/-- [core_models::num::{core_models::num::i128}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.I128.overflowing_pow
+  (x : Std.I128) (exp : Std.U32) : Result (Std.I128 × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_i128 x exp
+
+/-- [core_models::num::{core_models::num::isize}::overflowing_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 374:12-376:13
+    Visibility: public -/
+def num.Isize.overflowing_pow
+  (x : Std.Isize) (exp : Std.U32) : Result (Std.Isize × Bool) := do
+  rust_primitives.arithmetic.overflowing_pow_isize x exp
+
+/-- [core_models::num::{core_models::num::i8}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.I8.checked_pow
+  (x : Std.I8) (exp : Std.U32) : Result (option.Option Std.I8) := do
+  let (result, overflowed) ← num.I8.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::i16}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.I16.checked_pow
+  (x : Std.I16) (exp : Std.U32) : Result (option.Option Std.I16) := do
+  let (result, overflowed) ← num.I16.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::i32}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.I32.checked_pow
+  (x : Std.I32) (exp : Std.U32) : Result (option.Option Std.I32) := do
+  let (result, overflowed) ← num.I32.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::i64}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.I64.checked_pow
+  (x : Std.I64) (exp : Std.U32) : Result (option.Option Std.I64) := do
+  let (result, overflowed) ← num.I64.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::i128}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.I128.checked_pow
+  (x : Std.I128) (exp : Std.U32) : Result (option.Option Std.I128) := do
+  let (result, overflowed) ← num.I128.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
+/-- [core_models::num::{core_models::num::isize}::checked_pow]:
+    Source: 'core-models/src/core/num/mod.rs', lines 379:12-386:13
+    Visibility: public -/
+def num.Isize.checked_pow
+  (x : Std.Isize) (exp : Std.U32) : Result (option.Option Std.Isize) := do
+  let (result, overflowed) ← num.Isize.overflowing_pow x exp
+  if overflowed
+  then ok option.Option.None
+  else ok (option.Option.Some result)
+
 /-- [core_models::num::{core_models::num::i8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I8.count_ones (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I16.count_ones (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I32.count_ones (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I64.count_ones (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I128.count_ones (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.Isize.count_ones (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_isize x
 
 /-- [core_models::num::{core_models::num::i8}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.I8.abs (x : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.abs_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.I16.abs (x : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.abs_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.I32.abs (x : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.abs_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.I64.abs (x : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.abs_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.I128.abs (x : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.abs_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
+    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
     Visibility: public -/
 def num.Isize.abs (x : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.abs_isize x
 
 /-- [core_models::num::{core_models::num::i8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I8.rotate_right (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_right_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I16.rotate_right (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_right_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I32.rotate_right (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_right_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I64.rotate_right (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_right_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I128.rotate_right (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_right_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.Isize.rotate_right
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_right_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I8.rotate_left (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_left_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I16.rotate_left (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_left_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I32.rotate_left (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_left_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I64.rotate_left (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_left_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I128.rotate_left (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_left_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.Isize.rotate_left
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_left_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I8.leading_zeros (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I16.leading_zeros (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I32.leading_zeros (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I64.leading_zeros (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I128.leading_zeros (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.Isize.leading_zeros (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_isize x
 
 /-- [core_models::num::{core_models::num::i8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I8.ilog2 (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I16.ilog2 (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I32.ilog2 (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I64.ilog2 (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I128.ilog2 (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.Isize.ilog2 (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_isize x
 
 /-- [core_models::num::{core_models::num::i8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.I8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9280,7 +9484,7 @@ def num.I8.from_str_radix
   panicking.internal.panic (result.Result Std.I8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.I16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9289,7 +9493,7 @@ def num.I16.from_str_radix
   panicking.internal.panic (result.Result Std.I16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.I32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9298,7 +9502,7 @@ def num.I32.from_str_radix
   panicking.internal.panic (result.Result Std.I32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.I64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9307,7 +9511,7 @@ def num.I64.from_str_radix
   panicking.internal.panic (result.Result Std.I64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.I128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9316,7 +9520,7 @@ def num.I128.from_str_radix
   panicking.internal.panic (result.Result Std.I128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::isize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 418:12-423:13
     Visibility: public -/
 def num.Isize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9325,159 +9529,159 @@ def num.Isize.from_str_radix
   panicking.internal.panic (result.Result Std.Isize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.Isize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.I8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.I16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.I32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.I64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.I128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
+    Source: 'core-models/src/core/num/mod.rs', lines 431:12-433:13
     Visibility: public -/
 def num.Isize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.I8.to_be_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.I16.to_be_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.I32.to_be_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.I64.to_be_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.I128.to_be_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
+    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
     Visibility: public -/
 def num.Isize.to_be_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.I8.to_le_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.I16.to_le_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.I32.to_le_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.I64.to_le_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.I128.to_le_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
+    Source: 'core-models/src/core/num/mod.rs', lines 441:12-443:13
     Visibility: public -/
 def num.Isize.to_le_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.I8.checked_div
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9494,7 +9698,7 @@ def num.I8.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.I16.checked_div
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9511,7 +9715,7 @@ def num.I16.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.I32.checked_div
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9528,7 +9732,7 @@ def num.I32.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.I64.checked_div
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9545,7 +9749,7 @@ def num.I64.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.I128.checked_div
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9562,7 +9766,7 @@ def num.I128.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
+    Source: 'core-models/src/core/num/mod.rs', lines 445:12-451:13
     Visibility: public -/
 def num.Isize.checked_div
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9580,45 +9784,45 @@ def num.Isize.checked_div
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.I8.unchecked_div (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.I16.unchecked_div (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.I32.unchecked_div (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.I64.unchecked_div (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.I128.unchecked_div
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
+    Source: 'core-models/src/core/num/mod.rs', lines 454:12-456:13
     Visibility: public -/
 def num.Isize.unchecked_div
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x / y
 
 /-- [core_models::num::{core_models::num::i8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.I8.checked_rem
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9635,7 +9839,7 @@ def num.I8.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.I16.checked_rem
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9652,7 +9856,7 @@ def num.I16.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.I32.checked_rem
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9669,7 +9873,7 @@ def num.I32.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.I64.checked_rem
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9686,7 +9890,7 @@ def num.I64.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.I128.checked_rem
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9703,7 +9907,7 @@ def num.I128.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 458:12-464:13
     Visibility: public -/
 def num.Isize.checked_rem
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9721,45 +9925,45 @@ def num.Isize.checked_rem
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.I8.unchecked_rem (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.I16.unchecked_rem (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.I32.unchecked_rem (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.I64.unchecked_rem (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.I128.unchecked_rem
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 467:12-469:13
     Visibility: public -/
 def num.Isize.unchecked_rem
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x % y
 
 /-- [core_models::num::{core_models::num::i8}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.I8.signum (x : Std.I8) : Result Std.I8 := do
   if x > 0#i8
@@ -9769,7 +9973,7 @@ def num.I8.signum (x : Std.I8) : Result Std.I8 := do
        else ok (-1)#i8
 
 /-- [core_models::num::{core_models::num::i16}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.I16.signum (x : Std.I16) : Result Std.I16 := do
   if x > 0#i16
@@ -9779,7 +9983,7 @@ def num.I16.signum (x : Std.I16) : Result Std.I16 := do
        else ok (-1)#i16
 
 /-- [core_models::num::{core_models::num::i32}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.I32.signum (x : Std.I32) : Result Std.I32 := do
   if x > 0#i32
@@ -9789,7 +9993,7 @@ def num.I32.signum (x : Std.I32) : Result Std.I32 := do
        else ok (-1)#i32
 
 /-- [core_models::num::{core_models::num::i64}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.I64.signum (x : Std.I64) : Result Std.I64 := do
   if x > 0#i64
@@ -9799,7 +10003,7 @@ def num.I64.signum (x : Std.I64) : Result Std.I64 := do
        else ok (-1)#i64
 
 /-- [core_models::num::{core_models::num::i128}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.I128.signum (x : Std.I128) : Result Std.I128 := do
   if x > 0#i128
@@ -9809,7 +10013,7 @@ def num.I128.signum (x : Std.I128) : Result Std.I128 := do
        else ok (-1)#i128
 
 /-- [core_models::num::{core_models::num::isize}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-479:13
     Visibility: public -/
 def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
   if x > 0#isize
@@ -9819,7 +10023,7 @@ def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
        else ok (-1)#isize
 
 /-- [core_models::num::{core_models::num::i8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   let d ← x / y
@@ -9840,7 +10044,7 @@ def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   let d ← x / y
@@ -9861,7 +10065,7 @@ def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   let d ← x / y
@@ -9882,7 +10086,7 @@ def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   let d ← x / y
@@ -9903,7 +10107,7 @@ def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   let d ← x / y
@@ -9924,7 +10128,7 @@ def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::isize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
+    Source: 'core-models/src/core/num/mod.rs', lines 483:12-492:13
     Visibility: public -/
 def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   let d ← x / y
@@ -9946,169 +10150,169 @@ def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
        else ok d
 
 /-- [core_models::num::{impl core_models::default::Default for u8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def U8.Insts.CoreDefaultDefault.default : Result Std.U8 := do
   ok 0#u8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def U8.Insts.CoreDefaultDefault : default.Default Std.U8 := {
   default := U8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def U16.Insts.CoreDefaultDefault.default : Result Std.U16 := do
   ok 0#u16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def U16.Insts.CoreDefaultDefault : default.Default Std.U16 := {
   default := U16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def U32.Insts.CoreDefaultDefault.default : Result Std.U32 := do
   ok 0#u32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def U32.Insts.CoreDefaultDefault : default.Default Std.U32 := {
   default := U32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def U64.Insts.CoreDefaultDefault.default : Result Std.U64 := do
   ok 0#u64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def U64.Insts.CoreDefaultDefault : default.Default Std.U64 := {
   default := U64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def U128.Insts.CoreDefaultDefault.default : Result Std.U128 := do
   ok 0#u128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def U128.Insts.CoreDefaultDefault : default.Default Std.U128 := {
   default := U128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for usize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def Usize.Insts.CoreDefaultDefault.default : Result Std.Usize := do
   ok 0#usize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for usize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def Usize.Insts.CoreDefaultDefault : default.Default Std.Usize := {
   default := Usize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def I8.Insts.CoreDefaultDefault.default : Result Std.I8 := do
   ok 0#i8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def I8.Insts.CoreDefaultDefault : default.Default Std.I8 := {
   default := I8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def I16.Insts.CoreDefaultDefault.default : Result Std.I16 := do
   ok 0#i16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def I16.Insts.CoreDefaultDefault : default.Default Std.I16 := {
   default := I16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def I32.Insts.CoreDefaultDefault.default : Result Std.I32 := do
   ok 0#i32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def I32.Insts.CoreDefaultDefault : default.Default Std.I32 := {
   default := I32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def I64.Insts.CoreDefaultDefault.default : Result Std.I64 := do
   ok 0#i64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def I64.Insts.CoreDefaultDefault : default.Default Std.I64 := {
   default := I64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def I128.Insts.CoreDefaultDefault.default : Result Std.I128 := do
   ok 0#i128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def I128.Insts.CoreDefaultDefault : default.Default Std.I128 := {
   default := I128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for isize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
+    Source: 'core-models/src/core/num/mod.rs', lines 678:16-680:17
     Visibility: public -/
 def Isize.Insts.CoreDefaultDefault.default : Result Std.Isize := do
   ok 0#isize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for isize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 677:12-681:13 -/
 @[reducible]
 def Isize.Insts.CoreDefaultDefault : default.Default Std.Isize := {
   default := Isize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for bool}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 676:4-678:5
+    Source: 'core-models/src/core/num/mod.rs', lines 704:4-706:5
     Visibility: public -/
 def Bool.Insts.CoreDefaultDefault.default : Result Bool := do
   ok false
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for bool}]
-    Source: 'core-models/src/core/num/mod.rs', lines 674:0-679:1 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 702:0-707:1 -/
 @[reducible]
 def Bool.Insts.CoreDefaultDefault : default.Default Bool := {
   default := Bool.Insts.CoreDefaultDefault.default

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -505,73 +505,73 @@ structure num.error.ParseIntError where
   kind : num.error.IntErrorKind
 
 /-- [core_models::num::u8]
-    Source: 'core-models/src/core/num/mod.rs', lines 488:0-488:14
+    Source: 'core-models/src/core/num/mod.rs', lines 516:0-516:14
     Visibility: public -/
 @[reducible]
 def num.u8 := Unit
 
 /-- [core_models::num::u16]
-    Source: 'core-models/src/core/num/mod.rs', lines 491:0-491:15
+    Source: 'core-models/src/core/num/mod.rs', lines 519:0-519:15
     Visibility: public -/
 @[reducible]
 def num.u16 := Unit
 
 /-- [core_models::num::u32]
-    Source: 'core-models/src/core/num/mod.rs', lines 494:0-494:15
+    Source: 'core-models/src/core/num/mod.rs', lines 522:0-522:15
     Visibility: public -/
 @[reducible]
 def num.u32 := Unit
 
 /-- [core_models::num::u64]
-    Source: 'core-models/src/core/num/mod.rs', lines 497:0-497:15
+    Source: 'core-models/src/core/num/mod.rs', lines 525:0-525:15
     Visibility: public -/
 @[reducible]
 def num.u64 := Unit
 
 /-- [core_models::num::u128]
-    Source: 'core-models/src/core/num/mod.rs', lines 500:0-500:16
+    Source: 'core-models/src/core/num/mod.rs', lines 528:0-528:16
     Visibility: public -/
 @[reducible]
 def num.u128 := Unit
 
 /-- [core_models::num::usize]
-    Source: 'core-models/src/core/num/mod.rs', lines 503:0-503:17
+    Source: 'core-models/src/core/num/mod.rs', lines 531:0-531:17
     Visibility: public -/
 @[reducible]
 def num.usize := Unit
 
 /-- [core_models::num::i8]
-    Source: 'core-models/src/core/num/mod.rs', lines 506:0-506:14
+    Source: 'core-models/src/core/num/mod.rs', lines 534:0-534:14
     Visibility: public -/
 @[reducible]
 def num.i8 := Unit
 
 /-- [core_models::num::i16]
-    Source: 'core-models/src/core/num/mod.rs', lines 509:0-509:15
+    Source: 'core-models/src/core/num/mod.rs', lines 537:0-537:15
     Visibility: public -/
 @[reducible]
 def num.i16 := Unit
 
 /-- [core_models::num::i32]
-    Source: 'core-models/src/core/num/mod.rs', lines 512:0-512:15
+    Source: 'core-models/src/core/num/mod.rs', lines 540:0-540:15
     Visibility: public -/
 @[reducible]
 def num.i32 := Unit
 
 /-- [core_models::num::i64]
-    Source: 'core-models/src/core/num/mod.rs', lines 515:0-515:15
+    Source: 'core-models/src/core/num/mod.rs', lines 543:0-543:15
     Visibility: public -/
 @[reducible]
 def num.i64 := Unit
 
 /-- [core_models::num::i128]
-    Source: 'core-models/src/core/num/mod.rs', lines 518:0-518:16
+    Source: 'core-models/src/core/num/mod.rs', lines 546:0-546:16
     Visibility: public -/
 @[reducible]
 def num.i128 := Unit
 
 /-- [core_models::num::isize]
-    Source: 'core-models/src/core/num/mod.rs', lines 521:0-521:17
+    Source: 'core-models/src/core/num/mod.rs', lines 549:0-549:17
     Visibility: public -/
 @[reducible]
 def num.isize := Unit

--- a/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
@@ -365,6 +365,23 @@ def ioverflowing_mul {ty : IScalarTy} (x y : IScalar ty) : IScalar ty × Bool :=
   (⟨BitVec.ofInt _ z⟩,
    decide (¬ (-2 ^ (ty.numBits - 1) ≤ z ∧ z < 2 ^ (ty.numBits - 1))))
 
+/- `overflowing_pow` follows `overflowing_mul`: the wrapped power together with
+an overflow flag. Rust computes it by exponentiation-by-squaring over
+`overflowing_mul`, OR-ing the per-step flags. The closed forms below agree:
+wrapping multiplication is multiplication modulo `2^bits` and congruence is
+preserved under products, so the wrapped result is `x^n mod 2^bits`; and the
+flag is set iff some step overflows, which happens iff the exact `x^n` is out
+of range (if no step overflows every intermediate is exact, and the final
+step's non-overflow is exactly in-rangeness of `x^n`). -/
+
+def uoverflowing_pow {ty : UScalarTy} (x : UScalar ty) (n : Std.U32) : UScalar ty × Bool :=
+  (⟨BitVec.ofNat _ (x.val ^ n.val)⟩, decide (2 ^ ty.numBits ≤ x.val ^ n.val))
+
+def ioverflowing_pow {ty : IScalarTy} (x : IScalar ty) (n : Std.U32) : IScalar ty × Bool :=
+  let z := x.val ^ n.val
+  (⟨BitVec.ofInt _ z⟩,
+   decide (¬ (-2 ^ (ty.numBits - 1) ≤ z ∧ z < 2 ^ (ty.numBits - 1))))
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_u8"]
 def rust_primitives.arithmetic.overflowing_sub_u8 : Std.U8 → Std.U8 → Result (Std.U8 × Bool) :=
   fun x y => ok (uoverflowing_sub x y)
@@ -372,6 +389,10 @@ def rust_primitives.arithmetic.overflowing_sub_u8 : Std.U8 → Std.U8 → Result
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_u8"]
 def rust_primitives.arithmetic.overflowing_mul_u8 : Std.U8 → Std.U8 → Result (Std.U8 × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_u8"]
+def rust_primitives.arithmetic.overflowing_pow_u8 : Std.U8 → Std.U32 → Result (Std.U8 × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_u16"]
 def rust_primitives.arithmetic.overflowing_sub_u16 : Std.U16 → Std.U16 → Result (Std.U16 × Bool) :=
@@ -381,6 +402,10 @@ def rust_primitives.arithmetic.overflowing_sub_u16 : Std.U16 → Std.U16 → Res
 def rust_primitives.arithmetic.overflowing_mul_u16 : Std.U16 → Std.U16 → Result (Std.U16 × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_u16"]
+def rust_primitives.arithmetic.overflowing_pow_u16 : Std.U16 → Std.U32 → Result (Std.U16 × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_u32"]
 def rust_primitives.arithmetic.overflowing_sub_u32 : Std.U32 → Std.U32 → Result (Std.U32 × Bool) :=
   fun x y => ok (uoverflowing_sub x y)
@@ -388,6 +413,10 @@ def rust_primitives.arithmetic.overflowing_sub_u32 : Std.U32 → Std.U32 → Res
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_u32"]
 def rust_primitives.arithmetic.overflowing_mul_u32 : Std.U32 → Std.U32 → Result (Std.U32 × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_u32"]
+def rust_primitives.arithmetic.overflowing_pow_u32 : Std.U32 → Std.U32 → Result (Std.U32 × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_u64"]
 def rust_primitives.arithmetic.overflowing_sub_u64 : Std.U64 → Std.U64 → Result (Std.U64 × Bool) :=
@@ -397,6 +426,10 @@ def rust_primitives.arithmetic.overflowing_sub_u64 : Std.U64 → Std.U64 → Res
 def rust_primitives.arithmetic.overflowing_mul_u64 : Std.U64 → Std.U64 → Result (Std.U64 × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_u64"]
+def rust_primitives.arithmetic.overflowing_pow_u64 : Std.U64 → Std.U32 → Result (Std.U64 × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_u128"]
 def rust_primitives.arithmetic.overflowing_sub_u128 : Std.U128 → Std.U128 → Result (Std.U128 × Bool) :=
   fun x y => ok (uoverflowing_sub x y)
@@ -404,6 +437,10 @@ def rust_primitives.arithmetic.overflowing_sub_u128 : Std.U128 → Std.U128 → 
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_u128"]
 def rust_primitives.arithmetic.overflowing_mul_u128 : Std.U128 → Std.U128 → Result (Std.U128 × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_u128"]
+def rust_primitives.arithmetic.overflowing_pow_u128 : Std.U128 → Std.U32 → Result (Std.U128 × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_usize"]
 def rust_primitives.arithmetic.overflowing_sub_usize : Std.Usize → Std.Usize → Result (Std.Usize × Bool) :=
@@ -413,6 +450,10 @@ def rust_primitives.arithmetic.overflowing_sub_usize : Std.Usize → Std.Usize �
 def rust_primitives.arithmetic.overflowing_mul_usize : Std.Usize → Std.Usize → Result (Std.Usize × Bool) :=
   fun x y => ok (uoverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_usize"]
+def rust_primitives.arithmetic.overflowing_pow_usize : Std.Usize → Std.U32 → Result (Std.Usize × Bool) :=
+  fun x n => ok (uoverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_i8"]
 def rust_primitives.arithmetic.overflowing_sub_i8 : Std.I8 → Std.I8 → Result (Std.I8 × Bool) :=
   fun x y => ok (ioverflowing_sub x y)
@@ -420,6 +461,10 @@ def rust_primitives.arithmetic.overflowing_sub_i8 : Std.I8 → Std.I8 → Result
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_i8"]
 def rust_primitives.arithmetic.overflowing_mul_i8 : Std.I8 → Std.I8 → Result (Std.I8 × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_i8"]
+def rust_primitives.arithmetic.overflowing_pow_i8 : Std.I8 → Std.U32 → Result (Std.I8 × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_i16"]
 def rust_primitives.arithmetic.overflowing_sub_i16 : Std.I16 → Std.I16 → Result (Std.I16 × Bool) :=
@@ -429,6 +474,10 @@ def rust_primitives.arithmetic.overflowing_sub_i16 : Std.I16 → Std.I16 → Res
 def rust_primitives.arithmetic.overflowing_mul_i16 : Std.I16 → Std.I16 → Result (Std.I16 × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_i16"]
+def rust_primitives.arithmetic.overflowing_pow_i16 : Std.I16 → Std.U32 → Result (Std.I16 × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_i32"]
 def rust_primitives.arithmetic.overflowing_sub_i32 : Std.I32 → Std.I32 → Result (Std.I32 × Bool) :=
   fun x y => ok (ioverflowing_sub x y)
@@ -436,6 +485,10 @@ def rust_primitives.arithmetic.overflowing_sub_i32 : Std.I32 → Std.I32 → Res
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_i32"]
 def rust_primitives.arithmetic.overflowing_mul_i32 : Std.I32 → Std.I32 → Result (Std.I32 × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_i32"]
+def rust_primitives.arithmetic.overflowing_pow_i32 : Std.I32 → Std.U32 → Result (Std.I32 × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_i64"]
 def rust_primitives.arithmetic.overflowing_sub_i64 : Std.I64 → Std.I64 → Result (Std.I64 × Bool) :=
@@ -445,6 +498,10 @@ def rust_primitives.arithmetic.overflowing_sub_i64 : Std.I64 → Std.I64 → Res
 def rust_primitives.arithmetic.overflowing_mul_i64 : Std.I64 → Std.I64 → Result (Std.I64 × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_i64"]
+def rust_primitives.arithmetic.overflowing_pow_i64 : Std.I64 → Std.U32 → Result (Std.I64 × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_i128"]
 def rust_primitives.arithmetic.overflowing_sub_i128 : Std.I128 → Std.I128 → Result (Std.I128 × Bool) :=
   fun x y => ok (ioverflowing_sub x y)
@@ -453,6 +510,10 @@ def rust_primitives.arithmetic.overflowing_sub_i128 : Std.I128 → Std.I128 → 
 def rust_primitives.arithmetic.overflowing_mul_i128 : Std.I128 → Std.I128 → Result (Std.I128 × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
 
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_i128"]
+def rust_primitives.arithmetic.overflowing_pow_i128 : Std.I128 → Std.U32 → Result (Std.I128 × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
+
 @[rust_fun "rust_primitives::arithmetic::overflowing_sub_isize"]
 def rust_primitives.arithmetic.overflowing_sub_isize : Std.Isize → Std.Isize → Result (Std.Isize × Bool) :=
   fun x y => ok (ioverflowing_sub x y)
@@ -460,6 +521,10 @@ def rust_primitives.arithmetic.overflowing_sub_isize : Std.Isize → Std.Isize �
 @[rust_fun "rust_primitives::arithmetic::overflowing_mul_isize"]
 def rust_primitives.arithmetic.overflowing_mul_isize : Std.Isize → Std.Isize → Result (Std.Isize × Bool) :=
   fun x y => ok (ioverflowing_mul x y)
+
+@[rust_fun "rust_primitives::arithmetic::overflowing_pow_isize"]
+def rust_primitives.arithmetic.overflowing_pow_isize : Std.Isize → Std.U32 → Result (Std.Isize × Bool) :=
+  fun x n => ok (ioverflowing_pow x n)
 
 @[rust_fun "rust_primitives::arithmetic::pow_u8"]
 def rust_primitives.arithmetic.pow_u8 : Std.U8 → Std.U32 → Result Std.U8 :=


### PR DESCRIPTION
## Summary

Adds `overflowing_pow` and `checked_pow` for all integer widths, following the pattern of the existing overflowing/checked ops:

- `rust_primitives` gains `overflowing_pow_<T>` as thin wrappers over the stdlib.
- In the `num` model, `overflowing_pow` delegates to the primitive and `checked_pow` follows `checked_add`/`checked_sub`/`checked_mul` (overflowing op, flag turned into an `Option`), including the `hax_backend_fstar` exclude its siblings use.
- The Lean proof lib gets handwritten `uoverflowing_pow`/`ioverflowing_pow` next to `uoverflowing_mul`/`ioverflowing_mul`, with per-width bindings interleaved like the other overflowing ops; the F* interface gets the corresponding `val overflowing_pow_<T>` declarations. Regenerated Lean/F* files are in a separate commit, as in previous regens.

## Motivation

I'm using hax for some verification proofs-of-concept.

`checked_pow` shows up in some code being extracted with hax, e.g. decimal-scaling balance arithmetic in [Polkadot SDK](https://github.com/paritytech/polkadot-sdk/). Without a model of `*_pow` fns, such extractions reference a function the proof libs don't define.

## Semantics

Rust implements `overflowing_pow` as exponentiation-by-squaring over `overflowing_mul`, OR-ing the per-step overflow flags. The Lean/F* primitives model it with a closed form instead:

- wrapped value: `x^n mod 2^bits`
- flag: set iff the exact `x^n` exceeds the type's range

These agree with the Rust implementation:

- Value: each squaring step multiplies mod `2^bits`. Congruence is preserved under products, so the step-by-step result equals `x^n mod 2^bits`.
- Flag: if any step overflows, `x^n` is out of range. If no step overflows, every intermediate is exact, and the final step's flag reduces to exactly the question of whether `x^n` is in range.

The same argument is recorded in a comment next to the definitions.

## Placement

Flagging one code placement choice: this PR puts `overflowing_pow_<T>` in the `all_ops!` macro (next to `pow_<T>`, same `($T, u32)` signature) rather than in `arithmetic_ops!`'s `overflowing_ops:` list, whose signature is fixed to `($T, $T) -> ($T, bool)`. Extending that macro seemed excessive compared to the option taken.

## Testing

- `cargo test -p core-models`: 756 passed. Includes new model-vs-stdlib proptests for `overflowing_pow` and `checked_pow` on all 12 widths, with exponents up to 140 so every width crosses its overflow boundary.
- `lake build` on the Lean proof lib: builds clean.
- `make -C hax-lib/proof-libs/fstar/core` with F* 2025.10.06: all modules verify, including `Core_models.Num`.
- `cargo fmt --all -- --check`: clean.

### AI disclosure

This PR was with AI (Fable 5) assistance.

I hit these missing models while using hax downstream and had Fable write them, following the existing `overflowing_mul`/`checked_mul` patterns across the model, proof libs, and tests.

Reviewed manually; tested with the repo's own harnesses (proptests, Lean build, F* check, equivalence tests).