### PR TITLE
feat: Fall back to internal hax-lean lib when no pin is present

### DIFF
--- a/.github/workflows/check_hax_lean_pin.yml
+++ b/.github/workflows/check_hax_lean_pin.yml
@@ -1,0 +1,68 @@
+name: Check hax-lean pin
+
+# When a PR modifies the hax-lean library (`hax-lib/proof-libs/lean`),
+# `pins.toml` must NOT carry a `[hax-lean-lib]` pin. A pin makes lakefiles
+# generated via `cargo hax into lean --lakefile` depend on https://github.com/cryspen/hax-lean,
+# which can't contain the current changes yet. Removing the pin will make
+# `cargo hax into lean --lakefile` use the current `hax` commit instead.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-hax-lean-pin:
+    if: github.actor != 'github-merge-queue[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout full git history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Enforce no hax-lean pin when the in-tree library changes
+        run: |
+          git diff --name-only origin/${{ github.base_ref }} HEAD > changed_files.txt
+          echo "::group::Changed files"
+          cat changed_files.txt
+          echo "::endgroup::"
+
+          # Did this PR touch the in-tree Hax lean library?
+          if ! grep -q '^hax-lib/proof-libs/lean/' changed_files.txt; then
+            echo "No changes to hax-lib/proof-libs/lean; nothing to check."
+            exit 0
+          fi
+
+          # Is there a `[hax-lean-lib]` section in pins.toml?
+          if grep -qE '^\[hax-lean-lib\]' pins.toml; then
+            {
+              echo '**`hax-lib/proof-libs/lean` changed while a `[hax-lean-lib]` pin is set**'
+              echo ''
+              echo 'This PR edits the Hax lean library, but `pins.toml` still'
+              echo 'pins `[hax-lean-lib]` to a published release. Generated lakefiles'
+              echo 'would depend on the pinned release, not on your changes.'
+              echo ''
+              echo 'Remove the `[hax-lean-lib]` section from `pins.toml` so that'
+              echo '`cargo hax into lean --lakefile` points to the new changes'
+              echo '(`cryspen/hax` at the built commit), or revert the changes to'
+              echo '`hax-lib/proof-libs/lean`.'
+            } > error-message
+            cat error-message >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          echo "hax-lib/proof-libs/lean changed and no hax-lean pin is set. OK."
+
+      - name: Fail with markdown error
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let msg = 'Check failed.';
+            try { msg = fs.readFileSync('error-message', 'utf8'); } catch (e) {}
+            core.setFailed(msg);

--- a/cli/subcommands/src/aeneas.rs
+++ b/cli/subcommands/src/aeneas.rs
@@ -32,6 +32,7 @@ const LEAN_PIN_TOOLCHAIN: &str = pins::LEAN_TOOLCHAIN;
 const LEAN_LIB_PIN_REPO: &str = pins::LEAN_LIB_REPO;
 const LEAN_LIB_PIN_VERSION: &str = pins::LEAN_LIB_VERSION;
 const CHARON_PIN_VERSION: &str = pins::CHARON_VERSION;
+const HAX_COMMIT: &str = hax_types::HAX_COMMIT;
 
 // Flags that should trigger a warning when passed to charon/aeneas
 const CHARON_WARN_FLAGS: &[&str] = &["--dest-file"];

--- a/cli/subcommands/src/aeneas/lakefile.rs
+++ b/cli/subcommands/src/aeneas/lakefile.rs
@@ -9,15 +9,40 @@ use std::path::Path;
 ///
 /// The `aeneas` Lean proof library is pinned to the same source repo + commit as
 /// the `aeneas` binary hax expects (baked from `pins.toml`'s `[aeneas]`, see
-/// build.rs), so the proof library matches the extraction. The `Hax` Lean proof
-/// library is pinned from `[hax-lean-lib]`. All pins are required — `generate`
-/// rejects empty ones before we get here, so there are no fallbacks.
+/// build.rs), so the proof library matches the extraction.
+///
+/// The `Hax` Lean proof library is resolved in one of two ways:
+/// - if `pins.toml` carries a `[hax-lean-lib]` pin, depend on the published
+///   library at that repo + commit;
+/// - otherwise, depend on the in-tree copy shipped in the hax repo
+///   (`hax-lib/proof-libs/lean`) at the commit hax was built from, so the proof
+///   library matches this exact hax.
 fn lakefile_contents(crate_name: &str) -> String {
     let pkg_name = super::to_camel_case(crate_name);
     let aeneas_git = super::AENEAS_PIN_REPO;
     let aeneas_rev = super::AENEAS_PIN_VERSION;
-    let hax_lean_git = super::LEAN_LIB_PIN_REPO;
-    let hax_lean_rev = super::LEAN_LIB_PIN_VERSION;
+
+    let hax_require = if super::LEAN_LIB_PIN_REPO.is_empty() {
+        // No `[hax-lean-lib]` pin: point at the in-tree library in the hax repo.
+        let hax_rev = super::HAX_COMMIT;
+        format!(
+            r#"[[require]]
+name = "Hax"
+git = {{ url = "https://github.com/cryspen/hax", subDir = "hax-lib/proof-libs/lean" }}
+rev = "{hax_rev}"
+"#
+        )
+    } else {
+        let hax_lean_git = super::LEAN_LIB_PIN_REPO;
+        let hax_lean_rev = super::LEAN_LIB_PIN_VERSION;
+        format!(
+            r#"[[require]]
+name = "Hax"
+git = {{ url = "{hax_lean_git}" }}
+rev = "{hax_lean_rev}"
+"#
+        )
+    };
 
     format!(
         r#"name = "{pkg_name}"
@@ -33,11 +58,7 @@ git = "{aeneas_git}"
 rev = "{aeneas_rev}"
 subDir = "backends/lean"
 
-[[require]]
-name = "Hax"
-git = {{ url = "{hax_lean_git}" }}
-rev = "{hax_lean_rev}"
-"#
+{hax_require}"#
     )
 }
 

--- a/hax-types/build.rs
+++ b/hax-types/build.rs
@@ -33,8 +33,6 @@ const REQUIRED_PINS: &[(&str, &str)] = &[
     ("charon", "tag"),
     ("charon", "version"),
     ("lean", "toolchain"),
-    ("hax-lean-lib", "version"),
-    ("hax-lean-lib", "repo"),
 ];
 
 /// Bake the workspace-root tool pins (`pins.toml`) so they are available as

--- a/hax-types/src/lib.rs
+++ b/hax-types/src/lib.rs
@@ -30,6 +30,9 @@ pub mod engine_api;
 /// Compile-time version of hax
 pub const HAX_VERSION: &str = env!("HAX_VERSION");
 
+/// Git commit hax was built from (`"unknown"` outside a git checkout).
+pub const HAX_COMMIT: &str = env!("HAX_GIT_COMMIT_HASH");
+
 /// Tool pins, baked in at build time from the workspace-root `pins.toml` (see
 /// `build.rs`). Read here once so every consumer (`cargo-hax`'s lean
 /// backend, the `--help` text) shares a single source of truth. `build.rs`


### PR DESCRIPTION
## Problem

The `hax-lean` pin in `pins.toml` is used to generate the `lakefile.toml` when running `cargo hax into lean --lakefile`. The `hax-lean` repo gets automatically updated when the library changes in `hax`, but unfortunately, the pin does not get updated. So it's very easy to get version mismatches. In fact, it's impossible not to get them.

## Solution

With this PR, the `cargo hax into lean --lakefile` command uses different repos depending on whether there is a `hax-lean` pin or not:
  - if there is a `hax-lean` pin, it points the `lakefile` to `cryspen/hax-lean`
  - if there is no `hax-lean` pin, it points the `lakefile` to the corresponding subdirectory of `cryspen/hax` at the commit that `hax` was built with.

For every PR that changes the `hax-lean` library, we need to remove the `hax-lean` pin because it might no longer work. I added a CI job to enforce that. When we want to have a new version tag, we can add one manually to `hax-lean` and create a hax PR to update `pins.toml`.


---

Fixes: #2083

Assisted-By: Claude Opus 4.8

[skip changelog]