### PR TITLE
docs: do not call the sha3 specification an "implementation"

### DIFF
--- a/examples/sha3/proofs/lean/Sha3/Equivalence.lean
+++ b/examples/sha3/proofs/lean/Sha3/Equivalence.lean
@@ -180,12 +180,12 @@ theorem array.equality.PartialEqArray.eq_spec {N : Usize} (a0 : Array U64 N) (a1
 attribute [local spec] uncurry
 
 /-
-We prove two examples of equivalences between implementaiton and reference:
+We prove two examples of equivalences between implementation and specification:
 
 ## Part 1: Equivalence of `iota`
 
-Both implementations of iota yield the same state array, provided that the argument `i` is small
-enough. (Otherwise both implementations would access the round constants array out of bounds.)
+Implementation and specification of iota yield the same state array, provided that the argument
+`i` is small enough. (Otherwise both would access the round constants array out of bounds.)
 -/
 
 @[spec]
@@ -199,11 +199,11 @@ theorem iota_spec
   unfold KeccakState.iota KeccakState.Insts.CoreOpsIndexIndexPairUsizeUsizeT.index get_ij
     _requires_iota core.slice.Slice.len at *
   dsimp only [U64.Insts.Sha3ImplementationKeccakItem1.xor_constant, _veorq_n_u64, KeccakState.set, set_ij, _ensures_iota,
-    reference.iota]
+    specification.iota]
   -- Call `hax_mvcgen`. This tactic will run `mvcgen` on triples in both hypotheses and in goals
   hax_mvcgen
-  · have hr : ROUNDCONSTANTS = reference.ROUND_CONSTANTS := by
-      unfold ROUNDCONSTANTS reference.ROUND_CONSTANTS; rfl
+  · have hr : ROUNDCONSTANTS = specification.ROUND_CONSTANTS := by
+      unfold ROUNDCONSTANTS specification.ROUND_CONSTANTS; rfl
     expose_names
     have hx : r_9 = r_8 ^^^ r_7 := by grind
     grind
@@ -253,49 +253,49 @@ theorem rho_spec
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
-/- ### Panic-freedom of the reference implementations
+/- ### Panic-freedom of the specification
 
-We will also ignore the concrete implementations of the reference functions `theta`, `rho`, `pi`,
-`chi`, and `iota`, but we need to know that they do not panic:
+We will also ignore the proofs that the specifications of `theta`, `rho`, `pi`,
+`chi`, and `iota` do not panic:
 -/
 
-theorem reference_theta_spec (st) :
+theorem specification_theta_spec (st) :
     ⦃ ⌜ True ⌝ ⦄
-    reference.theta st
+    specification.theta st
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
-theorem reference_rho_spec (st) :
+theorem specification_rho_spec (st) :
     ⦃ ⌜ True ⌝ ⦄
-    reference.rho st
+    specification.rho st
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
-theorem reference_pi_spec (st) :
+theorem specification_pi_spec (st) :
     ⦃ ⌜ True ⌝ ⦄
-    reference.pi st
+    specification.pi st
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
-theorem reference_chi_spec (st) :
+theorem specification_chi_spec (st) :
     ⦃ ⌜ True ⌝ ⦄
-    reference.chi st
+    specification.chi st
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
-theorem reference_iota_spec (st i) :
+theorem specification_iota_spec (st i) :
     ⦃ ⌜ True ⌝ ⦄
-    reference.iota st i
+    specification.iota st i
     ⦃ ⇓ r => ⌜ True ⌝ ⦄ := by
   sorry
 
 /- ### Encapsulation specifications
 
-When running `mvcgen` on a program, we need specifications for all contained functions. For the
-reference functions and for the implementation `rho`, we do not have a specification. We want
-to abstract over whatever these functions are doing. For that purpose, we can use
-`core.Result.toPure_spec` to encapsulate their implementations and keep them opaque to mvcgen.
-It produces specifications such as:
+When running `mvcgen` on a program, we need spec lemmas for all contained functions. For the
+specification functions and for the implementation `rho`, we do not want to provide actual
+pre- and postconditions. We want to abstract over whatever these functions are doing. For that
+purpose, we can use `core.Result.toPure_spec` to encapsulate their definitions and keep them
+opaque to mvcgen. It produces spec lemmas such as:
 ```
 ⦃⌜True⌝⦄ rho st t ⦃ ⇓r => ⌜r = (rho st t).toPure⌝ ⦄
 ```
@@ -312,19 +312,19 @@ instance [Inhabited α] : Inhabited (Std.Array α n) := ⟨⟨List.replicate n.v
 def rho_spec' {st} {t} := Std.Result.toPure_spec (KeccakState.rho inst st t) (rho_spec st)
 
 @[spec]
-def reference_theta_spec' {st} := Std.Result.toPure_spec (reference.theta st) (reference_theta_spec st)
+def specification_theta_spec' {st} := Std.Result.toPure_spec (specification.theta st) (specification_theta_spec st)
 
 @[spec]
-def reference_rho_spec' {st} := Std.Result.toPure_spec (reference.rho st) (reference_rho_spec st)
+def specification_rho_spec' {st} := Std.Result.toPure_spec (specification.rho st) (specification_rho_spec st)
 
 @[spec]
-def reference_pi_spec' {st} := Std.Result.toPure_spec (reference.pi st) (reference_pi_spec st)
+def specification_pi_spec' {st} := Std.Result.toPure_spec (specification.pi st) (specification_pi_spec st)
 
 @[spec]
-def reference_chi_spec' {st} := Std.Result.toPure_spec (reference.chi st) (reference_chi_spec st)
+def specification_chi_spec' {st} := Std.Result.toPure_spec (specification.chi st) (specification_chi_spec st)
 
 @[spec]
-def reference_iota_spec' {st i} := Std.Result.toPure_spec (reference.iota st i) (reference_iota_spec st i)
+def specification_iota_spec' {st i} := Std.Result.toPure_spec (specification.iota st i) (specification_iota_spec st i)
 
 
 /- ### Equivalence proof

--- a/examples/sha3/src/lib.rs
+++ b/examples/sha3/src/lib.rs
@@ -1,15 +1,21 @@
-// This example verifies parts of SHA-3. We prove two (partial) implementations to be equivalent:
-// - a realistic SHA-3 implementation taken from the `libcrux` library
-// - a reference implementation close to the official FIPS spec of the algorithm
+// This example contains two small parts of a real-world implementation of SHA-3.
+// It also contains a Rust specification of these two parts, closely following the
+// official FIPS standard of the algorithm.
 
-// We verify only a very small part of SHA-3 here. Most of the implementation is not here
-// and some parts are `unimplemented!()`.
+// The two parts that we consider are:
+// - **Part 1:** the `iota` function, and
+// - **Part 2:** a single round of `keccak_f`.
+
+// We prove that the implementation is equivalent to the specification.
+
+// Note that this is only a very small part of SHA-3. Some of the functions that are part of
+// a round of `keccak_f`, but that we ignore in this example are simply `unimplemented!()`.
 
 // ===========================================================================
-// Reference implementation: The five step mappings — FIPS 202, Algorithms 1–6
+// Specification: The five step mappings — FIPS 202, Algorithms 1–6
 // ===========================================================================
 
-mod reference {
+mod specification {
 
     /// Keccak-f[1600] state: 5×5 lanes of 64-bit words.
     /// Keccak state type, exposed for cross-crate verification.
@@ -190,13 +196,13 @@ mod implementation {
     // Pre- and Postconditions
     // =========================================================================
 
-    use crate::reference;
+    use crate::specification;
 
     // =========================================================================
     // Theta & Rho
     // =========================================================================
 
-    // Theta and rho don't perfectly match the reference implementation. So we call `rho` from the
+    // Theta and rho don't perfectly match the specification. So we call `rho` from the
     // postcondition of theta. In this way, we can state a specification for `theta` and `rho` together.
 
     fn _requires_theta(_st: &KeccakState<1, u64>) -> bool {
@@ -206,7 +212,7 @@ mod implementation {
     fn _ensures_theta(st: &KeccakState<1, u64>, res: &KeccakState<1, u64>, d: [u64; 5]) -> bool {
         let mut res = res.clone();
         res.rho(d);
-        res.st == reference::rho(reference::theta(st.st))
+        res.st == specification::rho(specification::theta(st.st))
     }
 
     // =========================================================================
@@ -218,7 +224,7 @@ mod implementation {
     }
 
     fn _ensures_pi(st: &KeccakState<1, u64>, res: &KeccakState<1, u64>) -> bool {
-        res.st == reference::pi(st.st)
+        res.st == specification::pi(st.st)
     }
 
     // =========================================================================
@@ -230,7 +236,7 @@ mod implementation {
     }
 
     fn _ensures_chi(st: &KeccakState<1, u64>, res: &KeccakState<1, u64>) -> bool {
-        res.st == reference::chi(st.st)
+        res.st == specification::chi(st.st)
     }
 
     // =========================================================================
@@ -242,7 +248,7 @@ mod implementation {
     }
 
     fn _ensures_iota(st: &KeccakState<1, u64>, i: usize, res: &KeccakState<1, u64>) -> bool {
-        res.st == reference::iota(st.st, i)
+        res.st == specification::iota(st.st, i)
     }
 
     // =========================================================================
@@ -255,8 +261,10 @@ mod implementation {
 
     fn _ensures_round(st: &KeccakState<1, u64>, i: usize, res: &KeccakState<1, u64>) -> bool {
         res.st
-            == reference::iota(
-                reference::chi(reference::pi(reference::rho(reference::theta(st.st)))),
+            == specification::iota(
+                specification::chi(specification::pi(specification::rho(specification::theta(
+                    st.st,
+                )))),
                 i,
             )
     }


### PR DESCRIPTION
This PR fixes the description of the sha3 example to always say "specification" instead of "reference implementation".

[skip changelog]