### PR TITLE
ci: use Aeneas's olean cache

### DIFF
--- a/.github/workflows/core_models.yml
+++ b/.github/workflows/core_models.yml
@@ -205,7 +205,9 @@ jobs:
 
       # ---- The actual pipeline ------------------------------------------
       - name: Extract Lean library, build Lean library, run regression tests
-        run: make CHARON=$AENEAS_DIR/charon/bin/charon AENEAS=$AENEAS_DIR/bin/aeneas lean tests
+        run: |
+          unset CI # Allows us to use Aeneas's olean cache
+          make CHARON=$AENEAS_DIR/charon/bin/charon AENEAS=$AENEAS_DIR/bin/aeneas lean tests
 
       # ---- Enforce that committed extraction matches re-extraction ------
       # If this fails: someone changed Rust source / patcher without

--- a/.github/workflows/verify_extraction.yml
+++ b/.github/workflows/verify_extraction.yml
@@ -79,6 +79,7 @@ jobs:
 
     - name: Build the example
       run: |
+        unset CI # Allows us to use Aeneas's olean cache
         cd examples/${{ matrix.example }}
         PATH="$HOME/.cargo/bin:$PATH" nix develop ..#ci-examples --command make clean
         PATH="$HOME/.cargo/bin:$PATH" nix develop ..#ci-examples --command make


### PR DESCRIPTION
I configured Aeneas to upload cached `olean` files to GitHub, so that we don't need to rebuild locally every time. Unfortunately, Aeneas builds slightly differently depending on an environment variable called `CI`. I am not sure why exactly they did that; all I have found is this comment: https://github.com/AeneasVerif/aeneas/blob/main/backends/lean/lakefile.lean#L18-L19. 

The result is that, if `CI` is set, lake will notice and not use the cache. So here, I unset the `CI` environment variable, which allows us to use the cache. I can see in the CI of this PR that Aeneas has not been rebuilt. What surprises me is that the examples run in 6-9 min here, whereas they used to take 18-27 min. Does building Aeneas really take that long?


Assisted by AI.

[skip changelog]