### PR TITLE
fix(engine): lazy resolution of UIDs to avoid crashes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changes to the Rust Engine:
  - Fix diagnostic reporting (cryspen/hax-evit/159)
 
 Changes to the engine:
+ - Don't fail when an item carries a hax attribute pointing to an item that
+   another backend `cfg`-ed out. Backend-specific item quotes such as
+   `#[hax_lib::legacy_lean::before(..)]` used to abort extraction to any other
+   backend with `Could not find item with UID ...` (#2026)
+ - Drop rustc's internal `<cfg_trace>`/`<cfg_attr_trace>` marker attributes, which
+   made the engine print Rust code that could not be parsed back (#2026)
 
 Changes to the frontend:
  - Fix all observable issues in the new rust version of the THIR importer (cryspen/hax-evit/155)

--- a/engine/lib/attr_payloads.ml
+++ b/engine/lib/attr_payloads.ml
@@ -163,7 +163,7 @@ module Make (F : Features.T) (Error : Phase_utils.ERROR) = struct
     val item_uid_map : item UId.Map.t
     val try_item_of_uid : UId.t -> item option
     val item_of_uid : UId.t -> item
-    val associated_items_per_roles : attrs -> item list AssocRole.Map.t
+    val associated_uids_per_roles : attrs -> UId.t list AssocRole.Map.t
     val associated_item : AssocRole.t -> attrs -> item option
 
     val associated_fn :
@@ -238,10 +238,16 @@ module Make (F : Features.T) (Error : Phase_utils.ERROR) = struct
              @@ "Could not find item with UID "
              ^ [%show: UId.t] uid)
 
-    let associated_items_per_roles : attrs -> item list AssocRole.Map.t =
-      raw_associated_item
-      >> List.map ~f:(map_snd item_of_uid)
-      >> Map.of_alist_multi (module AssocRole)
+    (* Note: this map contains UIDs, not items: resolving UIDs into items is
+       done lazily by [associated_items] below. This laziness is important:
+       an item may carry an `AssociatedItem` attribute whose target item does
+       not exist. This is the case e.g. for backend-specific item quotes
+       (`hax_lib::<backend>::{before,after,replace}`): the quote payload item
+       is `cfg`-gated on the backend being extracted to, while the marker
+       attribute on the decorated item is not. Resolving every UID eagerly
+       would make extraction fail for a role nobody ever looks at. *)
+    let associated_uids_per_roles : attrs -> UId.t list AssocRole.Map.t =
+      raw_associated_item >> Map.of_alist_multi (module AssocRole)
 
     let expect_singleton failure = function
       | [] -> None
@@ -255,7 +261,8 @@ module Make (F : Features.T) (Error : Phase_utils.ERROR) = struct
     let find_or_empty role list = Map.find list role |> Option.value ~default:[]
 
     let associated_items (role : AssocRole.t) (attrs : attrs) : item list =
-      associated_items_per_roles attrs |> find_or_empty role
+      associated_uids_per_roles attrs
+      |> find_or_empty role |> List.map ~f:item_of_uid
 
     let associated_item (role : AssocRole.t) (attrs : attrs) : item option =
       associated_items role attrs

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -114,8 +114,19 @@ let c_logical_op : Thir.logical_op -> logical_op = function
   | And -> And
   | Or -> Or
 
+(** The markers rustc leaves behind when it expands [#[cfg(..)]] and
+    [#[cfg_attr(..)]] attributes. They exist only so that rustc can report
+    better spans in its own diagnostics: they carry no information for us. Note
+    their paths are purposefully invalid Rust identifiers, so that users cannot
+    write them: keeping them around makes [Print_rust] produce Rust code that
+    cannot be parsed back. *)
+let cfg_trace_attributes = [ "<cfg_trace>"; "<cfg_attr_trace>" ]
+
 let c_attr (attr : Thir.attribute) : attr option =
   match attr with
+  | Unparsed { path; _ }
+    when List.mem cfg_trace_attributes path ~equal:[%eq: string] ->
+      None
   | Parsed (DocComment { kind; comment; span; _ }) ->
       let kind =
         match kind with Thir.Line -> DCKLine | Thir.Block -> DCKBlock

--- a/rust-engine/src/import_thir.rs
+++ b/rust-engine/src/import_thir.rs
@@ -174,9 +174,22 @@ fn has_automatically_derived(attrs: &ast::Attributes) -> bool {
     })
 }
 
+/// The markers rustc leaves behind when it expands `#[cfg(..)]` and
+/// `#[cfg_attr(..)]` attributes. They exist only so that rustc can report better
+/// spans in its own diagnostics: they carry no information for us. Note their
+/// paths are purposefully invalid Rust identifiers, so that users cannot write
+/// them: keeping them around makes the Rust printer produce code that cannot be
+/// parsed back.
+const CFG_TRACE_ATTRIBUTES: &[&str] = &["<cfg_trace>", "<cfg_attr_trace>"];
+
 impl Import<Option<ast::Attribute>> for frontend::Attribute {
     fn import(&self, context: &Context) -> Option<ast::Attribute> {
         match self {
+            frontend::Attribute::Unparsed(frontend::AttrItem { path, .. })
+                if CFG_TRACE_ATTRIBUTES.contains(&path.as_str()) =>
+            {
+                None
+            }
             frontend::Attribute::Parsed(frontend::AttributeKind::DocComment {
                 kind,
                 span,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,4 +32,4 @@ syn = { version = "2.0.114", features = ["full"] }
 [workspace]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(hax_backend_fstar)', 'cfg(hax_compilation)', 'cfg(hax_backend_legacy_lean)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(hax_backend_coq)', 'cfg(hax_backend_fstar)', 'cfg(hax_compilation)', 'cfg(hax_backend_legacy_lean)'] }

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib.v
@@ -88,19 +88,17 @@ Definition props '(_ : unit) : unit :=
   let _ := tt in
   tt.
 
-(Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
-Details: Could not find item with UID (Attr_payloads.UId.T.UId "1e61e9169082451f863721e491e17abe")
+Definition inlined_code (foo : t_Foo) : unit :=
+  let vv_a := (13 : t_i32) in
+  let _ := tt in
+  tt.
 
-Note: the error was labeled with context `Coq backend`.
-(* ERROR_ITEM *))
 Definition inlined_code__v_V : t_u8 :=
   (12 : t_u8).
 
-(Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
-Details: Could not find item with UID (Attr_payloads.UId.T.UId "738e326ccf104622b4dffb4a7537f7ef")
+Definition mutliple_before_after '(_ : unit) : unit :=
+  tt.
 
-Note: the error was labeled with context `Coq backend`.
-(* ERROR_ITEM *))
 Definition some_function '(_ : unit) : t_String :=
   f_from (("hello from Rust"%string : string)).
 

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Int_model.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Int_model.v
@@ -34,7 +34,7 @@ Definition Add_f_add (x : t_Int) (y : t_Int) : t_Int :=
 
 
 
-Instance t_Sub_1018840095 : t_Sub ((t_Int)) ((t_Int)) :=
+Instance t_Sub_927712755 : t_Sub ((t_Int)) ((t_Int)) :=
   {
     implaabbcc_t_Sub_f_Output := t_Int;
     implaabbcc_t_Sub_f_sub := fun  (self : t_Int) (other : t_Int)=>

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Newtype_pattern.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Newtype_pattern.v
@@ -38,7 +38,7 @@ Definition impl_SafeIndex__new (i : t_usize) : t_Option ((t_SafeIndex)) :=
 Definition impl_SafeIndex__as_usize (self : t_SafeIndex) : t_usize :=
   f_i self.
 
-Instance t_Index_399234194 `{v_T : Type} : t_Index ((t_Array (v_T) ((10 : t_usize)))) ((t_SafeIndex)) :=
+Instance t_Index_869802955 `{v_T : Type} : t_Index ((t_Array (v_T) ((10 : t_usize)))) ((t_SafeIndex)) :=
   {
     implaabbcc_t_Index_f_Output := v_T;
     implaabbcc_t_Index_f_index := fun  (self : t_Array (v_T) ((10 : t_usize))) (index : t_SafeIndex)=>

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Postprocess_with.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Postprocess_with.v
@@ -13,15 +13,10 @@ From Core Require Import Core.
 
 (* NotImplementedYet *)
 
-(Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
-Details: Could not find item with UID (Attr_payloads.UId.T.UId "67fe4a41ab194cf2b3af036223b1578b")
-
-Note: the error was labeled with context `Coq backend`.
-(* ERROR_ITEM *))
+Definition f '(_ : unit) : unit :=
+  tt.
 
 
-(Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
-Details: Could not find item with UID (Attr_payloads.UId.T.UId "c03bd3f6acd14e2bb1b48548c89b034e")
 
-Note: the error was labeled with context `Coq backend`.
-(* ERROR_ITEM *))
+Definition g '(_ : unit) : unit :=
+  tt.

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Pre_post_on_traits_and_impls.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Pre_post_on_traits_and_impls.v
@@ -35,13 +35,13 @@ Record ViaMul_record : Type :=
 #[export]
 Notation "'ViaMul_ViaMul_record'" := Build_ViaMul_record.
 
-Instance t_Operation_731303356 : t_Operation ((t_ViaAdd)) :=
+Instance t_Operation_327643986 : t_Operation ((t_ViaAdd)) :=
   {
     implaabbcc_t_Operation_f_double := fun  (x : t_u8)=>
       f_add (x) (x);
   }.
 
-Instance t_Operation_114354514 : t_Operation ((t_ViaMul)) :=
+Instance t_Operation_110544059 : t_Operation ((t_ViaMul)) :=
   {
     implaabbcc_t_Operation_f_double := fun  (x : t_u8)=>
       f_mul (x) ((2 : t_u8));

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Refined_arithmetic.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Refined_arithmetic.v
@@ -29,14 +29,14 @@ Record Foo_record : Type :=
   settable! (Build_Foo_record) <Foo_0>.
 Notation "'Foo_Foo_record'" := Build_Foo_record.
 
-Instance t_Add_318651082 : t_Add ((t_Foo)) ((t_Foo)) :=
+Instance t_Add_788047522 : t_Add ((t_Foo)) ((t_Foo)) :=
   {
     implaabbcc_t_Add_f_Output := t_Foo;
     implaabbcc_t_Add_f_add := fun  (self : t_Foo) (rhs : t_Foo)=>
       Foo (f_add (0 self) (0 rhs));
   }.
 
-Instance t_Mul_834634512 : t_Mul ((t_Foo)) ((t_Foo)) :=
+Instance t_Mul_385142173 : t_Mul ((t_Foo)) ((t_Foo)) :=
   {
     implaabbcc_t_Mul_f_Output := t_Foo;
     implaabbcc_t_Mul_f_mul := fun  (self : t_Foo) (rhs : t_Foo)=>

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Refined_indexes.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Refined_indexes.v
@@ -34,7 +34,7 @@ Definition mutation_example (uuse_generic_update_at : t_MyArray) (uuse_specializ
   let specialized_as_well := impl__to_vec (update_at_usize (impl_1__as_slice (specialized_as_well)) ((2 : t_usize)) ((0 : t_u8))) in
   (uuse_generic_update_at,uuse_specialized_update_at,specialized_as_well).
 
-Instance t_Index_700323200 : t_Index ((t_MyArray)) ((t_usize)) :=
+Instance t_Index_513449966 : t_Index ((t_MyArray)) ((t_usize)) :=
   {
     implaabbcc_t_Index_f_Output := t_u8;
     implaabbcc_t_Index_f_index := fun  (self : t_MyArray) (index : t_usize)=>

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Replace_body.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Replace_body.v
@@ -26,7 +26,7 @@ Notation "'Foo_Foo_record'" := Build_Foo_record.
 Definition impl_Foo__assoc_fn (self : t_Foo) (x : t_u8) : unit :=
   tt.
 
-Instance t_ToString_521259839 : t_ToString ((t_Foo)) :=
+Instance t_ToString_184612037 : t_ToString ((t_Foo)) :=
   {
     implaabbcc_t_ToString_(* f_to_string *) := fun  (self : t_Foo)=>
       f_into (("Hello"%string : string));

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Requires_mut.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Requires_mut.v
@@ -24,7 +24,7 @@ Class t_Foo (v_Self : Type) : Type :=
   }.
 Arguments t_Foo (_).
 
-Instance t_Foo_40164482 : t_Foo ((unit)) :=
+Instance t_Foo_1025931942 : t_Foo ((unit)) :=
   {
     implaabbcc_t_Foo_f_f := fun  (x : t_u8) (y : t_u8)=>
       let y := f_add (y) (x) in

--- a/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Verifcation_status.v
+++ b/tests/snapshots/legacy/attributes/lib/coq/New_tests_Legacy__attributes__lib_Verifcation_status.v
@@ -13,11 +13,9 @@ From Core Require Import Core.
 
 (* NotImplementedYet *)
 
-(Fatal error: something we considered as impossible occurred! Please report this by submitting an issue on GitHub!
-Details: Could not find item with UID (Attr_payloads.UId.T.UId "7d56100bd16e4021875b0cdd5e403b29")
+Definition a_function_which_only_laxes '(_ : unit) : unit :=
+  assert ((false : bool)).
 
-Note: the error was labeled with context `Coq backend`.
-(* ERROR_ITEM *))
 Definition a_panicfree_function '(_ : unit) : t_u8 :=
   let a := (3 : t_u8) in
   let b := (6 : t_u8) in

--- a/tests/snapshots/legacy/cli/interface-only/lib/coq/New_tests_Legacy__cli__interface_only__lib.v
+++ b/tests/snapshots/legacy/cli/interface-only/lib/coq/New_tests_Legacy__cli__interface_only__lib.v
@@ -45,7 +45,7 @@ Record Bar_record : Type :=
 #[export]
 Notation "'Bar_Bar_record'" := Build_Bar_record.
 
-Instance t_From_780549722 : t_From ((t_Bar)) ((unit)) :=
+Instance t_From_69477044 : t_From ((t_Bar)) ((unit)) :=
   {
     implaabbcc_t_From_f_from := fun  (() : unit)=>
       Bar;
@@ -54,7 +54,7 @@ Instance t_From_780549722 : t_From ((t_Bar)) ((unit)) :=
 Definition f_from__impl_1__from '(_ : t_u8) : t_Bar :=
   Bar.
 
-Instance t_From_120840175 : t_From ((t_Bar)) ((t_u8)) :=
+Instance t_From_168308453 : t_From ((t_Bar)) ((t_u8)) :=
   {
     implaabbcc_t_From_f_from := fun  (x : t_u8)=>
       f_from__impl_1__from (x);
@@ -69,7 +69,7 @@ Arguments Holder_f_value {_}.
 #[export] Instance settable_Holder_record `{v_T : Type} : Settable _ :=
   settable! (Build_Holder_record (v_T := v_T)) <Holder_f_value>.
 
-Instance t_From_793872821 `{v_T : Type} : t_From ((t_Holder ((v_T)))) ((unit)) :=
+Instance t_From_381761661 `{v_T : Type} : t_From ((t_Holder ((v_T)))) ((unit)) :=
   {
     implaabbcc_t_From_f_from := fun  (() : unit)=>
       Holder (impl__new (tt));
@@ -84,7 +84,7 @@ Arguments Param_f_value {_}.
 #[export] Instance settable_Param_record `{v_SIZE : t_usize} : Settable _ :=
   settable! (Build_Param_record (v_SIZE := v_SIZE)) <Param_f_value>.
 
-Instance t_From_151397874 `{v_SIZE : t_usize} : t_From ((t_Param (v_SIZE))) ((unit)) :=
+Instance t_From_289956640 `{v_SIZE : t_usize} : t_From ((t_Param (v_SIZE))) ((unit)) :=
   {
     implaabbcc_t_From_f_from := fun  (() : unit)=>
       Param (repeat ((0 : t_u8)) (v_SIZE));
@@ -100,7 +100,7 @@ Class t_T (v_Self : Type) : Type :=
   }.
 Arguments t_T (_).
 
-Instance t_T_761168096 : t_T ((t_u8)) :=
+Instance t_T_652982305 : t_T ((t_u8)) :=
   {
     implaabbcc_t_T_f_Assoc := t_u8;
     implaabbcc_t_T_f_d := fun  (_ : unit)=>
@@ -113,7 +113,7 @@ Class t_T2 (v_Self : Type) : Type :=
   }.
 Arguments t_T2 (_).
 
-Instance t_T2_217803810 : t_T2 ((t_u8)) :=
+Instance t_T2_178967458 : t_T2 ((t_u8)) :=
   {
     implaabbcc_t_T2_f_d := fun  (_ : unit)=>
       tt;

--- a/tests/src/legacy/attributes/lib.rs
+++ b/tests/src/legacy/attributes/lib.rs
@@ -1,5 +1,5 @@
 //! @fail(tc): legacy-lean(1)
-//! @fail(extraction): ssprove(HAX0001), coq(HAX0002, HAX0002, HAX0002, HAX0002, HAX0002)
+//! @fail(extraction): ssprove(HAX0001)
 //! @fail(tc): fstar(47)
 use hax_lib as hax;
 


### PR DESCRIPTION
Fixes #2026 

The role UIDs in `associated_items_per_roles` are now resolved lazily to avoid crashes when one is unavailable because of cfg-gating.

Implementation was AI-assisted, with manual testing and review.