### PR TITLE
proof-libs/fstar: specify abs_i8/16/32/64/128/isize instead of leaving them uninterpreted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changes to hax-lib:
  - Support quote annotations (`before`, `after`, `options`) on inherent `impl` blocks and on their items (#1698)
  - Fix some regressions in the F* proof lib (particularly the `vec_deque` models)
  - Specify the F* `overflowing_add`/`overflowing_sub` primitives, which were left uninterpreted. The `checked_*` integer models route through them, so they could not be used in a proof (#2127)
+ - F* lib: specify `abs_i8/16/32/64/128/isize` (previously wholly uninterpreted) with the documented wrap-to-`MIN` result refinement, unblocking proofs about `i*::abs` and the AVX2 `_mm256_abs_epi32` models (#2107)
 
 Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)

--- a/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
+++ b/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
@@ -136,7 +136,16 @@ let rem_euclid_i8 (x: i8) (y: i8 {v y <> 0}): i8 = x %! y
 val pow_i8 : i8 -> u32 -> i8
 val overflowing_pow_i8 : i8 -> u32 -> i8 & bool
 val count_ones_i8 : i8 -> r:u32{v r <= 8}
-val abs_i8 : i8 -> i8
+/// `i8::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `i8::MIN` cannot be represented as an `i8`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `i8::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint I8`.
+val abs_i8 (x: i8)
+  : r: i8 { v r == (if v x = minint I8 then minint I8
+                 else if v x < 0 then - (v x) else v x) }
 
 let wrapping_add_i16 : i16 -> i16 -> i16 = add_mod
 let saturating_add_i16 : i16 -> i16 -> i16 = add_sat
@@ -151,7 +160,16 @@ let rem_euclid_i16 (x: i16) (y: i16 {v y <> 0}): i16 = x %! y
 val pow_i16 : x: i16 -> y:u32 -> result: i16 {v x == 2 /\ v y < 15 ==> (Math.Lemmas.pow2_lt_compat 15 (v y); result == mk_i16 (pow2 (v y)))}
 val overflowing_pow_i16 : i16 -> u32 -> i16 & bool
 val count_ones_i16 : i16 -> r:u32{v r <= 16}
-val abs_i16 : i16 -> i16
+/// `i16::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `i16::MIN` cannot be represented as an `i16`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `i16::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint I16`.
+val abs_i16 (x: i16)
+  : r: i16 { v r == (if v x = minint I16 then minint I16
+                 else if v x < 0 then - (v x) else v x) }
 
 let wrapping_add_i32 : i32 -> i32 -> i32 = add_mod
 let saturating_add_i32 : i32 -> i32 -> i32 = add_sat
@@ -166,7 +184,16 @@ let rem_euclid_i32 (x: i32) (y: i32 {v y <> 0}): i32 = x %! y
 val pow_i32 : x : i32 -> y:u32 -> result: i32 {v x == 2 /\ v y <= 16 ==> result == mk_i32 (pow2 (v y))}
 val overflowing_pow_i32 : i32 -> u32 -> i32 & bool
 val count_ones_i32 : i32 -> r:u32{v r <= 32}
-val abs_i32 : i32 -> i32
+/// `i32::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `i32::MIN` cannot be represented as an `i32`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `i32::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint I32`.
+val abs_i32 (x: i32)
+  : r: i32 { v r == (if v x = minint I32 then minint I32
+                 else if v x < 0 then - (v x) else v x) }
 
 let wrapping_add_i64 : i64 -> i64 -> i64 = add_mod
 let saturating_add_i64 : i64 -> i64 -> i64 = add_sat
@@ -181,7 +208,16 @@ let rem_euclid_i64 (x: i64) (y: i64 {v y <> 0}): i64 = x %! y
 val pow_i64 : i64 -> u32 -> i64
 val overflowing_pow_i64 : i64 -> u32 -> i64 & bool
 val count_ones_i64 : i64 -> r:u32{v r <= 64}
-val abs_i64 : i64 -> i64
+/// `i64::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `i64::MIN` cannot be represented as an `i64`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `i64::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint I64`.
+val abs_i64 (x: i64)
+  : r: i64 { v r == (if v x = minint I64 then minint I64
+                 else if v x < 0 then - (v x) else v x) }
 
 let wrapping_add_i128 : i128 -> i128 -> i128 = add_mod
 let saturating_add_i128 : i128 -> i128 -> i128 = add_sat
@@ -196,7 +232,16 @@ let rem_euclid_i128 (x: i128) (y: i128 {v y <> 0}): i128 = x %! y
 val pow_i128 : i128 -> u32 -> i128
 val overflowing_pow_i128 : i128 -> u32 -> i128 & bool
 val count_ones_i128 : i128 -> r:u32{v r <= 128}
-val abs_i128 : i128 -> i128
+/// `i128::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `i128::MIN` cannot be represented as an `i128`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `i128::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint I128`.
+val abs_i128 (x: i128)
+  : r: i128 { v r == (if v x = minint I128 then minint I128
+                 else if v x < 0 then - (v x) else v x) }
 
 let wrapping_add_isize : isize -> isize -> isize = add_mod
 let saturating_add_isize : isize -> isize -> isize = add_sat
@@ -211,7 +256,16 @@ let rem_euclid_isize (x: isize) (y: isize {v y <> 0}): isize = x %! y
 val pow_isize : isize -> u32 -> isize
 val overflowing_pow_isize : isize -> u32 -> isize & bool
 val count_ones_isize : isize -> r:u32{v r <= size_bits}
-val abs_isize : isize -> isize
+/// `isize::abs`.  Rust documents the overflow case explicitly: "The absolute
+/// value of `isize::MIN` cannot be represented as an `isize`, and attempting to
+/// calculate it will cause an overflow. This means that code in debug mode will
+/// trigger a panic on this case and optimized code will return `isize::MIN`
+/// without a panic."  This model is total, so it specifies the optimized
+/// (wrap-to-MIN) behaviour; callers that must exclude it should require
+/// `v x > minint ISIZE`.
+val abs_isize (x: isize)
+  : r: isize { v r == (if v x = minint ISIZE then minint ISIZE
+                 else if v x < 0 then - (v x) else v x) }
 
 let v_USIZE_MAX = mk_usize max_usize
 let v_ISIZE_MAX = mk_isize max_isize


### PR DESCRIPTION
`Rust_primitives.Arithmetic.abs_i32` (and its five siblings) were declared as

    val abs_i32 : i32 -> i32

i.e. WHOLLY UNINTERPRETED: nothing relates the result to the argument, so no
proof about `i32::abs` can say anything at all. `Core_models.Num.impl_i32__abs`
forwards straight to it, so every downstream model of `_mm256_abs_epi32` and
friends inherits the gap.

Give each a result refinement stating Rust's documented behaviour:

    val abs_i32 (x: i32)
      : r: i32 { v r == (if v x = minint I32 then minint I32
                     else if v x < 0 then - (v x) else v x) }

Rust documents the overflow case explicitly: "The absolute value of `i32::MIN`
cannot be represented as an `i32` ... code in debug mode will trigger a panic on
this case and optimized code will return `i32::MIN` without a panic." These
models are total, so they specify the optimized (wrap-to-MIN) behaviour rather
than a precondition; a caller that must exclude it can require
`v x > minint I32`, and then the refinement gives plain `|x|`.

This remains an ASSUMPTION - the module is interface-only, so it is part of the
hax trusted primitive base, not something proven here. It is checkable against
the Rust documentation quoted above, which is the point: previously there was
nothing to check.

Non-breaking: strengthening a `val`'s result refinement is monotone for callers,
and nothing in proof-libs implements these vals.

Verified: `Rust_primitives.Arithmetic` typechecks, all VCs discharged.

Motivation: libcrux's ml-dsa AVX2 proof of `mm256_abs_epi32` cannot be closed
without this - it is currently the single blocker that has no in-repo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)