### PR TITLE
Warn on playwright failures

### DIFF
--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -56,8 +56,7 @@ jobs:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         set -euo pipefail
-        open=$(gh issue list --state open --limit 1000 --json number,title \
-                 --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+        open=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
         if [ -n "$open" ]; then
           echo "Issue #$open is already open, not opening another one."
           exit 0

--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -48,3 +48,23 @@ jobs:
         name: playwright-report
         path: docs/.test/playwright-report/
         retention-days: 30
+    - name: Open an issue on failure
+      if: failure() && github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TITLE: Scheduled Playwright docs tests are failing
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        open=$(gh issue list --state open --limit 1000 --json number,title \
+                 --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+        if [ -n "$open" ]; then
+          echo "Issue #$open is already open, not opening another one."
+          exit 0
+        fi
+        gh issue create --title "$TITLE" --label tests --body \
+          "The scheduled [Playwright Docs Tests]($RUN_URL) run failed on \`$GITHUB_SHA\`.
+
+        Download the \`playwright-report\` artifact from that run to see which
+        checks failed. This issue is opened once per breakage; while it stays
+        open, subsequent failing runs will not open or comment on anything."

--- a/docs/blog/posts/this-month-in-hax/2026-02.md
+++ b/docs/blog/posts/this-month-in-hax/2026-02.md
@@ -8,7 +8,7 @@ date: 2026-03-03
 In February, we successfully merged **32 pull requests**!
 
 This month, the Lean backend made headway by getting new Rust proof attributes. With the new attributes, Users can choose between two proof methods, one based on symbolic reasoning (`grind`) and one based on bit-blasting (`bv_decide`). This new setup is illustrated in our updated [Tutorial](https://hax.cryspen.com/manual/lean/tutorial/)
-and the [Chacha20](https://github.com/cryspen/hax/blob/main/examples/lean_chacha20/src/lib.rs)
+and the [Chacha20](https://github.com/cryspen/hax/blob/566b44879d37cc68f9cbcdaf282e80551b8363cd/examples/lean_chacha20/src/lib.rs)
 example. Moreover, the Lean backend produces
 prettier output by opening namespaces, handles for-loops more reliably, and its library contains more of our Rust core models.
 


### PR DESCRIPTION
Fixes #1762, failures will open an issue, then people who are interested can subscribe to be notified about new issues. This seems more reliable than trying to directly notify about the failure, and the issue can be useful.

The PR also fixes a dead link which should help fix the current playwright failures, a playground fix is also need.

[skip changelog]