### PR TITLE
fix: remove hax-lean version

### DIFF
--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,5 +1,4 @@
 name = "hax"
-version = "0.1.0"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
This version gets displayed on Reservoir: https://reservoir.lean-lang.org/@cryspen/hax

To prevent this from getting outdated, I remove it entirely. This is what most packages on Reservoir do, including mathlib.

[skip changelog]