### PR TITLE
Fix Playwright timeouts

### DIFF
--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     if: github.repository == 'cryspen/hax'
-    timeout-minutes: 45
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -41,7 +41,7 @@ jobs:
         exit ${exit_code1:-0} || exit ${exit_code2:-0}
     - name: Run Playwright tests
       working-directory: docs/.test
-      run: npx playwright test --reporter github,html --trace on 
+      run: npx playwright test --reporter github,html
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ Use `--help` on any subcommand for options (e.g. `cargo hax into fstar --z3rlimi
 <details>
   <summary><b>Nix</b></summary>
 
- This should work on [Linux](https://nixos.org/download.html#nix-install-linux), [MacOS](https://nixos.org/download.html#nix-install-macos) and [Windows](https://nixos.org/download.html#nix-install-windows).
+ This should work on [Linux](https://nixos.org/download/#nix-install-linux), [MacOS](https://nixos.org/download/#nix-install-macos) and [Windows](https://nixos.org/download/#nix-install-windows).
 
 <details>
   <summary><b>Prerequisites:</b> <a href="https://nixos.org/">Nix package
-manager</a> <i>(with <a href="https://nixos.wiki/wiki/Flakes">flakes</a> enabled)</i></summary>
+manager</a> <i>(with <a href="https://wiki.nixos.org/wiki/Flakes">flakes</a> enabled)</i></summary>
 
   - Either using the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer), with the following bash one-liner:
     ```bash

--- a/docs/.test/playwright.config.ts
+++ b/docs/.test/playwright.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     timeout: 600_000,
     expect: { timeout: 300_000 },
     reporter: [['list']],
+    workers: process.env.CI ? 8 : undefined,
+    retries: process.env.CI ? 2 : 0,
     use: {
         baseURL: 'http://localhost:8000',
         serviceWorkers: 'block',

--- a/docs/.test/tests/docs.spec.ts
+++ b/docs/.test/tests/docs.spec.ts
@@ -61,8 +61,10 @@ let run_tests = () => {
                 });
                 let other_page = await page.context().newPage();
                 let { status, html } = await tryNavigateTo(other_page, link.toString());
-                let anti_bot_codes = [401, 403, 429, 451, 999].includes(status);
-                expect(anti_bot_codes || (status >= 200 && status < 300)).toBeTruthy()
+                let anti_bot_code = [401, 403, 429, 451, 999].includes(status);
+                if (anti_bot_code)
+                    console.warn('⚠️ Accepting status ' + status + ' as an anti-bot answer, the link might be broken: ', link);
+                expect(anti_bot_code || (status >= 200 && status < 300)).toBeTruthy()
 
                 let hash = (new URL(link)).hash?.replace(/^#/, '');
                 if (hash && !link.includes(""))

--- a/docs/.test/tests/docs.spec.ts
+++ b/docs/.test/tests/docs.spec.ts
@@ -47,75 +47,85 @@ let run_tests = () => {
     }
 
 
-    for (let link of links) {
-        if (link.includes("hax-playground.cryspen.com/") || link.includes("#__codelineno"))
-            continue;
-        test('Check if link is live: ' + link, (async ({ page, baseURL }, testInfo) => {
-            await testInfo.attach('Parent pages', {
-                body: [...(links_origins.get(link) || new Set())].join('\n'),
-                contentType: 'text/plain',
-            });
-            let other_page = await page.context().newPage();
-            let { status, html } = await tryNavigateTo(other_page, link.toString());
-            let anti_bot_codes = [401, 403, 429, 451, 999].includes(status);
-            expect(anti_bot_codes || (status >= 200 && status < 300)).toBeTruthy()
-
-            let hash = (new URL(link)).hash?.replace(/^#/, '');
-            if (hash && !link.includes(""))
-                await test.step("Try detection of fragment `" + hash + '`', async () => {
-                    let el = other_page.locator('[id="' + cssEscape(hash) + '"]');
-                    if (await el.count() === 0)
-                        console.warn('⚠️ Could not find anchor in a page ', link);
+    test.describe('Link checks', () => {
+        // Link checks are independent from each other and spend all their time
+        // waiting on the network: run them across workers.
+        test.describe.configure({ mode: 'parallel' });
+        for (let link of links) {
+            if (link.includes("hax-playground.cryspen.com/") || link.includes("#__codelineno"))
+                continue;
+            test('Check if link is live: ' + link, (async ({ page, baseURL }, testInfo) => {
+                await testInfo.attach('Parent pages', {
+                    body: [...(links_origins.get(link) || new Set())].join('\n'),
+                    contentType: 'text/plain',
                 });
-        }));
-    }
+                let other_page = await page.context().newPage();
+                let { status, html } = await tryNavigateTo(other_page, link.toString());
+                let anti_bot_codes = [401, 403, 429, 451, 999].includes(status);
+                expect(anti_bot_codes || (status >= 200 && status < 300)).toBeTruthy()
 
-    for (let p of PAGES) {
-        if (!p.has_playground)
-            continue;
-        test('Test playgrounds in `' + p.url + '`', async ({ page, baseURL }, testInfo) => {
-            await page.goto(p.url, { waitUntil: 'domcontentloaded' });
-            const playableLocators = page.locator('.playable:has(.md-hax-playground .fa-check)');
-            const count = await playableLocators.count();
-
-            for (let i = 0; i < count; i++) {
-                await test.step(`Try playground #${i}`, async () => {
-                    const playable = playableLocators.nth(i);
-                    const contents = await playable.locator(".cm-content").first().innerText();
-                    await testInfo.attach('Code snippet contents', {
-                        body: contents,
-                        contentType: 'text/plain',
+                let hash = (new URL(link)).hash?.replace(/^#/, '');
+                if (hash && !link.includes(""))
+                    await test.step("Try detection of fragment `" + hash + '`', async () => {
+                        let el = other_page.locator('[id="' + cssEscape(hash) + '"]');
+                        if (await el.count() === 0)
+                            console.warn('⚠️ Could not find anchor in a page ', link);
                     });
+            }));
+        }
+    });
 
-                    const checkBtn = playable.locator('.md-hax-playground .fa-check');
-                    await checkBtn.first().click();
+    test.describe('Playgrounds', () => {
+        // Every snippet is compiled and typechecked by the hax playground service:
+        // keep those tests on a single worker so that we don't overload it.
+        test.describe.configure({ mode: 'default' });
+        for (let p of PAGES) {
+            if (!p.has_playground)
+                continue;
+            test('Test playgrounds in `' + p.url + '`', async ({ page, baseURL }, testInfo) => {
+                await page.goto(p.url, { waitUntil: 'domcontentloaded' });
+                const playableLocators = page.locator('.playable:has(.md-hax-playground .fa-check)');
+                const count = await playableLocators.count();
 
-                    let classes = '';
-                    let hasSuccess = false;
-                    let hasFailure = false;
+                for (let i = 0; i < count; i++) {
+                    await test.step(`Try playground #${i}`, async () => {
+                        const playable = playableLocators.nth(i);
+                        const contents = await playable.locator(".cm-content").first().innerText();
+                        await testInfo.attach('Code snippet contents', {
+                            body: contents,
+                            contentType: 'text/plain',
+                        });
 
-                    for (let i = 0; i < 60; i++) {
-                        classes = (await playable.getAttribute('class')) || '';
-                        hasSuccess = classes.includes('state-success');
-                        hasFailure = classes.includes('state-failure');
-                        if (hasSuccess || hasFailure)
-                            break;
-                        await new Promise(r => setTimeout(r, 1000));
-                    }
+                        const checkBtn = playable.locator('.md-hax-playground .fa-check');
+                        await checkBtn.first().click();
 
-                    expect(hasSuccess || hasFailure, "At least class `state-success` or `state-failure` should have been attached; none detected.").toBeTruthy();
+                        let classes = '';
+                        let hasSuccess = false;
+                        let hasFailure = false;
 
-                    const expectFailure = classes.includes('expect-failure');
+                        for (let i = 0; i < 60; i++) {
+                            classes = (await playable.getAttribute('class')) || '';
+                            hasSuccess = classes.includes('state-success');
+                            hasFailure = classes.includes('state-failure');
+                            if (hasSuccess || hasFailure)
+                                break;
+                            await new Promise(r => setTimeout(r, 1000));
+                        }
 
-                    if (expectFailure) {
-                        expect(hasFailure, '`.state-failure` should be set (the snippet is tagged with a class `expect-failure`), but `.state-success` was detected').toBeTruthy();
-                    } else {
-                        expect(hasSuccess, '`.state-success` should be set, but `.state-failure` was detected').toBeTruthy();
-                    }
-                });
-            }
-        });
-    }
+                        expect(hasSuccess || hasFailure, "At least class `state-success` or `state-failure` should have been attached; none detected.").toBeTruthy();
+
+                        const expectFailure = classes.includes('expect-failure');
+
+                        if (expectFailure) {
+                            expect(hasFailure, '`.state-failure` should be set (the snippet is tagged with a class `expect-failure`), but `.state-success` was detected').toBeTruthy();
+                        } else {
+                            expect(hasSuccess, '`.state-success` should be set, but `.state-failure` was detected').toBeTruthy();
+                        }
+                    });
+                }
+            });
+        }
+    });
 };
 
 run_tests();

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -41,7 +41,7 @@ Note:
 
 ### Nix
 
-This should work on [Linux](https://nixos.org/download.html#nix-install-linux), [MacOS](https://nixos.org/download.html#nix-install-macos) and [Windows](https://nixos.org/download.html#nix-install-windows).
+This should work on [Linux](https://nixos.org/download/#nix-install-linux), [MacOS](https://nixos.org/download/#nix-install-macos) and [Windows](https://nixos.org/download/#nix-install-windows).
 
 <b>Prerequisites:</b> <a href="https://nixos.org/">Nix package
 manager</a> <i>(with <a href="https://nixos.wiki/wiki/Flakes">flakes</a> enabled)</i>


### PR DESCRIPTION
Following the fixes for the Playwright job in https://github.com/cryspen/hax/pull/2114 and in the playground, we now get a timeout because the job takes too long (https://github.com/cryspen/hax/actions/runs/30895288783).

This PR:
- increases the timeout from 45 to 90 minutes
- parallelizes the dead link checks to improve the runtime
- allows 2 retries to avoid spurious failures because of network issues

[skip changelog]