### PR TITLE
[F* core-models] Fix module cyclicity between `convert` and `num`

### DIFF
--- a/hax-lib/core-models/core-models/src/core/convert.rs
+++ b/hax-lib/core-models/core-models/src/core/convert.rs
@@ -112,6 +112,8 @@ macro_rules! int_from {
 
 use super::num::error::TryFromIntError;
 
+// Bounds go through `crate::num::$To_t` rather than `$To_t` (real `core`); see the
+// note above `uint_impl!` in `num/mod.rs`.
 macro_rules! int_try_from {
     (
         $($From_t: ident)*,
@@ -122,7 +124,7 @@ macro_rules! int_try_from {
             impl TryFrom<$From_t> for $To_t {
                 type Error = TryFromIntError;
                 fn try_from(x: $From_t) -> Result<$To_t, TryFromIntError> {
-                    if x > ($To_t::MAX as $From_t) || x < ($To_t::MIN as $From_t) {
+                    if x > (crate::num::$To_t::MAX as $From_t) || x < (crate::num::$To_t::MIN as $From_t) {
                         Result::Err(TryFromIntError(()))
                     } else {
                         Result::Ok(x as $To_t)
@@ -191,7 +193,7 @@ macro_rules! int_try_from_u_to_i {
             impl TryFrom<$From_t> for $To_t {
                 type Error = TryFromIntError;
                 fn try_from(x: $From_t) -> Result<$To_t, TryFromIntError> {
-                    if x > ($To_t::MAX as $From_t) {
+                    if x > (crate::num::$To_t::MAX as $From_t) {
                         Result::Err(TryFromIntError(()))
                     } else {
                         Result::Ok(x as $To_t)
@@ -213,7 +215,7 @@ macro_rules! int_try_from_i_to_u {
                 type Error = TryFromIntError;
                 #[allow(unused_comparisons)]
                 fn try_from(x: $From_t) -> Result<$To_t, TryFromIntError> {
-                    if x < 0 || (x as u128) > ($To_t::MAX as u128) {
+                    if x < 0 || (x as u128) > (crate::num::$To_t::MAX as u128) {
                         Result::Err(TryFromIntError(()))
                     } else {
                         Result::Ok(x as $To_t)

--- a/hax-lib/core-models/core-models/src/core/convert.rs
+++ b/hax-lib/core-models/core-models/src/core/convert.rs
@@ -112,8 +112,8 @@ macro_rules! int_from {
 
 use super::num::error::TryFromIntError;
 
-// Bounds go through `crate::num::$To_t` rather than `$To_t` (real `core`); see the
-// note above `uint_impl!` in `num/mod.rs`.
+// Bounds go through `crate::num::$To_t` rather than `$To_t` (real `core`); this
+// avoids cyclic module dependencies in F*.
 macro_rules! int_try_from {
     (
         $($From_t: ident)*,

--- a/hax-lib/core-models/core-models/src/core/iter.rs
+++ b/hax-lib/core-models/core-models/src/core/iter.rs
@@ -413,7 +413,7 @@ pub mod adapters {
                         let i = self.count;
                         // TODO check what to do here. It would be bad to have an iterator with
                         // more than usize::MAX elements, this could be a requirement (but hard to formulate).
-                        hax_lib::assume!(self.count < usize::MAX);
+                        hax_lib::assume!(self.count < crate::num::usize::MAX);
                         self.count += 1;
                         Option::Some((i, a))
                     }

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -40,7 +40,6 @@ macro_rules! uint_impl {
                 paste! { [<overflowing_add_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_add(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_add(x, y);
                 if overflowed {
@@ -67,7 +66,6 @@ macro_rules! uint_impl {
                 paste! { [<overflowing_sub_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_sub(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_sub(x, y);
                 if overflowed {
@@ -94,7 +92,6 @@ macro_rules! uint_impl {
                 paste! { [<overflowing_mul_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_mul(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_mul(x, y);
                 if overflowed {
@@ -143,7 +140,6 @@ macro_rules! uint_impl {
             }
             /// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
             #[hax_lib::opaque]
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn from_str_radix(
                 src: &str,
                 radix: core::primitive::u32,
@@ -171,7 +167,6 @@ macro_rules! uint_impl {
                 paste! { [<to_le_bytes_ $Name>](bytes) }
             }
             /// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_div(x: $Self, y: $Self) -> Option<$Self> {
                 if y == 0 {
                     Option::None
@@ -185,7 +180,6 @@ macro_rules! uint_impl {
                 x / y
             }
             /// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_rem(x: $Self, y: $Self) -> Option<$Self> {
                 if y == 0 {
                     Option::None
@@ -268,7 +262,6 @@ macro_rules! iint_impl {
                 paste! { [<overflowing_add_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_add(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_add(x, y);
                 if overflowed {
@@ -295,7 +288,6 @@ macro_rules! iint_impl {
                 paste! { [<overflowing_sub_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_sub(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_sub(x, y);
                 if overflowed {
@@ -310,7 +302,6 @@ macro_rules! iint_impl {
                 x - y
             }
             /// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_add_unsigned(x: $Self, y: $USelf) -> Option<$Self> {
                 // Signed overflow from wrapping_add(x, y as $Self) represents unsigned overflow
                 // iff the signed overflow flag matches whether y exceeds the signed maximum.
@@ -322,7 +313,6 @@ macro_rules! iint_impl {
                 }
             }
             /// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_sub_unsigned(x: $Self, y: $USelf) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_sub(x, y as $Self);
                 if overflowed == (y > <$Name>::MAX as $USelf) {
@@ -344,7 +334,6 @@ macro_rules! iint_impl {
                 paste! { [<overflowing_mul_ $Name>](x, y) }
             }
             /// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_mul(x: $Self, y: $Self) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_mul(x, y);
                 if overflowed {
@@ -398,7 +387,6 @@ macro_rules! iint_impl {
             }
             /// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
             #[hax_lib::opaque]
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn from_str_radix(
                 src: &str,
                 radix: core::primitive::u32,
@@ -426,7 +414,6 @@ macro_rules! iint_impl {
                 paste! { [<to_le_bytes_ $Name>](bytes) }
             }
             /// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_div(x: $Self, y: $Self) -> Option<$Self> {
                 if y == 0 || (x == <$Name>::MIN && y == -1) {
                     Option::None
@@ -440,7 +427,6 @@ macro_rules! iint_impl {
                 x / y
             }
             /// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_rem(x: $Self, y: $Self) -> Option<$Self> {
                 if y == 0 || (x == <$Name>::MIN && y == -1) {
                     Option::None

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -8,6 +8,9 @@ pub mod error;
 
 use rust_primitives::arithmetic::*;
 
+// Bounds must be spelled `<$Name>::MAX`/`MIN` (our marker types), not
+// `$Self::MAX`/`MIN` (real `core`): both print the same, but only the former is a
+// dependency hax sees, and cycles it misses become recursive backend modules.
 macro_rules! uint_impl {
     (
         $Self: ty,
@@ -47,7 +50,7 @@ macro_rules! uint_impl {
                 }
             }
             /// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-            #[hax_lib::requires(x.to_int() + y.to_int() <= $Self::MAX.to_int())]
+            #[hax_lib::requires(x.to_int() + y.to_int() <= <$Name>::MAX.to_int())]
             pub unsafe fn unchecked_add(x: $Self, y: $Self) -> $Self {
                 x + y
             }
@@ -101,7 +104,7 @@ macro_rules! uint_impl {
                 }
             }
             /// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-            #[hax_lib::requires(x.to_int() * y.to_int() <= $Self::MAX.to_int())]
+            #[hax_lib::requires(x.to_int() * y.to_int() <= <$Name>::MAX.to_int())]
             pub unsafe fn unchecked_mul(x: $Self, y: $Self) -> $Self {
                 x * y
             }
@@ -275,7 +278,7 @@ macro_rules! iint_impl {
                 }
             }
             /// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-            #[hax_lib::requires(x.to_int() + y.to_int() <= $Self::MAX.to_int() && x.to_int() + y.to_int() >= $Self::MIN.to_int())]
+            #[hax_lib::requires(x.to_int() + y.to_int() <= <$Name>::MAX.to_int() && x.to_int() + y.to_int() >= <$Name>::MIN.to_int())]
             pub unsafe fn unchecked_add(x: $Self, y: $Self) -> $Self {
                 x + y
             }
@@ -302,7 +305,7 @@ macro_rules! iint_impl {
                 }
             }
             /// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-            #[hax_lib::requires(x.to_int() - y.to_int() <= $Self::MAX.to_int() && x.to_int() - y.to_int() >= $Self::MIN.to_int())]
+            #[hax_lib::requires(x.to_int() - y.to_int() <= <$Name>::MAX.to_int() && x.to_int() - y.to_int() >= <$Name>::MIN.to_int())]
             pub unsafe fn unchecked_sub(x: $Self, y: $Self) -> $Self {
                 x - y
             }
@@ -312,7 +315,7 @@ macro_rules! iint_impl {
                 // Signed overflow from wrapping_add(x, y as $Self) represents unsigned overflow
                 // iff the signed overflow flag matches whether y exceeds the signed maximum.
                 let (result, overflowed) = Self::overflowing_add(x, y as $Self);
-                if overflowed == (y > Self::MAX as $USelf) {
+                if overflowed == (y > <$Name>::MAX as $USelf) {
                     Option::Some(result)
                 } else {
                     Option::None
@@ -322,7 +325,7 @@ macro_rules! iint_impl {
             #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_sub_unsigned(x: $Self, y: $USelf) -> Option<$Self> {
                 let (result, overflowed) = Self::overflowing_sub(x, y as $Self);
-                if overflowed == (y > Self::MAX as $USelf) {
+                if overflowed == (y > <$Name>::MAX as $USelf) {
                     Option::Some(result)
                 } else {
                     Option::None
@@ -351,7 +354,7 @@ macro_rules! iint_impl {
                 }
             }
             /// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-            #[hax_lib::requires(x.to_int() * y.to_int() <= $Self::MAX.to_int() && x.to_int() * y.to_int() >= $Self::MIN.to_int())]
+            #[hax_lib::requires(x.to_int() * y.to_int() <= <$Name>::MAX.to_int() && x.to_int() * y.to_int() >= <$Name>::MIN.to_int())]
             pub unsafe fn unchecked_mul(x: $Self, y: $Self) -> $Self {
                 x * y
             }
@@ -369,7 +372,7 @@ macro_rules! iint_impl {
                 paste! { [<count_ones_ $Name>](x) }
             }
             /// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-            #[hax_lib::requires(x > $Self::MIN)]
+            #[hax_lib::requires(x > <$Name>::MIN)]
             pub fn abs(x: $Self) -> $Self {
                 paste! { [<abs_ $Name>](x) }
             }
@@ -425,28 +428,28 @@ macro_rules! iint_impl {
             /// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
             #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_div(x: $Self, y: $Self) -> Option<$Self> {
-                if y == 0 || (x == Self::MIN && y == -1) {
+                if y == 0 || (x == <$Name>::MIN && y == -1) {
                     Option::None
                 } else {
                     Option::Some(x / y)
                 }
             }
             /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-            #[hax_lib::requires(y != 0 && (x != $Self::MIN || y != -1))]
+            #[hax_lib::requires(y != 0 && (x != <$Name>::MIN || y != -1))]
             pub unsafe fn unchecked_div(x: $Self, y: $Self) -> $Self {
                 x / y
             }
             /// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
             #[cfg_attr(hax_backend_fstar, hax_lib::exclude)] //avoid cyclic dependency
             pub fn checked_rem(x: $Self, y: $Self) -> Option<$Self> {
-                if y == 0 || (x == Self::MIN && y == -1) {
+                if y == 0 || (x == <$Name>::MIN && y == -1) {
                     Option::None
                 } else {
                     Option::Some(x % y)
                 }
             }
             /// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-            #[hax_lib::requires(y != 0 && (x != $Self::MIN || y != -1))]
+            #[hax_lib::requires(y != 0 && (x != <$Name>::MIN || y != -1))]
             pub unsafe fn unchecked_rem(x: $Self, y: $Self) -> $Self {
                 x % y
             }
@@ -462,7 +465,7 @@ macro_rules! iint_impl {
             }
             /// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
             // `requires` rules out the div-by-zero and `MIN / -1` panics.
-            #[hax_lib::requires(y != 0 && !(x == $Self::MIN && y == -1))]
+            #[hax_lib::requires(y != 0 && !(x == <$Name>::MIN && y == -1))]
             pub fn div_ceil(x: $Self, y: $Self) -> $Self {
                 let d = x / y;
                 let r = x % y;

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -8,7 +8,7 @@ pub mod error;
 
 use rust_primitives::arithmetic::*;
 
-// Bounds must be spelled `<$Name>::MAX`/`MIN` (our marker types), not
+// Bounds must be spelled `<$Name>::MAX`/`MIN` (referring to core models), not
 // `$Self::MAX`/`MIN` (real `core`): both print the same, but only the former is a
 // dependency hax sees, and cycles it misses become recursive backend modules.
 macro_rules! uint_impl {

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -211,6 +211,2131 @@ type t_Zip (v_I1: Type0) (v_I2: Type0) = {
   f_it2:v_I2
 }
 
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_6__MIN: u8 = mk_u8 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_6__MAX: u8 = mk_u8 255
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_6__BITS: u32 = mk_u32 8
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_6__wrapping_add (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_add_u8 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_6__saturating_add (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_add_u8 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_6__overflowing_add (x y: u8) : (u8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_u8 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_6__wrapping_sub (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_sub_u8 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_6__saturating_sub (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_sub_u8 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_6__overflowing_sub (x y: u8) : (u8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_u8 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_6__wrapping_mul (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_mul_u8 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_6__saturating_mul (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_mul_u8 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_6__overflowing_mul (x y: u8) : (u8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_u8 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_6__pow (x: u8) (exp: u32) : u8 = Rust_primitives.Arithmetic.pow_u8 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_6__count_ones (x: u8) : u32 = Rust_primitives.Arithmetic.count_ones_u8 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_6__rotate_right': x: u8 -> n: u32 -> u8
+
+unfold
+let impl_6__rotate_right = impl_6__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_6__rotate_left': x: u8 -> n: u32 -> u8
+
+unfold
+let impl_6__rotate_left = impl_6__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_6__leading_zeros': x: u8 -> u32
+
+unfold
+let impl_6__leading_zeros = impl_6__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_6__ilog2': x: u8 -> u32
+
+unfold
+let impl_6__ilog2 = impl_6__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_6__from_be_bytes': bytes: t_Array u8 (mk_usize 1) -> u8
+
+unfold
+let impl_6__from_be_bytes = impl_6__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_6__from_le_bytes': bytes: t_Array u8 (mk_usize 1) -> u8
+
+unfold
+let impl_6__from_le_bytes = impl_6__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_6__to_be_bytes': bytes: u8 -> t_Array u8 (mk_usize 1)
+
+unfold
+let impl_6__to_be_bytes = impl_6__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_6__to_le_bytes': bytes: u8 -> t_Array u8 (mk_usize 1)
+
+unfold
+let impl_6__to_le_bytes = impl_6__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_6__is_power_of_two (x: u8) : bool =
+  x <>. mk_u8 0 && (x &. (x -! mk_u8 1 <: u8) <: u8) =. mk_u8 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_6__is_multiple_of (x y: u8) : bool =
+  if y =. mk_u8 0 then x =. mk_u8 0 else (x %! y <: u8) =. mk_u8 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_6__unchecked_add (x y: u8)
+    : Prims.Pure u8
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_6__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_6__unchecked_sub (x y: u8) : Prims.Pure u8 (requires x >=. y) (fun _ -> Prims.l_True) =
+  x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_6__unchecked_mul (x y: u8)
+    : Prims.Pure u8
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_6__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_6__rem_euclid (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_u8 x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_6__unchecked_div (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
+  x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_6__unchecked_rem (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
+  x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_6__div_ceil (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
+  let d:u8 = x /! y in
+  let r:u8 = x %! y in
+  if r >. mk_u8 0 then d +! mk_u8 1 else d
+
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_7__MIN: u16 = mk_u16 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_7__MAX: u16 = mk_u16 65535
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_7__BITS: u32 = mk_u32 16
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_7__wrapping_add (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_add_u16 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_7__saturating_add (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_add_u16 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_7__overflowing_add (x y: u16) : (u16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_u16 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_7__wrapping_sub (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_sub_u16 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_7__saturating_sub (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_sub_u16 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_7__overflowing_sub (x y: u16) : (u16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_u16 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_7__wrapping_mul (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_mul_u16 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_7__saturating_mul (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_mul_u16 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_7__overflowing_mul (x y: u16) : (u16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_u16 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_7__pow (x: u16) (exp: u32) : u16 = Rust_primitives.Arithmetic.pow_u16 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_7__count_ones (x: u16) : u32 = Rust_primitives.Arithmetic.count_ones_u16 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_7__rotate_right': x: u16 -> n: u32 -> u16
+
+unfold
+let impl_7__rotate_right = impl_7__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_7__rotate_left': x: u16 -> n: u32 -> u16
+
+unfold
+let impl_7__rotate_left = impl_7__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_7__leading_zeros': x: u16 -> u32
+
+unfold
+let impl_7__leading_zeros = impl_7__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_7__ilog2': x: u16 -> u32
+
+unfold
+let impl_7__ilog2 = impl_7__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_7__from_be_bytes': bytes: t_Array u8 (mk_usize 2) -> u16
+
+unfold
+let impl_7__from_be_bytes = impl_7__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_7__from_le_bytes': bytes: t_Array u8 (mk_usize 2) -> u16
+
+unfold
+let impl_7__from_le_bytes = impl_7__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_7__to_be_bytes': bytes: u16 -> t_Array u8 (mk_usize 2)
+
+unfold
+let impl_7__to_be_bytes = impl_7__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_7__to_le_bytes': bytes: u16 -> t_Array u8 (mk_usize 2)
+
+unfold
+let impl_7__to_le_bytes = impl_7__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_7__is_power_of_two (x: u16) : bool =
+  x <>. mk_u16 0 && (x &. (x -! mk_u16 1 <: u16) <: u16) =. mk_u16 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_7__is_multiple_of (x y: u16) : bool =
+  if y =. mk_u16 0 then x =. mk_u16 0 else (x %! y <: u16) =. mk_u16 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_7__unchecked_add (x y: u16)
+    : Prims.Pure u16
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_7__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_7__unchecked_sub (x y: u16) : Prims.Pure u16 (requires x >=. y) (fun _ -> Prims.l_True) =
+  x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_7__unchecked_mul (x y: u16)
+    : Prims.Pure u16
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_7__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_7__rem_euclid (x y: u16) : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_u16 x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_7__unchecked_div (x y: u16)
+    : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_7__unchecked_rem (x y: u16)
+    : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_7__div_ceil (x y: u16) : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) =
+  let d:u16 = x /! y in
+  let r:u16 = x %! y in
+  if r >. mk_u16 0 then d +! mk_u16 1 else d
+
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_8__MIN: u32 = mk_u32 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_8__MAX: u32 = mk_u32 4294967295
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_8__BITS: u32 = mk_u32 32
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_8__wrapping_add (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_add_u32 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_8__saturating_add (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_add_u32 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_8__overflowing_add (x y: u32) : (u32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_u32 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_8__wrapping_sub (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_sub_u32 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_8__saturating_sub (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_sub_u32 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_8__overflowing_sub (x y: u32) : (u32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_u32 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_8__wrapping_mul (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_mul_u32 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_8__saturating_mul (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_mul_u32 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_8__overflowing_mul (x y: u32) : (u32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_u32 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_8__pow (x exp: u32) : u32 = Rust_primitives.Arithmetic.pow_u32 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_8__count_ones (x: u32) : u32 = Rust_primitives.Arithmetic.count_ones_u32 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_8__rotate_right': x: u32 -> n: u32 -> u32
+
+unfold
+let impl_8__rotate_right = impl_8__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_8__rotate_left': x: u32 -> n: u32 -> u32
+
+unfold
+let impl_8__rotate_left = impl_8__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_8__leading_zeros': x: u32 -> u32
+
+unfold
+let impl_8__leading_zeros = impl_8__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_8__ilog2': x: u32 -> u32
+
+unfold
+let impl_8__ilog2 = impl_8__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_8__from_be_bytes': bytes: t_Array u8 (mk_usize 4) -> u32
+
+unfold
+let impl_8__from_be_bytes = impl_8__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_8__from_le_bytes': bytes: t_Array u8 (mk_usize 4) -> u32
+
+unfold
+let impl_8__from_le_bytes = impl_8__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_8__to_be_bytes': bytes: u32 -> t_Array u8 (mk_usize 4)
+
+unfold
+let impl_8__to_be_bytes = impl_8__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_8__to_le_bytes': bytes: u32 -> t_Array u8 (mk_usize 4)
+
+unfold
+let impl_8__to_le_bytes = impl_8__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_8__is_power_of_two (x: u32) : bool =
+  x <>. mk_u32 0 && (x &. (x -! mk_u32 1 <: u32) <: u32) =. mk_u32 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_8__is_multiple_of (x y: u32) : bool =
+  if y =. mk_u32 0 then x =. mk_u32 0 else (x %! y <: u32) =. mk_u32 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_8__unchecked_add (x y: u32)
+    : Prims.Pure u32
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_8__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_8__unchecked_sub (x y: u32) : Prims.Pure u32 (requires x >=. y) (fun _ -> Prims.l_True) =
+  x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_8__unchecked_mul (x y: u32)
+    : Prims.Pure u32
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_8__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_8__rem_euclid (x y: u32) : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_u32 x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_8__unchecked_div (x y: u32)
+    : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_8__unchecked_rem (x y: u32)
+    : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_8__div_ceil (x y: u32) : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) =
+  let d:u32 = x /! y in
+  let r:u32 = x %! y in
+  if r >. mk_u32 0 then d +! mk_u32 1 else d
+
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_9__MIN: u64 = mk_u64 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_9__MAX: u64 = mk_u64 18446744073709551615
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_9__BITS: u32 = mk_u32 64
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_9__wrapping_add (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_add_u64 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_9__saturating_add (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_add_u64 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_9__overflowing_add (x y: u64) : (u64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_u64 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_9__wrapping_sub (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_sub_u64 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_9__saturating_sub (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_sub_u64 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_9__overflowing_sub (x y: u64) : (u64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_u64 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_9__wrapping_mul (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_mul_u64 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_9__saturating_mul (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_mul_u64 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_9__overflowing_mul (x y: u64) : (u64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_u64 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_9__pow (x: u64) (exp: u32) : u64 = Rust_primitives.Arithmetic.pow_u64 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_9__count_ones (x: u64) : u32 = Rust_primitives.Arithmetic.count_ones_u64 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_9__rotate_right': x: u64 -> n: u32 -> u64
+
+unfold
+let impl_9__rotate_right = impl_9__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_9__rotate_left': x: u64 -> n: u32 -> u64
+
+unfold
+let impl_9__rotate_left = impl_9__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_9__leading_zeros': x: u64 -> u32
+
+unfold
+let impl_9__leading_zeros = impl_9__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_9__ilog2': x: u64 -> u32
+
+unfold
+let impl_9__ilog2 = impl_9__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_9__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> u64
+
+unfold
+let impl_9__from_be_bytes = impl_9__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_9__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> u64
+
+unfold
+let impl_9__from_le_bytes = impl_9__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_9__to_be_bytes': bytes: u64 -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_9__to_be_bytes = impl_9__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_9__to_le_bytes': bytes: u64 -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_9__to_le_bytes = impl_9__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_9__is_power_of_two (x: u64) : bool =
+  x <>. mk_u64 0 && (x &. (x -! mk_u64 1 <: u64) <: u64) =. mk_u64 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_9__is_multiple_of (x y: u64) : bool =
+  if y =. mk_u64 0 then x =. mk_u64 0 else (x %! y <: u64) =. mk_u64 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_9__unchecked_add (x y: u64)
+    : Prims.Pure u64
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_9__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_9__unchecked_sub (x y: u64) : Prims.Pure u64 (requires x >=. y) (fun _ -> Prims.l_True) =
+  x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_9__unchecked_mul (x y: u64)
+    : Prims.Pure u64
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_9__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_9__rem_euclid (x y: u64) : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_u64 x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_9__unchecked_div (x y: u64)
+    : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_9__unchecked_rem (x y: u64)
+    : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_9__div_ceil (x y: u64) : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) =
+  let d:u64 = x /! y in
+  let r:u64 = x %! y in
+  if r >. mk_u64 0 then d +! mk_u64 1 else d
+
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_10__MIN: u128 = mk_u128 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_10__MAX: u128 = mk_u128 340282366920938463463374607431768211455
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_10__BITS: u32 = mk_u32 128
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_10__wrapping_add (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_add_u128 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_10__saturating_add (x y: u128) : u128 = Rust_primitives.Arithmetic.saturating_add_u128 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_10__overflowing_add (x y: u128) : (u128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_u128 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_10__wrapping_sub (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_sub_u128 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_10__saturating_sub (x y: u128) : u128 = Rust_primitives.Arithmetic.saturating_sub_u128 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_10__overflowing_sub (x y: u128) : (u128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_u128 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_10__wrapping_mul (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_mul_u128 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_10__saturating_mul (x y: u128) : u128 = Rust_primitives.Arithmetic.saturating_mul_u128 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_10__overflowing_mul (x y: u128) : (u128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_u128 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_10__pow (x: u128) (exp: u32) : u128 = Rust_primitives.Arithmetic.pow_u128 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_10__count_ones (x: u128) : u32 = Rust_primitives.Arithmetic.count_ones_u128 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_10__rotate_right': x: u128 -> n: u32 -> u128
+
+unfold
+let impl_10__rotate_right = impl_10__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_10__rotate_left': x: u128 -> n: u32 -> u128
+
+unfold
+let impl_10__rotate_left = impl_10__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_10__leading_zeros': x: u128 -> u32
+
+unfold
+let impl_10__leading_zeros = impl_10__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_10__ilog2': x: u128 -> u32
+
+unfold
+let impl_10__ilog2 = impl_10__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_10__from_be_bytes': bytes: t_Array u8 (mk_usize 16) -> u128
+
+unfold
+let impl_10__from_be_bytes = impl_10__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_10__from_le_bytes': bytes: t_Array u8 (mk_usize 16) -> u128
+
+unfold
+let impl_10__from_le_bytes = impl_10__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_10__to_be_bytes': bytes: u128 -> t_Array u8 (mk_usize 16)
+
+unfold
+let impl_10__to_be_bytes = impl_10__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_10__to_le_bytes': bytes: u128 -> t_Array u8 (mk_usize 16)
+
+unfold
+let impl_10__to_le_bytes = impl_10__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_10__is_power_of_two (x: u128) : bool =
+  x <>. mk_u128 0 && (x &. (x -! mk_u128 1 <: u128) <: u128) =. mk_u128 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_10__is_multiple_of (x y: u128) : bool =
+  if y =. mk_u128 0 then x =. mk_u128 0 else (x %! y <: u128) =. mk_u128 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_10__unchecked_add (x y: u128)
+    : Prims.Pure u128
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_10__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_10__unchecked_sub (x y: u128) : Prims.Pure u128 (requires x >=. y) (fun _ -> Prims.l_True) =
+  x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_10__unchecked_mul (x y: u128)
+    : Prims.Pure u128
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_10__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_10__rem_euclid (x y: u128)
+    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_u128 x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_10__unchecked_div (x y: u128)
+    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_10__unchecked_rem (x y: u128)
+    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_10__div_ceil (x y: u128)
+    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) =
+  let d:u128 = x /! y in
+  let r:u128 = x %! y in
+  if r >. mk_u128 0 then d +! mk_u128 1 else d
+
+/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
+let impl_11__MIN: usize = mk_usize 0
+
+/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
+let impl_11__MAX: usize = Rust_primitives.Arithmetic.v_USIZE_MAX
+
+/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
+let impl_11__BITS: u32 = Rust_primitives.Arithmetic.v_SIZE_BITS
+
+/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
+let impl_11__wrapping_add (x y: usize) : usize = Rust_primitives.Arithmetic.wrapping_add_usize x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_11__saturating_add (x y: usize) : usize =
+  Rust_primitives.Arithmetic.saturating_add_usize x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_11__overflowing_add (x y: usize) : (usize & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_usize x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_11__wrapping_sub (x y: usize) : usize = Rust_primitives.Arithmetic.wrapping_sub_usize x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_11__saturating_sub (x y: usize) : usize =
+  Rust_primitives.Arithmetic.saturating_sub_usize x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_11__overflowing_sub (x y: usize) : (usize & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_usize x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_11__wrapping_mul (x y: usize) : usize = Rust_primitives.Arithmetic.wrapping_mul_usize x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_11__saturating_mul (x y: usize) : usize =
+  Rust_primitives.Arithmetic.saturating_mul_usize x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_11__overflowing_mul (x y: usize) : (usize & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_usize x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_11__pow (x: usize) (exp: u32) : usize = Rust_primitives.Arithmetic.pow_usize x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_11__count_ones (x: usize) : u32 = Rust_primitives.Arithmetic.count_ones_usize x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_11__rotate_right': x: usize -> n: u32 -> usize
+
+unfold
+let impl_11__rotate_right = impl_11__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_11__rotate_left': x: usize -> n: u32 -> usize
+
+unfold
+let impl_11__rotate_left = impl_11__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_11__leading_zeros': x: usize -> u32
+
+unfold
+let impl_11__leading_zeros = impl_11__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_11__ilog2': x: usize -> u32
+
+unfold
+let impl_11__ilog2 = impl_11__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_11__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
+
+unfold
+let impl_11__from_be_bytes = impl_11__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_11__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
+
+unfold
+let impl_11__from_le_bytes = impl_11__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_11__to_be_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_11__to_be_bytes = impl_11__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_11__to_le_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_11__to_le_bytes = impl_11__to_le_bytes'
+
+/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
+let impl_11__is_power_of_two (x: usize) : bool =
+  x <>. mk_usize 0 && (x &. (x -! mk_usize 1 <: usize) <: usize) =. mk_usize 0
+
+/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
+let impl_11__is_multiple_of (x y: usize) : bool =
+  if y =. mk_usize 0 then x =. mk_usize 0 else (x %! y <: usize) =. mk_usize 0
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_11__unchecked_add (x y: usize)
+    : Prims.Pure usize
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_11__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_11__unchecked_sub (x y: usize)
+    : Prims.Pure usize (requires x >=. y) (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_11__unchecked_mul (x y: usize)
+    : Prims.Pure usize
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_11__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_11__rem_euclid (x y: usize)
+    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_usize x y
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_11__unchecked_div (x y: usize)
+    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_11__unchecked_rem (x y: usize)
+    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
+let impl_11__div_ceil (x y: usize)
+    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) =
+  let d:usize = x /! y in
+  let r:usize = x %! y in
+  if r >. mk_usize 0 then d +! mk_usize 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_12__MIN: i8 = mk_i8 (-128)
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_12__MAX: i8 = mk_i8 127
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_12__BITS: u32 = mk_u32 8
+
+let impl_12__wrapping_add (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_add_i8 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_12__saturating_add (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_add_i8 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_12__overflowing_add (x y: i8) : (i8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_i8 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_12__wrapping_sub (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_sub_i8 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_12__saturating_sub (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_sub_i8 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_12__overflowing_sub (x y: i8) : (i8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_i8 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_12__wrapping_mul (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_mul_i8 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_12__saturating_mul (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_mul_i8 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_12__overflowing_mul (x y: i8) : (i8 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_i8 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_12__pow (x: i8) (exp: u32) : i8 = Rust_primitives.Arithmetic.pow_i8 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_12__count_ones (x: i8) : u32 = Rust_primitives.Arithmetic.count_ones_i8 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_12__rotate_right': x: i8 -> n: u32 -> i8
+
+unfold
+let impl_12__rotate_right = impl_12__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_12__rotate_left': x: i8 -> n: u32 -> i8
+
+unfold
+let impl_12__rotate_left = impl_12__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_12__leading_zeros': x: i8 -> u32
+
+unfold
+let impl_12__leading_zeros = impl_12__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_12__ilog2': x: i8 -> u32
+
+unfold
+let impl_12__ilog2 = impl_12__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_12__from_be_bytes': bytes: t_Array u8 (mk_usize 1) -> i8
+
+unfold
+let impl_12__from_be_bytes = impl_12__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_12__from_le_bytes': bytes: t_Array u8 (mk_usize 1) -> i8
+
+unfold
+let impl_12__from_le_bytes = impl_12__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_12__to_be_bytes': bytes: i8 -> t_Array u8 (mk_usize 1)
+
+unfold
+let impl_12__to_be_bytes = impl_12__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_12__to_le_bytes': bytes: i8 -> t_Array u8 (mk_usize 1)
+
+unfold
+let impl_12__to_le_bytes = impl_12__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_12__signum (x: i8) : i8 =
+  if x >. mk_i8 0 then mk_i8 1 else if x =. mk_i8 0 then mk_i8 0 else mk_i8 (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_12__unchecked_add (x y: i8)
+    : Prims.Pure i8
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_12__unchecked_sub (x y: i8)
+    : Prims.Pure i8
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_12__unchecked_mul (x y: i8)
+    : Prims.Pure i8
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_12__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_12__rem_euclid (x y: i8) : Prims.Pure i8 (requires y <>. mk_i8 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_i8 x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_12__abs (x: i8) : Prims.Pure i8 (requires x >. impl_12__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_i8 x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_12__unchecked_div (x y: i8)
+    : Prims.Pure i8
+      (requires y <>. mk_i8 0 && (x <>. impl_12__MIN || y <>. mk_i8 (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_12__unchecked_rem (x y: i8)
+    : Prims.Pure i8
+      (requires y <>. mk_i8 0 && (x <>. impl_12__MIN || y <>. mk_i8 (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_12__div_ceil (x y: i8)
+    : Prims.Pure i8
+      (requires y <>. mk_i8 0 && ~.((x =. impl_12__MIN <: bool) && (y =. mk_i8 (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:i8 = x /! y in
+  let r:i8 = x %! y in
+  if r >. mk_i8 0 && y >. mk_i8 0 || r <. mk_i8 0 && y <. mk_i8 0 then d +! mk_i8 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_13__MIN: i16 = mk_i16 (-32768)
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_13__MAX: i16 = mk_i16 32767
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_13__BITS: u32 = mk_u32 16
+
+let impl_13__wrapping_add (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_add_i16 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_13__saturating_add (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_add_i16 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_13__overflowing_add (x y: i16) : (i16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_i16 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_13__wrapping_sub (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_sub_i16 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_13__saturating_sub (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_sub_i16 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_13__overflowing_sub (x y: i16) : (i16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_i16 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_13__wrapping_mul (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_mul_i16 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_13__saturating_mul (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_mul_i16 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_13__overflowing_mul (x y: i16) : (i16 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_i16 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_13__pow (x: i16) (exp: u32) : i16 = Rust_primitives.Arithmetic.pow_i16 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_13__count_ones (x: i16) : u32 = Rust_primitives.Arithmetic.count_ones_i16 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_13__rotate_right': x: i16 -> n: u32 -> i16
+
+unfold
+let impl_13__rotate_right = impl_13__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_13__rotate_left': x: i16 -> n: u32 -> i16
+
+unfold
+let impl_13__rotate_left = impl_13__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_13__leading_zeros': x: i16 -> u32
+
+unfold
+let impl_13__leading_zeros = impl_13__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_13__ilog2': x: i16 -> u32
+
+unfold
+let impl_13__ilog2 = impl_13__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_13__from_be_bytes': bytes: t_Array u8 (mk_usize 2) -> i16
+
+unfold
+let impl_13__from_be_bytes = impl_13__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_13__from_le_bytes': bytes: t_Array u8 (mk_usize 2) -> i16
+
+unfold
+let impl_13__from_le_bytes = impl_13__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_13__to_be_bytes': bytes: i16 -> t_Array u8 (mk_usize 2)
+
+unfold
+let impl_13__to_be_bytes = impl_13__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_13__to_le_bytes': bytes: i16 -> t_Array u8 (mk_usize 2)
+
+unfold
+let impl_13__to_le_bytes = impl_13__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_13__signum (x: i16) : i16 =
+  if x >. mk_i16 0 then mk_i16 1 else if x =. mk_i16 0 then mk_i16 0 else mk_i16 (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_13__unchecked_add (x y: i16)
+    : Prims.Pure i16
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_13__unchecked_sub (x y: i16)
+    : Prims.Pure i16
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_13__unchecked_mul (x y: i16)
+    : Prims.Pure i16
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_13__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_13__rem_euclid (x y: i16)
+    : Prims.Pure i16 (requires y <>. mk_i16 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_i16 x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_13__abs (x: i16) : Prims.Pure i16 (requires x >. impl_13__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_i16 x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_13__unchecked_div (x y: i16)
+    : Prims.Pure i16
+      (requires y <>. mk_i16 0 && (x <>. impl_13__MIN || y <>. mk_i16 (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_13__unchecked_rem (x y: i16)
+    : Prims.Pure i16
+      (requires y <>. mk_i16 0 && (x <>. impl_13__MIN || y <>. mk_i16 (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_13__div_ceil (x y: i16)
+    : Prims.Pure i16
+      (requires y <>. mk_i16 0 && ~.((x =. impl_13__MIN <: bool) && (y =. mk_i16 (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:i16 = x /! y in
+  let r:i16 = x %! y in
+  if r >. mk_i16 0 && y >. mk_i16 0 || r <. mk_i16 0 && y <. mk_i16 0 then d +! mk_i16 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_14__MIN: i32 = mk_i32 (-2147483648)
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_14__MAX: i32 = mk_i32 2147483647
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_14__BITS: u32 = mk_u32 32
+
+let impl_14__wrapping_add (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_add_i32 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_14__saturating_add (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_add_i32 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_14__overflowing_add (x y: i32) : (i32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_i32 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_14__wrapping_sub (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_sub_i32 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_14__saturating_sub (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_sub_i32 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_14__overflowing_sub (x y: i32) : (i32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_i32 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_14__wrapping_mul (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_mul_i32 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_14__saturating_mul (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_mul_i32 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_14__overflowing_mul (x y: i32) : (i32 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_i32 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_14__pow (x: i32) (exp: u32) : i32 = Rust_primitives.Arithmetic.pow_i32 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_14__count_ones (x: i32) : u32 = Rust_primitives.Arithmetic.count_ones_i32 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_14__rotate_right': x: i32 -> n: u32 -> i32
+
+unfold
+let impl_14__rotate_right = impl_14__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_14__rotate_left': x: i32 -> n: u32 -> i32
+
+unfold
+let impl_14__rotate_left = impl_14__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_14__leading_zeros': x: i32 -> u32
+
+unfold
+let impl_14__leading_zeros = impl_14__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_14__ilog2': x: i32 -> u32
+
+unfold
+let impl_14__ilog2 = impl_14__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_14__from_be_bytes': bytes: t_Array u8 (mk_usize 4) -> i32
+
+unfold
+let impl_14__from_be_bytes = impl_14__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_14__from_le_bytes': bytes: t_Array u8 (mk_usize 4) -> i32
+
+unfold
+let impl_14__from_le_bytes = impl_14__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_14__to_be_bytes': bytes: i32 -> t_Array u8 (mk_usize 4)
+
+unfold
+let impl_14__to_be_bytes = impl_14__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_14__to_le_bytes': bytes: i32 -> t_Array u8 (mk_usize 4)
+
+unfold
+let impl_14__to_le_bytes = impl_14__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_14__signum (x: i32) : i32 =
+  if x >. mk_i32 0 then mk_i32 1 else if x =. mk_i32 0 then mk_i32 0 else mk_i32 (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_14__unchecked_add (x y: i32)
+    : Prims.Pure i32
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_14__unchecked_sub (x y: i32)
+    : Prims.Pure i32
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_14__unchecked_mul (x y: i32)
+    : Prims.Pure i32
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_14__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_14__rem_euclid (x y: i32)
+    : Prims.Pure i32 (requires y <>. mk_i32 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_i32 x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_14__abs (x: i32) : Prims.Pure i32 (requires x >. impl_14__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_i32 x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_14__unchecked_div (x y: i32)
+    : Prims.Pure i32
+      (requires y <>. mk_i32 0 && (x <>. impl_14__MIN || y <>. mk_i32 (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_14__unchecked_rem (x y: i32)
+    : Prims.Pure i32
+      (requires y <>. mk_i32 0 && (x <>. impl_14__MIN || y <>. mk_i32 (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_14__div_ceil (x y: i32)
+    : Prims.Pure i32
+      (requires y <>. mk_i32 0 && ~.((x =. impl_14__MIN <: bool) && (y =. mk_i32 (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:i32 = x /! y in
+  let r:i32 = x %! y in
+  if r >. mk_i32 0 && y >. mk_i32 0 || r <. mk_i32 0 && y <. mk_i32 0 then d +! mk_i32 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_15__MIN: i64 = mk_i64 (-9223372036854775808)
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_15__MAX: i64 = mk_i64 9223372036854775807
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_15__BITS: u32 = mk_u32 64
+
+let impl_15__wrapping_add (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_add_i64 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_15__saturating_add (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_add_i64 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_15__overflowing_add (x y: i64) : (i64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_i64 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_15__wrapping_sub (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_sub_i64 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_15__saturating_sub (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_sub_i64 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_15__overflowing_sub (x y: i64) : (i64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_i64 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_15__wrapping_mul (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_mul_i64 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_15__saturating_mul (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_mul_i64 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_15__overflowing_mul (x y: i64) : (i64 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_i64 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_15__pow (x: i64) (exp: u32) : i64 = Rust_primitives.Arithmetic.pow_i64 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_15__count_ones (x: i64) : u32 = Rust_primitives.Arithmetic.count_ones_i64 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_15__rotate_right': x: i64 -> n: u32 -> i64
+
+unfold
+let impl_15__rotate_right = impl_15__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_15__rotate_left': x: i64 -> n: u32 -> i64
+
+unfold
+let impl_15__rotate_left = impl_15__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_15__leading_zeros': x: i64 -> u32
+
+unfold
+let impl_15__leading_zeros = impl_15__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_15__ilog2': x: i64 -> u32
+
+unfold
+let impl_15__ilog2 = impl_15__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_15__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> i64
+
+unfold
+let impl_15__from_be_bytes = impl_15__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_15__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> i64
+
+unfold
+let impl_15__from_le_bytes = impl_15__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_15__to_be_bytes': bytes: i64 -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_15__to_be_bytes = impl_15__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_15__to_le_bytes': bytes: i64 -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_15__to_le_bytes = impl_15__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_15__signum (x: i64) : i64 =
+  if x >. mk_i64 0 then mk_i64 1 else if x =. mk_i64 0 then mk_i64 0 else mk_i64 (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_15__unchecked_add (x y: i64)
+    : Prims.Pure i64
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_15__unchecked_sub (x y: i64)
+    : Prims.Pure i64
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_15__unchecked_mul (x y: i64)
+    : Prims.Pure i64
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_15__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_15__rem_euclid (x y: i64)
+    : Prims.Pure i64 (requires y <>. mk_i64 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_i64 x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_15__abs (x: i64) : Prims.Pure i64 (requires x >. impl_15__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_i64 x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_15__unchecked_div (x y: i64)
+    : Prims.Pure i64
+      (requires y <>. mk_i64 0 && (x <>. impl_15__MIN || y <>. mk_i64 (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_15__unchecked_rem (x y: i64)
+    : Prims.Pure i64
+      (requires y <>. mk_i64 0 && (x <>. impl_15__MIN || y <>. mk_i64 (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_15__div_ceil (x y: i64)
+    : Prims.Pure i64
+      (requires y <>. mk_i64 0 && ~.((x =. impl_15__MIN <: bool) && (y =. mk_i64 (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:i64 = x /! y in
+  let r:i64 = x %! y in
+  if r >. mk_i64 0 && y >. mk_i64 0 || r <. mk_i64 0 && y <. mk_i64 0 then d +! mk_i64 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_16__MIN: i128 = mk_i128 (-170141183460469231731687303715884105728)
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_16__MAX: i128 = mk_i128 170141183460469231731687303715884105727
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_16__BITS: u32 = mk_u32 128
+
+let impl_16__wrapping_add (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_add_i128 x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_16__saturating_add (x y: i128) : i128 = Rust_primitives.Arithmetic.saturating_add_i128 x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_16__overflowing_add (x y: i128) : (i128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_i128 x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_16__wrapping_sub (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_sub_i128 x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_16__saturating_sub (x y: i128) : i128 = Rust_primitives.Arithmetic.saturating_sub_i128 x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_16__overflowing_sub (x y: i128) : (i128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_i128 x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_16__wrapping_mul (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_mul_i128 x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_16__saturating_mul (x y: i128) : i128 = Rust_primitives.Arithmetic.saturating_mul_i128 x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_16__overflowing_mul (x y: i128) : (i128 & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_i128 x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_16__pow (x: i128) (exp: u32) : i128 = Rust_primitives.Arithmetic.pow_i128 x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_16__count_ones (x: i128) : u32 = Rust_primitives.Arithmetic.count_ones_i128 x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_16__rotate_right': x: i128 -> n: u32 -> i128
+
+unfold
+let impl_16__rotate_right = impl_16__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_16__rotate_left': x: i128 -> n: u32 -> i128
+
+unfold
+let impl_16__rotate_left = impl_16__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_16__leading_zeros': x: i128 -> u32
+
+unfold
+let impl_16__leading_zeros = impl_16__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_16__ilog2': x: i128 -> u32
+
+unfold
+let impl_16__ilog2 = impl_16__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_16__from_be_bytes': bytes: t_Array u8 (mk_usize 16) -> i128
+
+unfold
+let impl_16__from_be_bytes = impl_16__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_16__from_le_bytes': bytes: t_Array u8 (mk_usize 16) -> i128
+
+unfold
+let impl_16__from_le_bytes = impl_16__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_16__to_be_bytes': bytes: i128 -> t_Array u8 (mk_usize 16)
+
+unfold
+let impl_16__to_be_bytes = impl_16__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_16__to_le_bytes': bytes: i128 -> t_Array u8 (mk_usize 16)
+
+unfold
+let impl_16__to_le_bytes = impl_16__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_16__signum (x: i128) : i128 =
+  if x >. mk_i128 0 then mk_i128 1 else if x =. mk_i128 0 then mk_i128 0 else mk_i128 (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_16__unchecked_add (x y: i128)
+    : Prims.Pure i128
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_16__unchecked_sub (x y: i128)
+    : Prims.Pure i128
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_16__unchecked_mul (x y: i128)
+    : Prims.Pure i128
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_16__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_16__rem_euclid (x y: i128)
+    : Prims.Pure i128 (requires y <>. mk_i128 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_i128 x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_16__abs (x: i128) : Prims.Pure i128 (requires x >. impl_16__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_i128 x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_16__unchecked_div (x y: i128)
+    : Prims.Pure i128
+      (requires y <>. mk_i128 0 && (x <>. impl_16__MIN || y <>. mk_i128 (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_16__unchecked_rem (x y: i128)
+    : Prims.Pure i128
+      (requires y <>. mk_i128 0 && (x <>. impl_16__MIN || y <>. mk_i128 (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_16__div_ceil (x y: i128)
+    : Prims.Pure i128
+      (requires y <>. mk_i128 0 && ~.((x =. impl_16__MIN <: bool) && (y =. mk_i128 (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:i128 = x /! y in
+  let r:i128 = x %! y in
+  if r >. mk_i128 0 && y >. mk_i128 0 || r <. mk_i128 0 && y <. mk_i128 0 then d +! mk_i128 1 else d
+
+/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
+let impl_17__MIN: isize = Rust_primitives.Arithmetic.v_ISIZE_MIN
+
+/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
+let impl_17__MAX: isize = Rust_primitives.Arithmetic.v_ISIZE_MAX
+
+/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
+let impl_17__BITS: u32 = Rust_primitives.Arithmetic.v_SIZE_BITS
+
+let impl_17__wrapping_add (x y: isize) : isize = Rust_primitives.Arithmetic.wrapping_add_isize x y
+
+/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
+let impl_17__saturating_add (x y: isize) : isize =
+  Rust_primitives.Arithmetic.saturating_add_isize x y
+
+/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
+let impl_17__overflowing_add (x y: isize) : (isize & bool) =
+  Rust_primitives.Arithmetic.overflowing_add_isize x y
+
+/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
+let impl_17__wrapping_sub (x y: isize) : isize = Rust_primitives.Arithmetic.wrapping_sub_isize x y
+
+/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
+let impl_17__saturating_sub (x y: isize) : isize =
+  Rust_primitives.Arithmetic.saturating_sub_isize x y
+
+/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
+let impl_17__overflowing_sub (x y: isize) : (isize & bool) =
+  Rust_primitives.Arithmetic.overflowing_sub_isize x y
+
+/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
+let impl_17__wrapping_mul (x y: isize) : isize = Rust_primitives.Arithmetic.wrapping_mul_isize x y
+
+/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
+let impl_17__saturating_mul (x y: isize) : isize =
+  Rust_primitives.Arithmetic.saturating_mul_isize x y
+
+/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
+let impl_17__overflowing_mul (x y: isize) : (isize & bool) =
+  Rust_primitives.Arithmetic.overflowing_mul_isize x y
+
+/// See [`std::primitive::u8::pow`] (and similar for other integer types)
+let impl_17__pow (x: isize) (exp: u32) : isize = Rust_primitives.Arithmetic.pow_isize x exp
+
+/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
+let impl_17__count_ones (x: isize) : u32 = Rust_primitives.Arithmetic.count_ones_isize x
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+assume
+val impl_17__rotate_right': x: isize -> n: u32 -> isize
+
+unfold
+let impl_17__rotate_right = impl_17__rotate_right'
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+assume
+val impl_17__rotate_left': x: isize -> n: u32 -> isize
+
+unfold
+let impl_17__rotate_left = impl_17__rotate_left'
+
+/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
+assume
+val impl_17__leading_zeros': x: isize -> u32
+
+unfold
+let impl_17__leading_zeros = impl_17__leading_zeros'
+
+/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
+assume
+val impl_17__ilog2': x: isize -> u32
+
+unfold
+let impl_17__ilog2 = impl_17__ilog2'
+
+/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
+assume
+val impl_17__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
+
+unfold
+let impl_17__from_be_bytes = impl_17__from_be_bytes'
+
+/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
+assume
+val impl_17__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
+
+unfold
+let impl_17__from_le_bytes = impl_17__from_le_bytes'
+
+/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
+assume
+val impl_17__to_be_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_17__to_be_bytes = impl_17__to_be_bytes'
+
+/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
+assume
+val impl_17__to_le_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
+
+unfold
+let impl_17__to_le_bytes = impl_17__to_le_bytes'
+
+/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
+let impl_17__signum (x: isize) : isize =
+  if x >. mk_isize 0 then mk_isize 1 else if x =. mk_isize 0 then mk_isize 0 else mk_isize (-1)
+
+/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
+let impl_17__unchecked_add (x y: isize)
+    : Prims.Pure isize
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x +! y
+
+/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
+let impl_17__unchecked_sub (x y: isize)
+    : Prims.Pure isize
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x -! y
+
+/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
+let impl_17__unchecked_mul (x y: isize)
+    : Prims.Pure isize
+      (requires
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MAX <: Hax_lib.Int.t_Int) &&
+        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
+          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) >=
+        (Rust_primitives.Hax.Int.from_machine impl_17__MIN <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) = x *! y
+
+/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
+let impl_17__rem_euclid (x y: isize)
+    : Prims.Pure isize (requires y <>. mk_isize 0) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.rem_euclid_isize x y
+
+/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
+let impl_17__abs (x: isize) : Prims.Pure isize (requires x >. impl_17__MIN) (fun _ -> Prims.l_True) =
+  Rust_primitives.Arithmetic.abs_isize x
+
+/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
+let impl_17__unchecked_div (x y: isize)
+    : Prims.Pure isize
+      (requires y <>. mk_isize 0 && (x <>. impl_17__MIN || y <>. mk_isize (-1)))
+      (fun _ -> Prims.l_True) = x /! y
+
+/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
+let impl_17__unchecked_rem (x y: isize)
+    : Prims.Pure isize
+      (requires y <>. mk_isize 0 && (x <>. impl_17__MIN || y <>. mk_isize (-1)))
+      (fun _ -> Prims.l_True) = x %! y
+
+/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
+let impl_17__div_ceil (x y: isize)
+    : Prims.Pure isize
+      (requires y <>. mk_isize 0 && ~.((x =. impl_17__MIN <: bool) && (y =. mk_isize (-1) <: bool)))
+      (fun _ -> Prims.l_True) =
+  let d:isize = x /! y in
+  let r:isize = x %! y in
+  if r >. mk_isize 0 && y >. mk_isize 0 || r <. mk_isize 0 && y <. mk_isize 0
+  then d +! mk_isize 1
+  else d
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_18__from__num: Core_models.Default.t_Default u8 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: u8) -> true);
+    f_default = fun (_: Prims.unit) -> mk_u8 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_19__from__num: Core_models.Default.t_Default u16 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: u16) -> true);
+    f_default = fun (_: Prims.unit) -> mk_u16 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_20__from__num: Core_models.Default.t_Default u32 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: u32) -> true);
+    f_default = fun (_: Prims.unit) -> mk_u32 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_21__from__num: Core_models.Default.t_Default u64 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: u64) -> true);
+    f_default = fun (_: Prims.unit) -> mk_u64 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_22__from__num: Core_models.Default.t_Default u128 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: u128) -> true);
+    f_default = fun (_: Prims.unit) -> mk_u128 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_23__from__num: Core_models.Default.t_Default usize =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: usize) -> true);
+    f_default = fun (_: Prims.unit) -> mk_usize 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_24__from__num: Core_models.Default.t_Default i8 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: i8) -> true);
+    f_default = fun (_: Prims.unit) -> mk_i8 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_25__from__num: Core_models.Default.t_Default i16 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: i16) -> true);
+    f_default = fun (_: Prims.unit) -> mk_i16 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_26__from__num: Core_models.Default.t_Default i32 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: i32) -> true);
+    f_default = fun (_: Prims.unit) -> mk_i32 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_27__from__num: Core_models.Default.t_Default i64 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: i64) -> true);
+    f_default = fun (_: Prims.unit) -> mk_i64 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_28__from__num: Core_models.Default.t_Default i128 =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: i128) -> true);
+    f_default = fun (_: Prims.unit) -> mk_i128 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_29__from__num: Core_models.Default.t_Default isize =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: isize) -> true);
+    f_default = fun (_: Prims.unit) -> mk_isize 0
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_30__from__num: Core_models.Default.t_Default bool =
+  {
+    f_default_pre = (fun (_: Prims.unit) -> true);
+    f_default_post = (fun (_: Prims.unit) (out: bool) -> true);
+    f_default = fun (_: Prims.unit) -> false
+  }
+
 /// See [`std::ops::RangeTo`]
 type t_RangeTo (v_T: Type0) = { f_end:v_T }
 
@@ -302,6 +2427,394 @@ type t_FlatMap (v_I: Type0) (v_U: Type0) (v_F: Type0) = {
   f_f:v_F;
   f_current:t_Option v_U
 }
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_6__checked_add (x y: u8) : t_Option u8 =
+  let (result: u8), (overflowed: bool) = impl_6__overflowing_add x y in
+  if overflowed then Option_None <: t_Option u8 else Option_Some result <: t_Option u8
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_6__checked_sub (x y: u8) : t_Option u8 =
+  let (result: u8), (overflowed: bool) = impl_6__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option u8 else Option_Some result <: t_Option u8
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_6__checked_mul (x y: u8) : t_Option u8 =
+  let (result: u8), (overflowed: bool) = impl_6__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option u8 else Option_Some result <: t_Option u8
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_6__checked_div (x y: u8) : t_Option u8 =
+  if y =. mk_u8 0 then Option_None <: t_Option u8 else Option_Some (x /! y) <: t_Option u8
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_6__checked_rem (x y: u8) : t_Option u8 =
+  if y =. mk_u8 0 then Option_None <: t_Option u8 else Option_Some (x %! y) <: t_Option u8
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_7__checked_add (x y: u16) : t_Option u16 =
+  let (result: u16), (overflowed: bool) = impl_7__overflowing_add x y in
+  if overflowed then Option_None <: t_Option u16 else Option_Some result <: t_Option u16
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_7__checked_sub (x y: u16) : t_Option u16 =
+  let (result: u16), (overflowed: bool) = impl_7__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option u16 else Option_Some result <: t_Option u16
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_7__checked_mul (x y: u16) : t_Option u16 =
+  let (result: u16), (overflowed: bool) = impl_7__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option u16 else Option_Some result <: t_Option u16
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_7__checked_div (x y: u16) : t_Option u16 =
+  if y =. mk_u16 0 then Option_None <: t_Option u16 else Option_Some (x /! y) <: t_Option u16
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_7__checked_rem (x y: u16) : t_Option u16 =
+  if y =. mk_u16 0 then Option_None <: t_Option u16 else Option_Some (x %! y) <: t_Option u16
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_8__checked_add (x y: u32) : t_Option u32 =
+  let (result: u32), (overflowed: bool) = impl_8__overflowing_add x y in
+  if overflowed then Option_None <: t_Option u32 else Option_Some result <: t_Option u32
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_8__checked_sub (x y: u32) : t_Option u32 =
+  let (result: u32), (overflowed: bool) = impl_8__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option u32 else Option_Some result <: t_Option u32
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_8__checked_mul (x y: u32) : t_Option u32 =
+  let (result: u32), (overflowed: bool) = impl_8__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option u32 else Option_Some result <: t_Option u32
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_8__checked_div (x y: u32) : t_Option u32 =
+  if y =. mk_u32 0 then Option_None <: t_Option u32 else Option_Some (x /! y) <: t_Option u32
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_8__checked_rem (x y: u32) : t_Option u32 =
+  if y =. mk_u32 0 then Option_None <: t_Option u32 else Option_Some (x %! y) <: t_Option u32
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_9__checked_add (x y: u64) : t_Option u64 =
+  let (result: u64), (overflowed: bool) = impl_9__overflowing_add x y in
+  if overflowed then Option_None <: t_Option u64 else Option_Some result <: t_Option u64
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_9__checked_sub (x y: u64) : t_Option u64 =
+  let (result: u64), (overflowed: bool) = impl_9__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option u64 else Option_Some result <: t_Option u64
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_9__checked_mul (x y: u64) : t_Option u64 =
+  let (result: u64), (overflowed: bool) = impl_9__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option u64 else Option_Some result <: t_Option u64
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_9__checked_div (x y: u64) : t_Option u64 =
+  if y =. mk_u64 0 then Option_None <: t_Option u64 else Option_Some (x /! y) <: t_Option u64
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_9__checked_rem (x y: u64) : t_Option u64 =
+  if y =. mk_u64 0 then Option_None <: t_Option u64 else Option_Some (x %! y) <: t_Option u64
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_10__checked_add (x y: u128) : t_Option u128 =
+  let (result: u128), (overflowed: bool) = impl_10__overflowing_add x y in
+  if overflowed then Option_None <: t_Option u128 else Option_Some result <: t_Option u128
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_10__checked_sub (x y: u128) : t_Option u128 =
+  let (result: u128), (overflowed: bool) = impl_10__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option u128 else Option_Some result <: t_Option u128
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_10__checked_mul (x y: u128) : t_Option u128 =
+  let (result: u128), (overflowed: bool) = impl_10__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option u128 else Option_Some result <: t_Option u128
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_10__checked_div (x y: u128) : t_Option u128 =
+  if y =. mk_u128 0 then Option_None <: t_Option u128 else Option_Some (x /! y) <: t_Option u128
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_10__checked_rem (x y: u128) : t_Option u128 =
+  if y =. mk_u128 0 then Option_None <: t_Option u128 else Option_Some (x %! y) <: t_Option u128
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_11__checked_add (x y: usize) : t_Option usize =
+  let (result: usize), (overflowed: bool) = impl_11__overflowing_add x y in
+  if overflowed then Option_None <: t_Option usize else Option_Some result <: t_Option usize
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_11__checked_sub (x y: usize) : t_Option usize =
+  let (result: usize), (overflowed: bool) = impl_11__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option usize else Option_Some result <: t_Option usize
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_11__checked_mul (x y: usize) : t_Option usize =
+  let (result: usize), (overflowed: bool) = impl_11__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option usize else Option_Some result <: t_Option usize
+
+/// See [`std::primitive::u8::checked_div`] (and similar for other integer types)
+let impl_11__checked_div (x y: usize) : t_Option usize =
+  if y =. mk_usize 0 then Option_None <: t_Option usize else Option_Some (x /! y) <: t_Option usize
+
+/// See [`std::primitive::u8::checked_rem`] (and similar for other integer types)
+let impl_11__checked_rem (x y: usize) : t_Option usize =
+  if y =. mk_usize 0 then Option_None <: t_Option usize else Option_Some (x %! y) <: t_Option usize
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_12__checked_add (x y: i8) : t_Option i8 =
+  let (result: i8), (overflowed: bool) = impl_12__overflowing_add x y in
+  if overflowed then Option_None <: t_Option i8 else Option_Some result <: t_Option i8
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_12__checked_sub (x y: i8) : t_Option i8 =
+  let (result: i8), (overflowed: bool) = impl_12__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option i8 else Option_Some result <: t_Option i8
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_12__checked_add_unsigned (x: i8) (y: u8) : t_Option i8 =
+  let (result: i8), (overflowed: bool) = impl_12__overflowing_add x (cast (y <: u8) <: i8) in
+  if overflowed =. (y >. (cast (impl_12__MAX <: i8) <: u8) <: bool)
+  then Option_Some result <: t_Option i8
+  else Option_None <: t_Option i8
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_12__checked_sub_unsigned (x: i8) (y: u8) : t_Option i8 =
+  let (result: i8), (overflowed: bool) = impl_12__overflowing_sub x (cast (y <: u8) <: i8) in
+  if overflowed =. (y >. (cast (impl_12__MAX <: i8) <: u8) <: bool)
+  then Option_Some result <: t_Option i8
+  else Option_None <: t_Option i8
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_12__checked_mul (x y: i8) : t_Option i8 =
+  let (result: i8), (overflowed: bool) = impl_12__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option i8 else Option_Some result <: t_Option i8
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_12__checked_div (x y: i8) : t_Option i8 =
+  if y =. mk_i8 0 || x =. impl_12__MIN && y =. mk_i8 (-1)
+  then Option_None <: t_Option i8
+  else Option_Some (x /! y) <: t_Option i8
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_12__checked_rem (x y: i8) : t_Option i8 =
+  if y =. mk_i8 0 || x =. impl_12__MIN && y =. mk_i8 (-1)
+  then Option_None <: t_Option i8
+  else Option_Some (x %! y) <: t_Option i8
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_13__checked_add (x y: i16) : t_Option i16 =
+  let (result: i16), (overflowed: bool) = impl_13__overflowing_add x y in
+  if overflowed then Option_None <: t_Option i16 else Option_Some result <: t_Option i16
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_13__checked_sub (x y: i16) : t_Option i16 =
+  let (result: i16), (overflowed: bool) = impl_13__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option i16 else Option_Some result <: t_Option i16
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_13__checked_add_unsigned (x: i16) (y: u16) : t_Option i16 =
+  let (result: i16), (overflowed: bool) = impl_13__overflowing_add x (cast (y <: u16) <: i16) in
+  if overflowed =. (y >. (cast (impl_13__MAX <: i16) <: u16) <: bool)
+  then Option_Some result <: t_Option i16
+  else Option_None <: t_Option i16
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_13__checked_sub_unsigned (x: i16) (y: u16) : t_Option i16 =
+  let (result: i16), (overflowed: bool) = impl_13__overflowing_sub x (cast (y <: u16) <: i16) in
+  if overflowed =. (y >. (cast (impl_13__MAX <: i16) <: u16) <: bool)
+  then Option_Some result <: t_Option i16
+  else Option_None <: t_Option i16
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_13__checked_mul (x y: i16) : t_Option i16 =
+  let (result: i16), (overflowed: bool) = impl_13__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option i16 else Option_Some result <: t_Option i16
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_13__checked_div (x y: i16) : t_Option i16 =
+  if y =. mk_i16 0 || x =. impl_13__MIN && y =. mk_i16 (-1)
+  then Option_None <: t_Option i16
+  else Option_Some (x /! y) <: t_Option i16
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_13__checked_rem (x y: i16) : t_Option i16 =
+  if y =. mk_i16 0 || x =. impl_13__MIN && y =. mk_i16 (-1)
+  then Option_None <: t_Option i16
+  else Option_Some (x %! y) <: t_Option i16
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_14__checked_add (x y: i32) : t_Option i32 =
+  let (result: i32), (overflowed: bool) = impl_14__overflowing_add x y in
+  if overflowed then Option_None <: t_Option i32 else Option_Some result <: t_Option i32
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_14__checked_sub (x y: i32) : t_Option i32 =
+  let (result: i32), (overflowed: bool) = impl_14__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option i32 else Option_Some result <: t_Option i32
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_14__checked_add_unsigned (x: i32) (y: u32) : t_Option i32 =
+  let (result: i32), (overflowed: bool) = impl_14__overflowing_add x (cast (y <: u32) <: i32) in
+  if overflowed =. (y >. (cast (impl_14__MAX <: i32) <: u32) <: bool)
+  then Option_Some result <: t_Option i32
+  else Option_None <: t_Option i32
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_14__checked_sub_unsigned (x: i32) (y: u32) : t_Option i32 =
+  let (result: i32), (overflowed: bool) = impl_14__overflowing_sub x (cast (y <: u32) <: i32) in
+  if overflowed =. (y >. (cast (impl_14__MAX <: i32) <: u32) <: bool)
+  then Option_Some result <: t_Option i32
+  else Option_None <: t_Option i32
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_14__checked_mul (x y: i32) : t_Option i32 =
+  let (result: i32), (overflowed: bool) = impl_14__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option i32 else Option_Some result <: t_Option i32
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_14__checked_div (x y: i32) : t_Option i32 =
+  if y =. mk_i32 0 || x =. impl_14__MIN && y =. mk_i32 (-1)
+  then Option_None <: t_Option i32
+  else Option_Some (x /! y) <: t_Option i32
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_14__checked_rem (x y: i32) : t_Option i32 =
+  if y =. mk_i32 0 || x =. impl_14__MIN && y =. mk_i32 (-1)
+  then Option_None <: t_Option i32
+  else Option_Some (x %! y) <: t_Option i32
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_15__checked_add (x y: i64) : t_Option i64 =
+  let (result: i64), (overflowed: bool) = impl_15__overflowing_add x y in
+  if overflowed then Option_None <: t_Option i64 else Option_Some result <: t_Option i64
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_15__checked_sub (x y: i64) : t_Option i64 =
+  let (result: i64), (overflowed: bool) = impl_15__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option i64 else Option_Some result <: t_Option i64
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_15__checked_add_unsigned (x: i64) (y: u64) : t_Option i64 =
+  let (result: i64), (overflowed: bool) = impl_15__overflowing_add x (cast (y <: u64) <: i64) in
+  if overflowed =. (y >. (cast (impl_15__MAX <: i64) <: u64) <: bool)
+  then Option_Some result <: t_Option i64
+  else Option_None <: t_Option i64
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_15__checked_sub_unsigned (x: i64) (y: u64) : t_Option i64 =
+  let (result: i64), (overflowed: bool) = impl_15__overflowing_sub x (cast (y <: u64) <: i64) in
+  if overflowed =. (y >. (cast (impl_15__MAX <: i64) <: u64) <: bool)
+  then Option_Some result <: t_Option i64
+  else Option_None <: t_Option i64
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_15__checked_mul (x y: i64) : t_Option i64 =
+  let (result: i64), (overflowed: bool) = impl_15__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option i64 else Option_Some result <: t_Option i64
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_15__checked_div (x y: i64) : t_Option i64 =
+  if y =. mk_i64 0 || x =. impl_15__MIN && y =. mk_i64 (-1)
+  then Option_None <: t_Option i64
+  else Option_Some (x /! y) <: t_Option i64
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_15__checked_rem (x y: i64) : t_Option i64 =
+  if y =. mk_i64 0 || x =. impl_15__MIN && y =. mk_i64 (-1)
+  then Option_None <: t_Option i64
+  else Option_Some (x %! y) <: t_Option i64
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_16__checked_add (x y: i128) : t_Option i128 =
+  let (result: i128), (overflowed: bool) = impl_16__overflowing_add x y in
+  if overflowed then Option_None <: t_Option i128 else Option_Some result <: t_Option i128
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_16__checked_sub (x y: i128) : t_Option i128 =
+  let (result: i128), (overflowed: bool) = impl_16__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option i128 else Option_Some result <: t_Option i128
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_16__checked_add_unsigned (x: i128) (y: u128) : t_Option i128 =
+  let (result: i128), (overflowed: bool) = impl_16__overflowing_add x (cast (y <: u128) <: i128) in
+  if overflowed =. (y >. (cast (impl_16__MAX <: i128) <: u128) <: bool)
+  then Option_Some result <: t_Option i128
+  else Option_None <: t_Option i128
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_16__checked_sub_unsigned (x: i128) (y: u128) : t_Option i128 =
+  let (result: i128), (overflowed: bool) = impl_16__overflowing_sub x (cast (y <: u128) <: i128) in
+  if overflowed =. (y >. (cast (impl_16__MAX <: i128) <: u128) <: bool)
+  then Option_Some result <: t_Option i128
+  else Option_None <: t_Option i128
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_16__checked_mul (x y: i128) : t_Option i128 =
+  let (result: i128), (overflowed: bool) = impl_16__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option i128 else Option_Some result <: t_Option i128
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_16__checked_div (x y: i128) : t_Option i128 =
+  if y =. mk_i128 0 || x =. impl_16__MIN && y =. mk_i128 (-1)
+  then Option_None <: t_Option i128
+  else Option_Some (x /! y) <: t_Option i128
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_16__checked_rem (x y: i128) : t_Option i128 =
+  if y =. mk_i128 0 || x =. impl_16__MIN && y =. mk_i128 (-1)
+  then Option_None <: t_Option i128
+  else Option_Some (x %! y) <: t_Option i128
+
+/// See [`std::primitive::u8::checked_add`] (and similar for other integer types)
+let impl_17__checked_add (x y: isize) : t_Option isize =
+  let (result: isize), (overflowed: bool) = impl_17__overflowing_add x y in
+  if overflowed then Option_None <: t_Option isize else Option_Some result <: t_Option isize
+
+/// See [`std::primitive::u8::checked_sub`] (and similar for other integer types)
+let impl_17__checked_sub (x y: isize) : t_Option isize =
+  let (result: isize), (overflowed: bool) = impl_17__overflowing_sub x y in
+  if overflowed then Option_None <: t_Option isize else Option_Some result <: t_Option isize
+
+/// See [`std::primitive::i8::checked_add_unsigned`] (and similar for other signed integer types)
+let impl_17__checked_add_unsigned (x: isize) (y: usize) : t_Option isize =
+  let (result: isize), (overflowed: bool) =
+    impl_17__overflowing_add x (cast (y <: usize) <: isize)
+  in
+  if overflowed =. (y >. (cast (impl_17__MAX <: isize) <: usize) <: bool)
+  then Option_Some result <: t_Option isize
+  else Option_None <: t_Option isize
+
+/// See [`std::primitive::i8::checked_sub_unsigned`] (and similar for other signed integer types)
+let impl_17__checked_sub_unsigned (x: isize) (y: usize) : t_Option isize =
+  let (result: isize), (overflowed: bool) =
+    impl_17__overflowing_sub x (cast (y <: usize) <: isize)
+  in
+  if overflowed =. (y >. (cast (impl_17__MAX <: isize) <: usize) <: bool)
+  then Option_Some result <: t_Option isize
+  else Option_None <: t_Option isize
+
+/// See [`std::primitive::u8::checked_mul`] (and similar for other integer types)
+let impl_17__checked_mul (x y: isize) : t_Option isize =
+  let (result: isize), (overflowed: bool) = impl_17__overflowing_mul x y in
+  if overflowed then Option_None <: t_Option isize else Option_Some result <: t_Option isize
+
+/// See [`std::primitive::i8::checked_div`] (and similar for other signed integer types)
+let impl_17__checked_div (x y: isize) : t_Option isize =
+  if y =. mk_isize 0 || x =. impl_17__MIN && y =. mk_isize (-1)
+  then Option_None <: t_Option isize
+  else Option_Some (x /! y) <: t_Option isize
+
+/// See [`std::primitive::i8::checked_rem`] (and similar for other signed integer types)
+let impl_17__checked_rem (x y: isize) : t_Option isize =
+  if y =. mk_isize 0 || x =. impl_17__MIN && y =. mk_isize (-1)
+  then Option_None <: t_Option isize
+  else Option_Some (x %! y) <: t_Option isize
 
 /// See [`std::option::Option::is_some_and`]
 let impl__is_some_and
@@ -579,6 +3092,102 @@ let impl_2__from__option (#v_T: Type0) : Core_models.Default.t_Default (t_Option
 type t_Result (v_T: Type0) (v_E: Type0) =
   | Result_Ok : v_T -> t_Result v_T v_E
   | Result_Err : v_E -> t_Result v_T v_E
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_6__from_str_radix': src: string -> radix: u32
+  -> t_Result u8 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_6__from_str_radix = impl_6__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_7__from_str_radix': src: string -> radix: u32
+  -> t_Result u16 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_7__from_str_radix = impl_7__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_8__from_str_radix': src: string -> radix: u32
+  -> t_Result u32 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_8__from_str_radix = impl_8__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_9__from_str_radix': src: string -> radix: u32
+  -> t_Result u64 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_9__from_str_radix = impl_9__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_10__from_str_radix': src: string -> radix: u32
+  -> t_Result u128 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_10__from_str_radix = impl_10__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_11__from_str_radix': src: string -> radix: u32
+  -> t_Result usize Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_11__from_str_radix = impl_11__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_12__from_str_radix': src: string -> radix: u32
+  -> t_Result i8 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_12__from_str_radix = impl_12__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_13__from_str_radix': src: string -> radix: u32
+  -> t_Result i16 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_13__from_str_radix = impl_13__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_14__from_str_radix': src: string -> radix: u32
+  -> t_Result i32 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_14__from_str_radix = impl_14__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_15__from_str_radix': src: string -> radix: u32
+  -> t_Result i64 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_15__from_str_radix = impl_15__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_16__from_str_radix': src: string -> radix: u32
+  -> t_Result i128 Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_16__from_str_radix = impl_16__from_str_radix'
+
+/// See [`std::primitive::u8::from_str_radix`] (and similar for other integer types)
+assume
+val impl_17__from_str_radix': src: string -> radix: u32
+  -> t_Result isize Core_models.Num.Error.t_ParseIntError
+
+unfold
+let impl_17__from_str_radix = impl_17__from_str_radix'
 
 /// See [`std::option::Option::ok_or`]
 let impl__ok_or (#v_T #v_E: Type0) (self: t_Option v_T) (err: v_E) : t_Result v_T v_E =
@@ -1948,9 +4557,7 @@ let impl_41: t_TryFrom u8 u16 =
     f_try_from
     =
     fun (x: u16) ->
-      if
-        x >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u16) ||
-        x <. (cast (Core_models.Num.impl_u8__MIN <: u8) <: u16)
+      if x >. (cast (impl_6__MAX <: u8) <: u16) || x <. (cast (impl_6__MIN <: u8) <: u16)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -1972,9 +4579,7 @@ let impl_42__from__convert: t_TryFrom u8 u32 =
     f_try_from
     =
     fun (x: u32) ->
-      if
-        x >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u32) ||
-        x <. (cast (Core_models.Num.impl_u8__MIN <: u8) <: u32)
+      if x >. (cast (impl_6__MAX <: u8) <: u32) || x <. (cast (impl_6__MIN <: u8) <: u32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -1996,9 +4601,7 @@ let impl_43: t_TryFrom u16 u32 =
     f_try_from
     =
     fun (x: u32) ->
-      if
-        x >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u32) ||
-        x <. (cast (Core_models.Num.impl_u16__MIN <: u16) <: u32)
+      if x >. (cast (impl_7__MAX <: u16) <: u32) || x <. (cast (impl_7__MIN <: u16) <: u32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2021,9 +4624,7 @@ let impl_44__from__convert: t_TryFrom u8 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if
-        x >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u64) ||
-        x <. (cast (Core_models.Num.impl_u8__MIN <: u8) <: u64)
+      if x >. (cast (impl_6__MAX <: u8) <: u64) || x <. (cast (impl_6__MIN <: u8) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2045,9 +4646,7 @@ let impl_45: t_TryFrom u16 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if
-        x >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u64) ||
-        x <. (cast (Core_models.Num.impl_u16__MIN <: u16) <: u64)
+      if x >. (cast (impl_7__MAX <: u16) <: u64) || x <. (cast (impl_7__MIN <: u16) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2070,9 +4669,7 @@ let impl_46__from__convert: t_TryFrom u32 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if
-        x >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u64) ||
-        x <. (cast (Core_models.Num.impl_u32__MIN <: u32) <: u64)
+      if x >. (cast (impl_8__MAX <: u32) <: u64) || x <. (cast (impl_8__MIN <: u32) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2095,9 +4692,7 @@ let impl_47: t_TryFrom usize u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if
-        x >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u64) ||
-        x <. (cast (Core_models.Num.impl_usize__MIN <: usize) <: u64)
+      if x >. (cast (impl_11__MAX <: usize) <: u64) || x <. (cast (impl_11__MIN <: usize) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2122,9 +4717,7 @@ let impl_48__from__convert: t_TryFrom u8 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if
-        x >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128) ||
-        x <. (cast (Core_models.Num.impl_u8__MIN <: u8) <: u128)
+      if x >. (cast (impl_6__MAX <: u8) <: u128) || x <. (cast (impl_6__MIN <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2146,9 +4739,7 @@ let impl_49: t_TryFrom u16 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if
-        x >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128) ||
-        x <. (cast (Core_models.Num.impl_u16__MIN <: u16) <: u128)
+      if x >. (cast (impl_7__MAX <: u16) <: u128) || x <. (cast (impl_7__MIN <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2171,9 +4762,7 @@ let impl_50__from__convert: t_TryFrom u32 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if
-        x >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128) ||
-        x <. (cast (Core_models.Num.impl_u32__MIN <: u32) <: u128)
+      if x >. (cast (impl_8__MAX <: u32) <: u128) || x <. (cast (impl_8__MIN <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2196,9 +4785,7 @@ let impl_51: t_TryFrom u64 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if
-        x >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128) ||
-        x <. (cast (Core_models.Num.impl_u64__MIN <: u64) <: u128)
+      if x >. (cast (impl_9__MAX <: u64) <: u128) || x <. (cast (impl_9__MIN <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2221,9 +4808,7 @@ let impl_52__from__convert: t_TryFrom usize u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if
-        x >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128) ||
-        x <. (cast (Core_models.Num.impl_usize__MIN <: usize) <: u128)
+      if x >. (cast (impl_11__MAX <: usize) <: u128) || x <. (cast (impl_11__MIN <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2248,9 +4833,7 @@ let impl_53: t_TryFrom u8 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if
-        x >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: usize) ||
-        x <. (cast (Core_models.Num.impl_u8__MIN <: u8) <: usize)
+      if x >. (cast (impl_6__MAX <: u8) <: usize) || x <. (cast (impl_6__MIN <: u8) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2273,9 +4856,7 @@ let impl_54: t_TryFrom u16 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if
-        x >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: usize) ||
-        x <. (cast (Core_models.Num.impl_u16__MIN <: u16) <: usize)
+      if x >. (cast (impl_7__MAX <: u16) <: usize) || x <. (cast (impl_7__MIN <: u16) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2298,9 +4879,7 @@ let impl_55: t_TryFrom u32 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if
-        x >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) ||
-        x <. (cast (Core_models.Num.impl_u32__MIN <: u32) <: usize)
+      if x >. (cast (impl_8__MAX <: u32) <: usize) || x <. (cast (impl_8__MIN <: u32) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2323,9 +4902,7 @@ let impl_56: t_TryFrom u64 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if
-        x >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: usize) ||
-        x <. (cast (Core_models.Num.impl_u64__MIN <: u64) <: usize)
+      if x >. (cast (impl_9__MAX <: u64) <: usize) || x <. (cast (impl_9__MIN <: u64) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2348,9 +4925,7 @@ let impl_57: t_TryFrom i8 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: i16) ||
-        x <. (cast (Core_models.Num.impl_i8__MIN <: i8) <: i16)
+      if x >. (cast (impl_12__MAX <: i8) <: i16) || x <. (cast (impl_12__MIN <: i8) <: i16)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2372,9 +4947,7 @@ let impl_58: t_TryFrom i8 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: i32) ||
-        x <. (cast (Core_models.Num.impl_i8__MIN <: i8) <: i32)
+      if x >. (cast (impl_12__MAX <: i8) <: i32) || x <. (cast (impl_12__MIN <: i8) <: i32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2396,9 +4969,7 @@ let impl_59: t_TryFrom i16 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: i32) ||
-        x <. (cast (Core_models.Num.impl_i16__MIN <: i16) <: i32)
+      if x >. (cast (impl_13__MAX <: i16) <: i32) || x <. (cast (impl_13__MIN <: i16) <: i32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2421,9 +4992,7 @@ let impl_60: t_TryFrom i8 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: i64) ||
-        x <. (cast (Core_models.Num.impl_i8__MIN <: i8) <: i64)
+      if x >. (cast (impl_12__MAX <: i8) <: i64) || x <. (cast (impl_12__MIN <: i8) <: i64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2445,9 +5014,7 @@ let impl_61: t_TryFrom i16 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: i64) ||
-        x <. (cast (Core_models.Num.impl_i16__MIN <: i16) <: i64)
+      if x >. (cast (impl_13__MAX <: i16) <: i64) || x <. (cast (impl_13__MIN <: i16) <: i64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2470,9 +5037,7 @@ let impl_62: t_TryFrom i32 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: i64) ||
-        x <. (cast (Core_models.Num.impl_i32__MIN <: i32) <: i64)
+      if x >. (cast (impl_14__MAX <: i32) <: i64) || x <. (cast (impl_14__MIN <: i32) <: i64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2495,9 +5060,7 @@ let impl_63: t_TryFrom isize i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x >. (cast (Core_models.Num.impl_isize__MAX <: isize) <: i64) ||
-        x <. (cast (Core_models.Num.impl_isize__MIN <: isize) <: i64)
+      if x >. (cast (impl_17__MAX <: isize) <: i64) || x <. (cast (impl_17__MIN <: isize) <: i64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2522,9 +5085,7 @@ let impl_64: t_TryFrom i8 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: i128) ||
-        x <. (cast (Core_models.Num.impl_i8__MIN <: i8) <: i128)
+      if x >. (cast (impl_12__MAX <: i8) <: i128) || x <. (cast (impl_12__MIN <: i8) <: i128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2546,9 +5107,7 @@ let impl_65: t_TryFrom i16 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: i128) ||
-        x <. (cast (Core_models.Num.impl_i16__MIN <: i16) <: i128)
+      if x >. (cast (impl_13__MAX <: i16) <: i128) || x <. (cast (impl_13__MIN <: i16) <: i128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2571,9 +5130,7 @@ let impl_66: t_TryFrom i32 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: i128) ||
-        x <. (cast (Core_models.Num.impl_i32__MIN <: i32) <: i128)
+      if x >. (cast (impl_14__MAX <: i32) <: i128) || x <. (cast (impl_14__MIN <: i32) <: i128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2596,9 +5153,7 @@ let impl_67: t_TryFrom i64 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: i128) ||
-        x <. (cast (Core_models.Num.impl_i64__MIN <: i64) <: i128)
+      if x >. (cast (impl_15__MAX <: i64) <: i128) || x <. (cast (impl_15__MIN <: i64) <: i128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2621,9 +5176,7 @@ let impl_68: t_TryFrom isize i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x >. (cast (Core_models.Num.impl_isize__MAX <: isize) <: i128) ||
-        x <. (cast (Core_models.Num.impl_isize__MIN <: isize) <: i128)
+      if x >. (cast (impl_17__MAX <: isize) <: i128) || x <. (cast (impl_17__MIN <: isize) <: i128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2648,9 +5201,7 @@ let impl_69: t_TryFrom i8 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: isize) ||
-        x <. (cast (Core_models.Num.impl_i8__MIN <: i8) <: isize)
+      if x >. (cast (impl_12__MAX <: i8) <: isize) || x <. (cast (impl_12__MIN <: i8) <: isize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2673,9 +5224,7 @@ let impl_70: t_TryFrom i16 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: isize) ||
-        x <. (cast (Core_models.Num.impl_i16__MIN <: i16) <: isize)
+      if x >. (cast (impl_13__MAX <: i16) <: isize) || x <. (cast (impl_13__MIN <: i16) <: isize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2698,9 +5247,7 @@ let impl_71: t_TryFrom i32 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: isize) ||
-        x <. (cast (Core_models.Num.impl_i32__MIN <: i32) <: isize)
+      if x >. (cast (impl_14__MAX <: i32) <: isize) || x <. (cast (impl_14__MIN <: i32) <: isize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2723,9 +5270,7 @@ let impl_72: t_TryFrom i64 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: isize) ||
-        x <. (cast (Core_models.Num.impl_i64__MIN <: i64) <: isize)
+      if x >. (cast (impl_15__MAX <: i64) <: isize) || x <. (cast (impl_15__MIN <: i64) <: isize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2804,7 +5349,7 @@ let impl_77: t_TryFrom i8 u8 =
     f_try_from
     =
     fun (x: u8) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: u8)
+      if x >. (cast (impl_12__MAX <: i8) <: u8)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2826,7 +5371,7 @@ let impl_78: t_TryFrom i8 u16 =
     f_try_from
     =
     fun (x: u16) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: u16)
+      if x >. (cast (impl_12__MAX <: i8) <: u16)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2848,7 +5393,7 @@ let impl_79: t_TryFrom i16 u16 =
     f_try_from
     =
     fun (x: u16) ->
-      if x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: u16)
+      if x >. (cast (impl_13__MAX <: i16) <: u16)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2871,7 +5416,7 @@ let impl_80: t_TryFrom i8 u32 =
     f_try_from
     =
     fun (x: u32) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: u32)
+      if x >. (cast (impl_12__MAX <: i8) <: u32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2893,7 +5438,7 @@ let impl_81: t_TryFrom i16 u32 =
     f_try_from
     =
     fun (x: u32) ->
-      if x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: u32)
+      if x >. (cast (impl_13__MAX <: i16) <: u32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2916,7 +5461,7 @@ let impl_82: t_TryFrom i32 u32 =
     f_try_from
     =
     fun (x: u32) ->
-      if x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: u32)
+      if x >. (cast (impl_14__MAX <: i32) <: u32)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2939,7 +5484,7 @@ let impl_83: t_TryFrom i8 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: u64)
+      if x >. (cast (impl_12__MAX <: i8) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2961,7 +5506,7 @@ let impl_84: t_TryFrom i16 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: u64)
+      if x >. (cast (impl_13__MAX <: i16) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -2984,7 +5529,7 @@ let impl_85: t_TryFrom i32 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: u64)
+      if x >. (cast (impl_14__MAX <: i32) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3007,7 +5552,7 @@ let impl_86: t_TryFrom i64 u64 =
     f_try_from
     =
     fun (x: u64) ->
-      if x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: u64)
+      if x >. (cast (impl_15__MAX <: i64) <: u64)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3030,7 +5575,7 @@ let impl_87: t_TryFrom i8 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: u128)
+      if x >. (cast (impl_12__MAX <: i8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3052,7 +5597,7 @@ let impl_88: t_TryFrom i16 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: u128)
+      if x >. (cast (impl_13__MAX <: i16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3075,7 +5620,7 @@ let impl_89: t_TryFrom i32 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: u128)
+      if x >. (cast (impl_14__MAX <: i32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3098,7 +5643,7 @@ let impl_90: t_TryFrom i64 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: u128)
+      if x >. (cast (impl_15__MAX <: i64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3121,7 +5666,7 @@ let impl_91: t_TryFrom i128 u128 =
     f_try_from
     =
     fun (x: u128) ->
-      if x >. (cast (Core_models.Num.impl_i128__MAX <: i128) <: u128)
+      if x >. (cast (impl_16__MAX <: i128) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3146,7 +5691,7 @@ let impl_92: t_TryFrom i8 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if x >. (cast (Core_models.Num.impl_i8__MAX <: i8) <: usize)
+      if x >. (cast (impl_12__MAX <: i8) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3169,7 +5714,7 @@ let impl_93: t_TryFrom i16 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if x >. (cast (Core_models.Num.impl_i16__MAX <: i16) <: usize)
+      if x >. (cast (impl_13__MAX <: i16) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3192,7 +5737,7 @@ let impl_94: t_TryFrom i32 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if x >. (cast (Core_models.Num.impl_i32__MAX <: i32) <: usize)
+      if x >. (cast (impl_14__MAX <: i32) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3215,7 +5760,7 @@ let impl_95: t_TryFrom i64 usize =
     f_try_from
     =
     fun (x: usize) ->
-      if x >. (cast (Core_models.Num.impl_i64__MAX <: i64) <: usize)
+      if x >. (cast (impl_15__MAX <: i64) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3238,7 +5783,7 @@ let impl_96: t_TryFrom isize usize =
     f_try_from
     =
     fun (x: usize) ->
-      if x >. (cast (Core_models.Num.impl_isize__MAX <: isize) <: usize)
+      if x >. (cast (impl_17__MAX <: isize) <: usize)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3263,9 +5808,7 @@ let impl_97: t_TryFrom u8 i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if
-        x <. mk_i8 0 ||
-        (cast (x <: i8) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3287,9 +5830,7 @@ let impl_98: t_TryFrom u16 i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if
-        x <. mk_i8 0 ||
-        (cast (x <: i8) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3311,9 +5852,7 @@ let impl_99: t_TryFrom u32 i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if
-        x <. mk_i8 0 ||
-        (cast (x <: i8) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3335,9 +5874,7 @@ let impl_100: t_TryFrom u64 i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if
-        x <. mk_i8 0 ||
-        (cast (x <: i8) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3359,7 +5896,7 @@ let impl_101: t_TryFrom u128 i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3382,9 +5919,7 @@ let impl_102: t_TryFrom usize i8 =
     f_try_from
     =
     fun (x: i8) ->
-      if
-        x <. mk_i8 0 ||
-        (cast (x <: i8) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_i8 0 || (cast (x <: i8) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3409,9 +5944,7 @@ let impl_103: t_TryFrom u8 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x <. mk_i16 0 ||
-        (cast (x <: i16) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3433,9 +5966,7 @@ let impl_104: t_TryFrom u16 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x <. mk_i16 0 ||
-        (cast (x <: i16) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3458,9 +5989,7 @@ let impl_105: t_TryFrom u32 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x <. mk_i16 0 ||
-        (cast (x <: i16) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3483,9 +6012,7 @@ let impl_106: t_TryFrom u64 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x <. mk_i16 0 ||
-        (cast (x <: i16) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3508,7 +6035,7 @@ let impl_107: t_TryFrom u128 i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3531,9 +6058,7 @@ let impl_108: t_TryFrom usize i16 =
     f_try_from
     =
     fun (x: i16) ->
-      if
-        x <. mk_i16 0 ||
-        (cast (x <: i16) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_i16 0 || (cast (x <: i16) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3558,9 +6083,7 @@ let impl_109: t_TryFrom u8 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x <. mk_i32 0 ||
-        (cast (x <: i32) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3582,9 +6105,7 @@ let impl_110: t_TryFrom u16 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x <. mk_i32 0 ||
-        (cast (x <: i32) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3607,9 +6128,7 @@ let impl_111: t_TryFrom u32 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x <. mk_i32 0 ||
-        (cast (x <: i32) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3632,9 +6151,7 @@ let impl_112: t_TryFrom u64 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x <. mk_i32 0 ||
-        (cast (x <: i32) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3657,7 +6174,7 @@ let impl_113: t_TryFrom u128 i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3680,9 +6197,7 @@ let impl_114: t_TryFrom usize i32 =
     f_try_from
     =
     fun (x: i32) ->
-      if
-        x <. mk_i32 0 ||
-        (cast (x <: i32) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_i32 0 || (cast (x <: i32) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3707,9 +6222,7 @@ let impl_115: t_TryFrom u8 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x <. mk_i64 0 ||
-        (cast (x <: i64) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3731,9 +6244,7 @@ let impl_116: t_TryFrom u16 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x <. mk_i64 0 ||
-        (cast (x <: i64) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3756,9 +6267,7 @@ let impl_117: t_TryFrom u32 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x <. mk_i64 0 ||
-        (cast (x <: i64) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3781,9 +6290,7 @@ let impl_118: t_TryFrom u64 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x <. mk_i64 0 ||
-        (cast (x <: i64) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3806,7 +6313,7 @@ let impl_119: t_TryFrom u128 i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3829,9 +6336,7 @@ let impl_120: t_TryFrom usize i64 =
     f_try_from
     =
     fun (x: i64) ->
-      if
-        x <. mk_i64 0 ||
-        (cast (x <: i64) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_i64 0 || (cast (x <: i64) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3856,9 +6361,7 @@ let impl_121: t_TryFrom u8 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x <. mk_i128 0 ||
-        (cast (x <: i128) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3880,9 +6383,7 @@ let impl_122: t_TryFrom u16 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x <. mk_i128 0 ||
-        (cast (x <: i128) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3905,9 +6406,7 @@ let impl_123: t_TryFrom u32 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x <. mk_i128 0 ||
-        (cast (x <: i128) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3930,9 +6429,7 @@ let impl_124: t_TryFrom u64 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x <. mk_i128 0 ||
-        (cast (x <: i128) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3955,7 +6452,7 @@ let impl_125: t_TryFrom u128 i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -3980,9 +6477,7 @@ let impl_126: t_TryFrom usize i128 =
     f_try_from
     =
     fun (x: i128) ->
-      if
-        x <. mk_i128 0 ||
-        (cast (x <: i128) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_i128 0 || (cast (x <: i128) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4007,9 +6502,7 @@ let impl_127: t_TryFrom u8 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x <. mk_isize 0 ||
-        (cast (x <: isize) <: u128) >. (cast (Core_models.Num.impl_u8__MAX <: u8) <: u128)
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. (cast (impl_6__MAX <: u8) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4032,9 +6525,7 @@ let impl_128: t_TryFrom u16 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x <. mk_isize 0 ||
-        (cast (x <: isize) <: u128) >. (cast (Core_models.Num.impl_u16__MAX <: u16) <: u128)
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. (cast (impl_7__MAX <: u16) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4057,9 +6548,7 @@ let impl_129: t_TryFrom u32 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x <. mk_isize 0 ||
-        (cast (x <: isize) <: u128) >. (cast (Core_models.Num.impl_u32__MAX <: u32) <: u128)
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. (cast (impl_8__MAX <: u32) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4082,9 +6571,7 @@ let impl_130: t_TryFrom u64 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x <. mk_isize 0 ||
-        (cast (x <: isize) <: u128) >. (cast (Core_models.Num.impl_u64__MAX <: u64) <: u128)
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. (cast (impl_9__MAX <: u64) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4107,7 +6594,7 @@ let impl_131: t_TryFrom u128 isize =
     f_try_from
     =
     fun (x: isize) ->
-      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. Core_models.Num.impl_u128__MAX
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. impl_10__MAX
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4132,9 +6619,7 @@ let impl_132: t_TryFrom usize isize =
     f_try_from
     =
     fun (x: isize) ->
-      if
-        x <. mk_isize 0 ||
-        (cast (x <: isize) <: u128) >. (cast (Core_models.Num.impl_usize__MAX <: usize) <: u128)
+      if x <. mk_isize 0 || (cast (x <: isize) <: u128) >. (cast (impl_11__MAX <: usize) <: u128)
       then
         Result_Err
         (Core_models.Num.Error.TryFromIntError (() <: Prims.unit)
@@ -4197,9 +6682,7 @@ let impl_1__from__enumerate
         match out <: t_Option i0.f_Item with
         | Option_Some a ->
           let i:usize = self.f_count in
-          let _:Prims.unit =
-            Hax_lib.v_assume (b2t (self.f_count <. Core_models.Num.impl_usize__MAX <: bool))
-          in
+          let _:Prims.unit = Hax_lib.v_assume (b2t (self.f_count <. impl_11__MAX <: bool)) in
           let self:t_Enumerate v_I =
             { self with f_count = self.f_count +! mk_usize 1 } <: t_Enumerate v_I
           in

--- a/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Num.fst
@@ -3,2145 +3,940 @@ module Core_models.Num
 open FStar.Mul
 open Rust_primitives
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_u8__MIN: u8 = mk_u8 0
+include Core_models.Bundle {impl_6__MIN as impl_u8__MIN}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_u8__MAX: u8 = mk_u8 255
+include Core_models.Bundle {impl_6__MAX as impl_u8__MAX}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_u8__BITS: u32 = mk_u32 8
+include Core_models.Bundle {impl_6__BITS as impl_u8__BITS}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_u8__wrapping_add (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_add_u8 x y
+include Core_models.Bundle {impl_6__wrapping_add as impl_u8__wrapping_add}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_u8__saturating_add (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_add_u8 x y
+include Core_models.Bundle {impl_6__saturating_add as impl_u8__saturating_add}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_u8__overflowing_add (x y: u8) : (u8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_u8 x y
+include Core_models.Bundle {impl_6__overflowing_add as impl_u8__overflowing_add}
 
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_u8__wrapping_sub (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_sub_u8 x y
+include Core_models.Bundle {impl_6__checked_add as impl_u8__checked_add}
 
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_u8__saturating_sub (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_sub_u8 x y
+include Core_models.Bundle {impl_6__unchecked_add as impl_u8__unchecked_add}
 
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_u8__overflowing_sub (x y: u8) : (u8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_u8 x y
+include Core_models.Bundle {impl_6__wrapping_sub as impl_u8__wrapping_sub}
 
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_u8__wrapping_mul (x y: u8) : u8 = Rust_primitives.Arithmetic.wrapping_mul_u8 x y
+include Core_models.Bundle {impl_6__saturating_sub as impl_u8__saturating_sub}
 
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_u8__saturating_mul (x y: u8) : u8 = Rust_primitives.Arithmetic.saturating_mul_u8 x y
+include Core_models.Bundle {impl_6__overflowing_sub as impl_u8__overflowing_sub}
 
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_u8__overflowing_mul (x y: u8) : (u8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_u8 x y
+include Core_models.Bundle {impl_6__checked_sub as impl_u8__checked_sub}
 
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_u8__pow (x: u8) (exp: u32) : u8 = Rust_primitives.Arithmetic.pow_u8 x exp
+include Core_models.Bundle {impl_6__unchecked_sub as impl_u8__unchecked_sub}
 
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_u8__count_ones (x: u8) : u32 = Rust_primitives.Arithmetic.count_ones_u8 x
+include Core_models.Bundle {impl_6__wrapping_mul as impl_u8__wrapping_mul}
 
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_u8__rotate_right': x: u8 -> n: u32 -> u8
+include Core_models.Bundle {impl_6__saturating_mul as impl_u8__saturating_mul}
 
-unfold
-let impl_u8__rotate_right = impl_u8__rotate_right'
+include Core_models.Bundle {impl_6__overflowing_mul as impl_u8__overflowing_mul}
 
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_u8__rotate_left': x: u8 -> n: u32 -> u8
+include Core_models.Bundle {impl_6__checked_mul as impl_u8__checked_mul}
 
-unfold
-let impl_u8__rotate_left = impl_u8__rotate_left'
+include Core_models.Bundle {impl_6__unchecked_mul as impl_u8__unchecked_mul}
 
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_u8__leading_zeros': x: u8 -> u32
+include Core_models.Bundle {impl_6__rem_euclid as impl_u8__rem_euclid}
 
-unfold
-let impl_u8__leading_zeros = impl_u8__leading_zeros'
+include Core_models.Bundle {impl_6__pow as impl_u8__pow}
 
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_u8__ilog2': x: u8 -> u32
+include Core_models.Bundle {impl_6__count_ones as impl_u8__count_ones}
 
-unfold
-let impl_u8__ilog2 = impl_u8__ilog2'
+include Core_models.Bundle {impl_6__rotate_right as impl_u8__rotate_right}
 
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_u8__from_be_bytes': bytes: t_Array u8 (mk_usize 1) -> u8
+include Core_models.Bundle {impl_6__rotate_left as impl_u8__rotate_left}
 
-unfold
-let impl_u8__from_be_bytes = impl_u8__from_be_bytes'
+include Core_models.Bundle {impl_6__leading_zeros as impl_u8__leading_zeros}
 
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_u8__from_le_bytes': bytes: t_Array u8 (mk_usize 1) -> u8
+include Core_models.Bundle {impl_6__ilog2 as impl_u8__ilog2}
 
-unfold
-let impl_u8__from_le_bytes = impl_u8__from_le_bytes'
+include Core_models.Bundle {impl_6__from_str_radix as impl_u8__from_str_radix}
 
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_u8__to_be_bytes': bytes: u8 -> t_Array u8 (mk_usize 1)
+include Core_models.Bundle {impl_6__from_be_bytes as impl_u8__from_be_bytes}
 
-unfold
-let impl_u8__to_be_bytes = impl_u8__to_be_bytes'
+include Core_models.Bundle {impl_6__from_le_bytes as impl_u8__from_le_bytes}
 
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_u8__to_le_bytes': bytes: u8 -> t_Array u8 (mk_usize 1)
+include Core_models.Bundle {impl_6__to_be_bytes as impl_u8__to_be_bytes}
 
-unfold
-let impl_u8__to_le_bytes = impl_u8__to_le_bytes'
+include Core_models.Bundle {impl_6__to_le_bytes as impl_u8__to_le_bytes}
 
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_u8__is_power_of_two (x: u8) : bool =
-  x <>. mk_u8 0 && (x &. (x -! mk_u8 1 <: u8) <: u8) =. mk_u8 0
-
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_u8__is_multiple_of (x y: u8) : bool =
-  if y =. mk_u8 0 then x =. mk_u8 0 else (x %! y <: u8) =. mk_u8 0
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_u8__unchecked_add (x y: u8)
-    : Prims.Pure u8
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u8__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
+include Core_models.Bundle {impl_6__checked_div as impl_u8__checked_div}
 
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_u8__unchecked_sub (x y: u8) : Prims.Pure u8 (requires x >=. y) (fun _ -> Prims.l_True) =
-  x -! y
+include Core_models.Bundle {impl_6__unchecked_div as impl_u8__unchecked_div}
 
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_u8__unchecked_mul (x y: u8)
-    : Prims.Pure u8
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u8__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_6__checked_rem as impl_u8__checked_rem}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_u8__rem_euclid (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_u8 x y
+include Core_models.Bundle {impl_6__unchecked_rem as impl_u8__unchecked_rem}
 
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_u8__unchecked_div (x y: u8)
-    : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) = x /! y
+include Core_models.Bundle {impl_6__is_power_of_two as impl_u8__is_power_of_two}
 
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_u8__unchecked_rem (x y: u8)
-    : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) = x %! y
+include Core_models.Bundle {impl_6__div_ceil as impl_u8__div_ceil}
 
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_u8__div_ceil (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
-  let d:u8 = x /! y in
-  let r:u8 = x %! y in
-  if r >. mk_u8 0 then d +! mk_u8 1 else d
+include Core_models.Bundle {impl_6__is_multiple_of as impl_u8__is_multiple_of}
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_u16__MIN: u16 = mk_u16 0
+include Core_models.Bundle {impl_7__MIN as impl_u16__MIN}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_u16__MAX: u16 = mk_u16 65535
+include Core_models.Bundle {impl_7__MAX as impl_u16__MAX}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_u16__BITS: u32 = mk_u32 16
+include Core_models.Bundle {impl_7__BITS as impl_u16__BITS}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_u16__wrapping_add (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_add_u16 x y
+include Core_models.Bundle {impl_7__wrapping_add as impl_u16__wrapping_add}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_u16__saturating_add (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_add_u16 x y
+include Core_models.Bundle {impl_7__saturating_add as impl_u16__saturating_add}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_u16__overflowing_add (x y: u16) : (u16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_u16 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_u16__wrapping_sub (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_sub_u16 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_u16__saturating_sub (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_sub_u16 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_u16__overflowing_sub (x y: u16) : (u16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_u16 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_u16__wrapping_mul (x y: u16) : u16 = Rust_primitives.Arithmetic.wrapping_mul_u16 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_u16__saturating_mul (x y: u16) : u16 = Rust_primitives.Arithmetic.saturating_mul_u16 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_u16__overflowing_mul (x y: u16) : (u16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_u16 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_u16__pow (x: u16) (exp: u32) : u16 = Rust_primitives.Arithmetic.pow_u16 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_u16__count_ones (x: u16) : u32 = Rust_primitives.Arithmetic.count_ones_u16 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_u16__rotate_right': x: u16 -> n: u32 -> u16
-
-unfold
-let impl_u16__rotate_right = impl_u16__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_u16__rotate_left': x: u16 -> n: u32 -> u16
-
-unfold
-let impl_u16__rotate_left = impl_u16__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_u16__leading_zeros': x: u16 -> u32
-
-unfold
-let impl_u16__leading_zeros = impl_u16__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_u16__ilog2': x: u16 -> u32
-
-unfold
-let impl_u16__ilog2 = impl_u16__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_u16__from_be_bytes': bytes: t_Array u8 (mk_usize 2) -> u16
-
-unfold
-let impl_u16__from_be_bytes = impl_u16__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_u16__from_le_bytes': bytes: t_Array u8 (mk_usize 2) -> u16
-
-unfold
-let impl_u16__from_le_bytes = impl_u16__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_u16__to_be_bytes': bytes: u16 -> t_Array u8 (mk_usize 2)
-
-unfold
-let impl_u16__to_be_bytes = impl_u16__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_u16__to_le_bytes': bytes: u16 -> t_Array u8 (mk_usize 2)
-
-unfold
-let impl_u16__to_le_bytes = impl_u16__to_le_bytes'
-
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_u16__is_power_of_two (x: u16) : bool =
-  x <>. mk_u16 0 && (x &. (x -! mk_u16 1 <: u16) <: u16) =. mk_u16 0
-
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_u16__is_multiple_of (x y: u16) : bool =
-  if y =. mk_u16 0 then x =. mk_u16 0 else (x %! y <: u16) =. mk_u16 0
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_u16__unchecked_add (x y: u16)
-    : Prims.Pure u16
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u16__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
+include Core_models.Bundle {impl_7__overflowing_add as impl_u16__overflowing_add}
 
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_u16__unchecked_sub (x y: u16) : Prims.Pure u16 (requires x >=. y) (fun _ -> Prims.l_True) =
-  x -! y
+include Core_models.Bundle {impl_7__checked_add as impl_u16__checked_add}
 
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_u16__unchecked_mul (x y: u16)
-    : Prims.Pure u16
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u16__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_7__unchecked_add as impl_u16__unchecked_add}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_u16__rem_euclid (x y: u16)
-    : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_u16 x y
+include Core_models.Bundle {impl_7__wrapping_sub as impl_u16__wrapping_sub}
 
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_u16__unchecked_div (x y: u16)
-    : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) = x /! y
+include Core_models.Bundle {impl_7__saturating_sub as impl_u16__saturating_sub}
 
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_u16__unchecked_rem (x y: u16)
-    : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) = x %! y
+include Core_models.Bundle {impl_7__overflowing_sub as impl_u16__overflowing_sub}
 
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_u16__div_ceil (x y: u16) : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) =
-  let d:u16 = x /! y in
-  let r:u16 = x %! y in
-  if r >. mk_u16 0 then d +! mk_u16 1 else d
+include Core_models.Bundle {impl_7__checked_sub as impl_u16__checked_sub}
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_u32__MIN: u32 = mk_u32 0
+include Core_models.Bundle {impl_7__unchecked_sub as impl_u16__unchecked_sub}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_u32__MAX: u32 = mk_u32 4294967295
+include Core_models.Bundle {impl_7__wrapping_mul as impl_u16__wrapping_mul}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_u32__BITS: u32 = mk_u32 32
+include Core_models.Bundle {impl_7__saturating_mul as impl_u16__saturating_mul}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_u32__wrapping_add (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_add_u32 x y
+include Core_models.Bundle {impl_7__overflowing_mul as impl_u16__overflowing_mul}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_u32__saturating_add (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_add_u32 x y
+include Core_models.Bundle {impl_7__checked_mul as impl_u16__checked_mul}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_u32__overflowing_add (x y: u32) : (u32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_u32 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_u32__wrapping_sub (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_sub_u32 x y
+include Core_models.Bundle {impl_7__unchecked_mul as impl_u16__unchecked_mul}
 
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_u32__saturating_sub (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_sub_u32 x y
+include Core_models.Bundle {impl_7__rem_euclid as impl_u16__rem_euclid}
 
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_u32__overflowing_sub (x y: u32) : (u32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_u32 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_u32__wrapping_mul (x y: u32) : u32 = Rust_primitives.Arithmetic.wrapping_mul_u32 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_u32__saturating_mul (x y: u32) : u32 = Rust_primitives.Arithmetic.saturating_mul_u32 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_u32__overflowing_mul (x y: u32) : (u32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_u32 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_u32__pow (x exp: u32) : u32 = Rust_primitives.Arithmetic.pow_u32 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_u32__count_ones (x: u32) : u32 = Rust_primitives.Arithmetic.count_ones_u32 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_u32__rotate_right': x: u32 -> n: u32 -> u32
-
-unfold
-let impl_u32__rotate_right = impl_u32__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_u32__rotate_left': x: u32 -> n: u32 -> u32
-
-unfold
-let impl_u32__rotate_left = impl_u32__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_u32__leading_zeros': x: u32 -> u32
-
-unfold
-let impl_u32__leading_zeros = impl_u32__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_u32__ilog2': x: u32 -> u32
-
-unfold
-let impl_u32__ilog2 = impl_u32__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_u32__from_be_bytes': bytes: t_Array u8 (mk_usize 4) -> u32
-
-unfold
-let impl_u32__from_be_bytes = impl_u32__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_u32__from_le_bytes': bytes: t_Array u8 (mk_usize 4) -> u32
-
-unfold
-let impl_u32__from_le_bytes = impl_u32__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_u32__to_be_bytes': bytes: u32 -> t_Array u8 (mk_usize 4)
-
-unfold
-let impl_u32__to_be_bytes = impl_u32__to_be_bytes'
+include Core_models.Bundle {impl_7__pow as impl_u16__pow}
 
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_u32__to_le_bytes': bytes: u32 -> t_Array u8 (mk_usize 4)
+include Core_models.Bundle {impl_7__count_ones as impl_u16__count_ones}
 
-unfold
-let impl_u32__to_le_bytes = impl_u32__to_le_bytes'
+include Core_models.Bundle {impl_7__rotate_right as impl_u16__rotate_right}
 
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_u32__is_power_of_two (x: u32) : bool =
-  x <>. mk_u32 0 && (x &. (x -! mk_u32 1 <: u32) <: u32) =. mk_u32 0
+include Core_models.Bundle {impl_7__rotate_left as impl_u16__rotate_left}
 
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_u32__is_multiple_of (x y: u32) : bool =
-  if y =. mk_u32 0 then x =. mk_u32 0 else (x %! y <: u32) =. mk_u32 0
+include Core_models.Bundle {impl_7__leading_zeros as impl_u16__leading_zeros}
 
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_u32__unchecked_add (x y: u32)
-    : Prims.Pure u32
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u32__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
+include Core_models.Bundle {impl_7__ilog2 as impl_u16__ilog2}
 
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_u32__unchecked_sub (x y: u32) : Prims.Pure u32 (requires x >=. y) (fun _ -> Prims.l_True) =
-  x -! y
+include Core_models.Bundle {impl_7__from_str_radix as impl_u16__from_str_radix}
 
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_u32__unchecked_mul (x y: u32)
-    : Prims.Pure u32
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u32__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_7__from_be_bytes as impl_u16__from_be_bytes}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_u32__rem_euclid (x y: u32)
-    : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_u32 x y
+include Core_models.Bundle {impl_7__from_le_bytes as impl_u16__from_le_bytes}
 
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_u32__unchecked_div (x y: u32)
-    : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) = x /! y
+include Core_models.Bundle {impl_7__to_be_bytes as impl_u16__to_be_bytes}
 
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_u32__unchecked_rem (x y: u32)
-    : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) = x %! y
+include Core_models.Bundle {impl_7__to_le_bytes as impl_u16__to_le_bytes}
 
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_u32__div_ceil (x y: u32) : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) =
-  let d:u32 = x /! y in
-  let r:u32 = x %! y in
-  if r >. mk_u32 0 then d +! mk_u32 1 else d
+include Core_models.Bundle {impl_7__checked_div as impl_u16__checked_div}
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_u64__MIN: u64 = mk_u64 0
+include Core_models.Bundle {impl_7__unchecked_div as impl_u16__unchecked_div}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_u64__MAX: u64 = mk_u64 18446744073709551615
+include Core_models.Bundle {impl_7__checked_rem as impl_u16__checked_rem}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_u64__BITS: u32 = mk_u32 64
+include Core_models.Bundle {impl_7__unchecked_rem as impl_u16__unchecked_rem}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_u64__wrapping_add (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_add_u64 x y
+include Core_models.Bundle {impl_7__is_power_of_two as impl_u16__is_power_of_two}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_u64__saturating_add (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_add_u64 x y
+include Core_models.Bundle {impl_7__div_ceil as impl_u16__div_ceil}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_u64__overflowing_add (x y: u64) : (u64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_u64 x y
+include Core_models.Bundle {impl_7__is_multiple_of as impl_u16__is_multiple_of}
 
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_u64__wrapping_sub (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_sub_u64 x y
+include Core_models.Bundle {impl_8__MIN as impl_u32__MIN}
 
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_u64__saturating_sub (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_sub_u64 x y
+include Core_models.Bundle {impl_8__MAX as impl_u32__MAX}
 
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_u64__overflowing_sub (x y: u64) : (u64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_u64 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_u64__wrapping_mul (x y: u64) : u64 = Rust_primitives.Arithmetic.wrapping_mul_u64 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_u64__saturating_mul (x y: u64) : u64 = Rust_primitives.Arithmetic.saturating_mul_u64 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_u64__overflowing_mul (x y: u64) : (u64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_u64 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_u64__pow (x: u64) (exp: u32) : u64 = Rust_primitives.Arithmetic.pow_u64 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_u64__count_ones (x: u64) : u32 = Rust_primitives.Arithmetic.count_ones_u64 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_u64__rotate_right': x: u64 -> n: u32 -> u64
-
-unfold
-let impl_u64__rotate_right = impl_u64__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_u64__rotate_left': x: u64 -> n: u32 -> u64
-
-unfold
-let impl_u64__rotate_left = impl_u64__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_u64__leading_zeros': x: u64 -> u32
-
-unfold
-let impl_u64__leading_zeros = impl_u64__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_u64__ilog2': x: u64 -> u32
-
-unfold
-let impl_u64__ilog2 = impl_u64__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_u64__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> u64
-
-unfold
-let impl_u64__from_be_bytes = impl_u64__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_u64__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> u64
-
-unfold
-let impl_u64__from_le_bytes = impl_u64__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_u64__to_be_bytes': bytes: u64 -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_u64__to_be_bytes = impl_u64__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_u64__to_le_bytes': bytes: u64 -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_u64__to_le_bytes = impl_u64__to_le_bytes'
-
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_u64__is_power_of_two (x: u64) : bool =
-  x <>. mk_u64 0 && (x &. (x -! mk_u64 1 <: u64) <: u64) =. mk_u64 0
-
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_u64__is_multiple_of (x y: u64) : bool =
-  if y =. mk_u64 0 then x =. mk_u64 0 else (x %! y <: u64) =. mk_u64 0
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_u64__unchecked_add (x y: u64)
-    : Prims.Pure u64
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u64__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
+include Core_models.Bundle {impl_8__BITS as impl_u32__BITS}
 
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_u64__unchecked_sub (x y: u64) : Prims.Pure u64 (requires x >=. y) (fun _ -> Prims.l_True) =
-  x -! y
+include Core_models.Bundle {impl_8__wrapping_add as impl_u32__wrapping_add}
 
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_u64__unchecked_mul (x y: u64)
-    : Prims.Pure u64
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u64__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_8__saturating_add as impl_u32__saturating_add}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_u64__rem_euclid (x y: u64)
-    : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_u64 x y
+include Core_models.Bundle {impl_8__overflowing_add as impl_u32__overflowing_add}
 
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_u64__unchecked_div (x y: u64)
-    : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) = x /! y
+include Core_models.Bundle {impl_8__checked_add as impl_u32__checked_add}
 
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_u64__unchecked_rem (x y: u64)
-    : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) = x %! y
+include Core_models.Bundle {impl_8__unchecked_add as impl_u32__unchecked_add}
 
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_u64__div_ceil (x y: u64) : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) =
-  let d:u64 = x /! y in
-  let r:u64 = x %! y in
-  if r >. mk_u64 0 then d +! mk_u64 1 else d
+include Core_models.Bundle {impl_8__wrapping_sub as impl_u32__wrapping_sub}
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_u128__MIN: u128 = mk_u128 0
+include Core_models.Bundle {impl_8__saturating_sub as impl_u32__saturating_sub}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_u128__MAX: u128 = mk_u128 340282366920938463463374607431768211455
+include Core_models.Bundle {impl_8__overflowing_sub as impl_u32__overflowing_sub}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_u128__BITS: u32 = mk_u32 128
+include Core_models.Bundle {impl_8__checked_sub as impl_u32__checked_sub}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_u128__wrapping_add (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_add_u128 x y
+include Core_models.Bundle {impl_8__unchecked_sub as impl_u32__unchecked_sub}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_u128__saturating_add (x y: u128) : u128 =
-  Rust_primitives.Arithmetic.saturating_add_u128 x y
+include Core_models.Bundle {impl_8__wrapping_mul as impl_u32__wrapping_mul}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_u128__overflowing_add (x y: u128) : (u128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_u128 x y
+include Core_models.Bundle {impl_8__saturating_mul as impl_u32__saturating_mul}
 
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_u128__wrapping_sub (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_sub_u128 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_u128__saturating_sub (x y: u128) : u128 =
-  Rust_primitives.Arithmetic.saturating_sub_u128 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_u128__overflowing_sub (x y: u128) : (u128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_u128 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_u128__wrapping_mul (x y: u128) : u128 = Rust_primitives.Arithmetic.wrapping_mul_u128 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_u128__saturating_mul (x y: u128) : u128 =
-  Rust_primitives.Arithmetic.saturating_mul_u128 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_u128__overflowing_mul (x y: u128) : (u128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_u128 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_u128__pow (x: u128) (exp: u32) : u128 = Rust_primitives.Arithmetic.pow_u128 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_u128__count_ones (x: u128) : u32 = Rust_primitives.Arithmetic.count_ones_u128 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_u128__rotate_right': x: u128 -> n: u32 -> u128
-
-unfold
-let impl_u128__rotate_right = impl_u128__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_u128__rotate_left': x: u128 -> n: u32 -> u128
-
-unfold
-let impl_u128__rotate_left = impl_u128__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_u128__leading_zeros': x: u128 -> u32
-
-unfold
-let impl_u128__leading_zeros = impl_u128__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_u128__ilog2': x: u128 -> u32
-
-unfold
-let impl_u128__ilog2 = impl_u128__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_u128__from_be_bytes': bytes: t_Array u8 (mk_usize 16) -> u128
-
-unfold
-let impl_u128__from_be_bytes = impl_u128__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_u128__from_le_bytes': bytes: t_Array u8 (mk_usize 16) -> u128
-
-unfold
-let impl_u128__from_le_bytes = impl_u128__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_u128__to_be_bytes': bytes: u128 -> t_Array u8 (mk_usize 16)
-
-unfold
-let impl_u128__to_be_bytes = impl_u128__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_u128__to_le_bytes': bytes: u128 -> t_Array u8 (mk_usize 16)
-
-unfold
-let impl_u128__to_le_bytes = impl_u128__to_le_bytes'
-
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_u128__is_power_of_two (x: u128) : bool =
-  x <>. mk_u128 0 && (x &. (x -! mk_u128 1 <: u128) <: u128) =. mk_u128 0
-
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_u128__is_multiple_of (x y: u128) : bool =
-  if y =. mk_u128 0 then x =. mk_u128 0 else (x %! y <: u128) =. mk_u128 0
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_u128__unchecked_add (x y: u128)
-    : Prims.Pure u128
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u128__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_u128__unchecked_sub (x y: u128)
-    : Prims.Pure u128 (requires x >=. y) (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_u128__unchecked_mul (x y: u128)
-    : Prims.Pure u128
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_u128__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_8__overflowing_mul as impl_u32__overflowing_mul}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_u128__rem_euclid (x y: u128)
-    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_u128 x y
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_u128__unchecked_div (x y: u128)
-    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_u128__unchecked_rem (x y: u128)
-    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_u128__div_ceil (x y: u128)
-    : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) =
-  let d:u128 = x /! y in
-  let r:u128 = x %! y in
-  if r >. mk_u128 0 then d +! mk_u128 1 else d
+include Core_models.Bundle {impl_8__checked_mul as impl_u32__checked_mul}
 
-/// See [`std::primitive::u8::MIN`] (and similar for other unsigned integer types)
-let impl_usize__MIN: usize = mk_usize 0
+include Core_models.Bundle {impl_8__unchecked_mul as impl_u32__unchecked_mul}
 
-/// See [`std::primitive::u8::MAX`] (and similar for other unsigned integer types)
-let impl_usize__MAX: usize = Rust_primitives.Arithmetic.v_USIZE_MAX
+include Core_models.Bundle {impl_8__rem_euclid as impl_u32__rem_euclid}
 
-/// See [`std::primitive::u8::BITS`] (and similar for other unsigned integer types)
-let impl_usize__BITS: u32 = Rust_primitives.Arithmetic.v_SIZE_BITS
+include Core_models.Bundle {impl_8__pow as impl_u32__pow}
 
-/// See [`std::primitive::u8::wrapping_add`] (and similar for other unsigned integer types)
-let impl_usize__wrapping_add (x y: usize) : usize =
-  Rust_primitives.Arithmetic.wrapping_add_usize x y
+include Core_models.Bundle {impl_8__count_ones as impl_u32__count_ones}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_usize__saturating_add (x y: usize) : usize =
-  Rust_primitives.Arithmetic.saturating_add_usize x y
+include Core_models.Bundle {impl_8__rotate_right as impl_u32__rotate_right}
 
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_usize__overflowing_add (x y: usize) : (usize & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_usize x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_usize__wrapping_sub (x y: usize) : usize =
-  Rust_primitives.Arithmetic.wrapping_sub_usize x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_usize__saturating_sub (x y: usize) : usize =
-  Rust_primitives.Arithmetic.saturating_sub_usize x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_usize__overflowing_sub (x y: usize) : (usize & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_usize x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_usize__wrapping_mul (x y: usize) : usize =
-  Rust_primitives.Arithmetic.wrapping_mul_usize x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_usize__saturating_mul (x y: usize) : usize =
-  Rust_primitives.Arithmetic.saturating_mul_usize x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_usize__overflowing_mul (x y: usize) : (usize & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_usize x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_usize__pow (x: usize) (exp: u32) : usize = Rust_primitives.Arithmetic.pow_usize x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_usize__count_ones (x: usize) : u32 = Rust_primitives.Arithmetic.count_ones_usize x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_usize__rotate_right': x: usize -> n: u32 -> usize
-
-unfold
-let impl_usize__rotate_right = impl_usize__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_usize__rotate_left': x: usize -> n: u32 -> usize
-
-unfold
-let impl_usize__rotate_left = impl_usize__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_usize__leading_zeros': x: usize -> u32
-
-unfold
-let impl_usize__leading_zeros = impl_usize__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_usize__ilog2': x: usize -> u32
-
-unfold
-let impl_usize__ilog2 = impl_usize__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_usize__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
-
-unfold
-let impl_usize__from_be_bytes = impl_usize__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_usize__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> usize
-
-unfold
-let impl_usize__from_le_bytes = impl_usize__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_usize__to_be_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_usize__to_be_bytes = impl_usize__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_usize__to_le_bytes': bytes: usize -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_usize__to_le_bytes = impl_usize__to_le_bytes'
-
-/// See [`std::primitive::u8::is_power_of_two`] (and similar for other unsigned integer types)
-let impl_usize__is_power_of_two (x: usize) : bool =
-  x <>. mk_usize 0 && (x &. (x -! mk_usize 1 <: usize) <: usize) =. mk_usize 0
-
-/// See [`std::primitive::u8::is_multiple_of`] (and similar for other unsigned integer types)
-let impl_usize__is_multiple_of (x y: usize) : bool =
-  if y =. mk_usize 0 then x =. mk_usize 0 else (x %! y <: usize) =. mk_usize 0
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_usize__unchecked_add (x y: usize)
-    : Prims.Pure usize
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_usize__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_usize__unchecked_sub (x y: usize)
-    : Prims.Pure usize (requires x >=. y) (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_usize__unchecked_mul (x y: usize)
-    : Prims.Pure usize
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_usize__MAX <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
+include Core_models.Bundle {impl_8__rotate_left as impl_u32__rotate_left}
 
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_usize__rem_euclid (x y: usize)
-    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_usize x y
+include Core_models.Bundle {impl_8__leading_zeros as impl_u32__leading_zeros}
 
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_usize__unchecked_div (x y: usize)
-    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) = x /! y
+include Core_models.Bundle {impl_8__ilog2 as impl_u32__ilog2}
 
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_usize__unchecked_rem (x y: usize)
-    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) = x %! y
+include Core_models.Bundle {impl_8__from_str_radix as impl_u32__from_str_radix}
 
-/// See [`std::primitive::u8::div_ceil`] (and similar for other unsigned integer types)
-let impl_usize__div_ceil (x y: usize)
-    : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) =
-  let d:usize = x /! y in
-  let r:usize = x %! y in
-  if r >. mk_usize 0 then d +! mk_usize 1 else d
+include Core_models.Bundle {impl_8__from_be_bytes as impl_u32__from_be_bytes}
 
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_i8__MIN: i8 = mk_i8 (-128)
+include Core_models.Bundle {impl_8__from_le_bytes as impl_u32__from_le_bytes}
 
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_i8__MAX: i8 = mk_i8 127
+include Core_models.Bundle {impl_8__to_be_bytes as impl_u32__to_be_bytes}
 
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_i8__BITS: u32 = mk_u32 8
+include Core_models.Bundle {impl_8__to_le_bytes as impl_u32__to_le_bytes}
 
-let impl_i8__wrapping_add (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_add_i8 x y
+include Core_models.Bundle {impl_8__checked_div as impl_u32__checked_div}
 
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_i8__saturating_add (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_add_i8 x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_i8__overflowing_add (x y: i8) : (i8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_i8 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_i8__wrapping_sub (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_sub_i8 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_i8__saturating_sub (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_sub_i8 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_i8__overflowing_sub (x y: i8) : (i8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_i8 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_i8__wrapping_mul (x y: i8) : i8 = Rust_primitives.Arithmetic.wrapping_mul_i8 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_i8__saturating_mul (x y: i8) : i8 = Rust_primitives.Arithmetic.saturating_mul_i8 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_i8__overflowing_mul (x y: i8) : (i8 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_i8 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_i8__pow (x: i8) (exp: u32) : i8 = Rust_primitives.Arithmetic.pow_i8 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_i8__count_ones (x: i8) : u32 = Rust_primitives.Arithmetic.count_ones_i8 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_i8__rotate_right': x: i8 -> n: u32 -> i8
-
-unfold
-let impl_i8__rotate_right = impl_i8__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_i8__rotate_left': x: i8 -> n: u32 -> i8
-
-unfold
-let impl_i8__rotate_left = impl_i8__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_i8__leading_zeros': x: i8 -> u32
-
-unfold
-let impl_i8__leading_zeros = impl_i8__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_i8__ilog2': x: i8 -> u32
-
-unfold
-let impl_i8__ilog2 = impl_i8__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_i8__from_be_bytes': bytes: t_Array u8 (mk_usize 1) -> i8
-
-unfold
-let impl_i8__from_be_bytes = impl_i8__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_i8__from_le_bytes': bytes: t_Array u8 (mk_usize 1) -> i8
-
-unfold
-let impl_i8__from_le_bytes = impl_i8__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_i8__to_be_bytes': bytes: i8 -> t_Array u8 (mk_usize 1)
-
-unfold
-let impl_i8__to_be_bytes = impl_i8__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_i8__to_le_bytes': bytes: i8 -> t_Array u8 (mk_usize 1)
-
-unfold
-let impl_i8__to_le_bytes = impl_i8__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_i8__signum (x: i8) : i8 =
-  if x >. mk_i8 0 then mk_i8 1 else if x =. mk_i8 0 then mk_i8 0 else mk_i8 (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_i8__unchecked_add (x y: i8)
-    : Prims.Pure i8
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_i8__unchecked_sub (x y: i8)
-    : Prims.Pure i8
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_i8__unchecked_mul (x y: i8)
-    : Prims.Pure i8
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i8__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_i8__rem_euclid (x y: i8) : Prims.Pure i8 (requires y <>. mk_i8 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_i8 x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_i8__abs (x: i8) : Prims.Pure i8 (requires x >. impl_i8__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_i8 x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_i8__unchecked_div (x y: i8)
-    : Prims.Pure i8
-      (requires y <>. mk_i8 0 && (x <>. impl_i8__MIN || y <>. mk_i8 (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_i8__unchecked_rem (x y: i8)
-    : Prims.Pure i8
-      (requires y <>. mk_i8 0 && (x <>. impl_i8__MIN || y <>. mk_i8 (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_i8__div_ceil (x y: i8)
-    : Prims.Pure i8
-      (requires y <>. mk_i8 0 && ~.((x =. impl_i8__MIN <: bool) && (y =. mk_i8 (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:i8 = x /! y in
-  let r:i8 = x %! y in
-  if r >. mk_i8 0 && y >. mk_i8 0 || r <. mk_i8 0 && y <. mk_i8 0 then d +! mk_i8 1 else d
-
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_i16__MIN: i16 = mk_i16 (-32768)
-
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_i16__MAX: i16 = mk_i16 32767
-
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_i16__BITS: u32 = mk_u32 16
-
-let impl_i16__wrapping_add (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_add_i16 x y
-
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_i16__saturating_add (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_add_i16 x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_i16__overflowing_add (x y: i16) : (i16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_i16 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_i16__wrapping_sub (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_sub_i16 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_i16__saturating_sub (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_sub_i16 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_i16__overflowing_sub (x y: i16) : (i16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_i16 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_i16__wrapping_mul (x y: i16) : i16 = Rust_primitives.Arithmetic.wrapping_mul_i16 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_i16__saturating_mul (x y: i16) : i16 = Rust_primitives.Arithmetic.saturating_mul_i16 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_i16__overflowing_mul (x y: i16) : (i16 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_i16 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_i16__pow (x: i16) (exp: u32) : i16 = Rust_primitives.Arithmetic.pow_i16 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_i16__count_ones (x: i16) : u32 = Rust_primitives.Arithmetic.count_ones_i16 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_i16__rotate_right': x: i16 -> n: u32 -> i16
-
-unfold
-let impl_i16__rotate_right = impl_i16__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_i16__rotate_left': x: i16 -> n: u32 -> i16
-
-unfold
-let impl_i16__rotate_left = impl_i16__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_i16__leading_zeros': x: i16 -> u32
-
-unfold
-let impl_i16__leading_zeros = impl_i16__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_i16__ilog2': x: i16 -> u32
-
-unfold
-let impl_i16__ilog2 = impl_i16__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_i16__from_be_bytes': bytes: t_Array u8 (mk_usize 2) -> i16
-
-unfold
-let impl_i16__from_be_bytes = impl_i16__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_i16__from_le_bytes': bytes: t_Array u8 (mk_usize 2) -> i16
-
-unfold
-let impl_i16__from_le_bytes = impl_i16__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_i16__to_be_bytes': bytes: i16 -> t_Array u8 (mk_usize 2)
-
-unfold
-let impl_i16__to_be_bytes = impl_i16__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_i16__to_le_bytes': bytes: i16 -> t_Array u8 (mk_usize 2)
-
-unfold
-let impl_i16__to_le_bytes = impl_i16__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_i16__signum (x: i16) : i16 =
-  if x >. mk_i16 0 then mk_i16 1 else if x =. mk_i16 0 then mk_i16 0 else mk_i16 (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_i16__unchecked_add (x y: i16)
-    : Prims.Pure i16
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_i16__unchecked_sub (x y: i16)
-    : Prims.Pure i16
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_i16__unchecked_mul (x y: i16)
-    : Prims.Pure i16
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i16__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_i16__rem_euclid (x y: i16)
-    : Prims.Pure i16 (requires y <>. mk_i16 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_i16 x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_i16__abs (x: i16) : Prims.Pure i16 (requires x >. impl_i16__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_i16 x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_i16__unchecked_div (x y: i16)
-    : Prims.Pure i16
-      (requires y <>. mk_i16 0 && (x <>. impl_i16__MIN || y <>. mk_i16 (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_i16__unchecked_rem (x y: i16)
-    : Prims.Pure i16
-      (requires y <>. mk_i16 0 && (x <>. impl_i16__MIN || y <>. mk_i16 (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_i16__div_ceil (x y: i16)
-    : Prims.Pure i16
-      (requires y <>. mk_i16 0 && ~.((x =. impl_i16__MIN <: bool) && (y =. mk_i16 (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:i16 = x /! y in
-  let r:i16 = x %! y in
-  if r >. mk_i16 0 && y >. mk_i16 0 || r <. mk_i16 0 && y <. mk_i16 0 then d +! mk_i16 1 else d
-
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_i32__MIN: i32 = mk_i32 (-2147483648)
-
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_i32__MAX: i32 = mk_i32 2147483647
-
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_i32__BITS: u32 = mk_u32 32
-
-let impl_i32__wrapping_add (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_add_i32 x y
-
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_i32__saturating_add (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_add_i32 x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_i32__overflowing_add (x y: i32) : (i32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_i32 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_i32__wrapping_sub (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_sub_i32 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_i32__saturating_sub (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_sub_i32 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_i32__overflowing_sub (x y: i32) : (i32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_i32 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_i32__wrapping_mul (x y: i32) : i32 = Rust_primitives.Arithmetic.wrapping_mul_i32 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_i32__saturating_mul (x y: i32) : i32 = Rust_primitives.Arithmetic.saturating_mul_i32 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_i32__overflowing_mul (x y: i32) : (i32 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_i32 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_i32__pow (x: i32) (exp: u32) : i32 = Rust_primitives.Arithmetic.pow_i32 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_i32__count_ones (x: i32) : u32 = Rust_primitives.Arithmetic.count_ones_i32 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_i32__rotate_right': x: i32 -> n: u32 -> i32
-
-unfold
-let impl_i32__rotate_right = impl_i32__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_i32__rotate_left': x: i32 -> n: u32 -> i32
-
-unfold
-let impl_i32__rotate_left = impl_i32__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_i32__leading_zeros': x: i32 -> u32
-
-unfold
-let impl_i32__leading_zeros = impl_i32__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_i32__ilog2': x: i32 -> u32
-
-unfold
-let impl_i32__ilog2 = impl_i32__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_i32__from_be_bytes': bytes: t_Array u8 (mk_usize 4) -> i32
-
-unfold
-let impl_i32__from_be_bytes = impl_i32__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_i32__from_le_bytes': bytes: t_Array u8 (mk_usize 4) -> i32
-
-unfold
-let impl_i32__from_le_bytes = impl_i32__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_i32__to_be_bytes': bytes: i32 -> t_Array u8 (mk_usize 4)
-
-unfold
-let impl_i32__to_be_bytes = impl_i32__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_i32__to_le_bytes': bytes: i32 -> t_Array u8 (mk_usize 4)
-
-unfold
-let impl_i32__to_le_bytes = impl_i32__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_i32__signum (x: i32) : i32 =
-  if x >. mk_i32 0 then mk_i32 1 else if x =. mk_i32 0 then mk_i32 0 else mk_i32 (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_i32__unchecked_add (x y: i32)
-    : Prims.Pure i32
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_i32__unchecked_sub (x y: i32)
-    : Prims.Pure i32
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_i32__unchecked_mul (x y: i32)
-    : Prims.Pure i32
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i32__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_i32__rem_euclid (x y: i32)
-    : Prims.Pure i32 (requires y <>. mk_i32 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_i32 x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_i32__abs (x: i32) : Prims.Pure i32 (requires x >. impl_i32__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_i32 x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_i32__unchecked_div (x y: i32)
-    : Prims.Pure i32
-      (requires y <>. mk_i32 0 && (x <>. impl_i32__MIN || y <>. mk_i32 (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_i32__unchecked_rem (x y: i32)
-    : Prims.Pure i32
-      (requires y <>. mk_i32 0 && (x <>. impl_i32__MIN || y <>. mk_i32 (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_i32__div_ceil (x y: i32)
-    : Prims.Pure i32
-      (requires y <>. mk_i32 0 && ~.((x =. impl_i32__MIN <: bool) && (y =. mk_i32 (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:i32 = x /! y in
-  let r:i32 = x %! y in
-  if r >. mk_i32 0 && y >. mk_i32 0 || r <. mk_i32 0 && y <. mk_i32 0 then d +! mk_i32 1 else d
-
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_i64__MIN: i64 = mk_i64 (-9223372036854775808)
-
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_i64__MAX: i64 = mk_i64 9223372036854775807
-
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_i64__BITS: u32 = mk_u32 64
-
-let impl_i64__wrapping_add (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_add_i64 x y
-
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_i64__saturating_add (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_add_i64 x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_i64__overflowing_add (x y: i64) : (i64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_i64 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_i64__wrapping_sub (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_sub_i64 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_i64__saturating_sub (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_sub_i64 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_i64__overflowing_sub (x y: i64) : (i64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_i64 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_i64__wrapping_mul (x y: i64) : i64 = Rust_primitives.Arithmetic.wrapping_mul_i64 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_i64__saturating_mul (x y: i64) : i64 = Rust_primitives.Arithmetic.saturating_mul_i64 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_i64__overflowing_mul (x y: i64) : (i64 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_i64 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_i64__pow (x: i64) (exp: u32) : i64 = Rust_primitives.Arithmetic.pow_i64 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_i64__count_ones (x: i64) : u32 = Rust_primitives.Arithmetic.count_ones_i64 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_i64__rotate_right': x: i64 -> n: u32 -> i64
-
-unfold
-let impl_i64__rotate_right = impl_i64__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_i64__rotate_left': x: i64 -> n: u32 -> i64
-
-unfold
-let impl_i64__rotate_left = impl_i64__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_i64__leading_zeros': x: i64 -> u32
-
-unfold
-let impl_i64__leading_zeros = impl_i64__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_i64__ilog2': x: i64 -> u32
-
-unfold
-let impl_i64__ilog2 = impl_i64__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_i64__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> i64
-
-unfold
-let impl_i64__from_be_bytes = impl_i64__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_i64__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> i64
-
-unfold
-let impl_i64__from_le_bytes = impl_i64__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_i64__to_be_bytes': bytes: i64 -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_i64__to_be_bytes = impl_i64__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_i64__to_le_bytes': bytes: i64 -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_i64__to_le_bytes = impl_i64__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_i64__signum (x: i64) : i64 =
-  if x >. mk_i64 0 then mk_i64 1 else if x =. mk_i64 0 then mk_i64 0 else mk_i64 (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_i64__unchecked_add (x y: i64)
-    : Prims.Pure i64
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_i64__unchecked_sub (x y: i64)
-    : Prims.Pure i64
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_i64__unchecked_mul (x y: i64)
-    : Prims.Pure i64
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i64__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_i64__rem_euclid (x y: i64)
-    : Prims.Pure i64 (requires y <>. mk_i64 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_i64 x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_i64__abs (x: i64) : Prims.Pure i64 (requires x >. impl_i64__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_i64 x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_i64__unchecked_div (x y: i64)
-    : Prims.Pure i64
-      (requires y <>. mk_i64 0 && (x <>. impl_i64__MIN || y <>. mk_i64 (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_i64__unchecked_rem (x y: i64)
-    : Prims.Pure i64
-      (requires y <>. mk_i64 0 && (x <>. impl_i64__MIN || y <>. mk_i64 (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_i64__div_ceil (x y: i64)
-    : Prims.Pure i64
-      (requires y <>. mk_i64 0 && ~.((x =. impl_i64__MIN <: bool) && (y =. mk_i64 (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:i64 = x /! y in
-  let r:i64 = x %! y in
-  if r >. mk_i64 0 && y >. mk_i64 0 || r <. mk_i64 0 && y <. mk_i64 0 then d +! mk_i64 1 else d
-
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_i128__MIN: i128 = mk_i128 (-170141183460469231731687303715884105728)
-
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_i128__MAX: i128 = mk_i128 170141183460469231731687303715884105727
-
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_i128__BITS: u32 = mk_u32 128
-
-let impl_i128__wrapping_add (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_add_i128 x y
-
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_i128__saturating_add (x y: i128) : i128 =
-  Rust_primitives.Arithmetic.saturating_add_i128 x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_i128__overflowing_add (x y: i128) : (i128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_i128 x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_i128__wrapping_sub (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_sub_i128 x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_i128__saturating_sub (x y: i128) : i128 =
-  Rust_primitives.Arithmetic.saturating_sub_i128 x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_i128__overflowing_sub (x y: i128) : (i128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_i128 x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_i128__wrapping_mul (x y: i128) : i128 = Rust_primitives.Arithmetic.wrapping_mul_i128 x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_i128__saturating_mul (x y: i128) : i128 =
-  Rust_primitives.Arithmetic.saturating_mul_i128 x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_i128__overflowing_mul (x y: i128) : (i128 & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_i128 x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_i128__pow (x: i128) (exp: u32) : i128 = Rust_primitives.Arithmetic.pow_i128 x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_i128__count_ones (x: i128) : u32 = Rust_primitives.Arithmetic.count_ones_i128 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_i128__rotate_right': x: i128 -> n: u32 -> i128
-
-unfold
-let impl_i128__rotate_right = impl_i128__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_i128__rotate_left': x: i128 -> n: u32 -> i128
-
-unfold
-let impl_i128__rotate_left = impl_i128__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_i128__leading_zeros': x: i128 -> u32
-
-unfold
-let impl_i128__leading_zeros = impl_i128__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_i128__ilog2': x: i128 -> u32
-
-unfold
-let impl_i128__ilog2 = impl_i128__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_i128__from_be_bytes': bytes: t_Array u8 (mk_usize 16) -> i128
-
-unfold
-let impl_i128__from_be_bytes = impl_i128__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_i128__from_le_bytes': bytes: t_Array u8 (mk_usize 16) -> i128
-
-unfold
-let impl_i128__from_le_bytes = impl_i128__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_i128__to_be_bytes': bytes: i128 -> t_Array u8 (mk_usize 16)
-
-unfold
-let impl_i128__to_be_bytes = impl_i128__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_i128__to_le_bytes': bytes: i128 -> t_Array u8 (mk_usize 16)
-
-unfold
-let impl_i128__to_le_bytes = impl_i128__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_i128__signum (x: i128) : i128 =
-  if x >. mk_i128 0 then mk_i128 1 else if x =. mk_i128 0 then mk_i128 0 else mk_i128 (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_i128__unchecked_add (x y: i128)
-    : Prims.Pure i128
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_i128__unchecked_sub (x y: i128)
-    : Prims.Pure i128
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_i128__unchecked_mul (x y: i128)
-    : Prims.Pure i128
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_i128__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_i128__rem_euclid (x y: i128)
-    : Prims.Pure i128 (requires y <>. mk_i128 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_i128 x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_i128__abs (x: i128)
-    : Prims.Pure i128 (requires x >. impl_i128__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_i128 x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_i128__unchecked_div (x y: i128)
-    : Prims.Pure i128
-      (requires y <>. mk_i128 0 && (x <>. impl_i128__MIN || y <>. mk_i128 (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_i128__unchecked_rem (x y: i128)
-    : Prims.Pure i128
-      (requires y <>. mk_i128 0 && (x <>. impl_i128__MIN || y <>. mk_i128 (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_i128__div_ceil (x y: i128)
-    : Prims.Pure i128
-      (requires y <>. mk_i128 0 && ~.((x =. impl_i128__MIN <: bool) && (y =. mk_i128 (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:i128 = x /! y in
-  let r:i128 = x %! y in
-  if r >. mk_i128 0 && y >. mk_i128 0 || r <. mk_i128 0 && y <. mk_i128 0 then d +! mk_i128 1 else d
-
-/// See [`std::primitive::i8::MIN`] (and similar for other signed integer types)
-let impl_isize__MIN: isize = Rust_primitives.Arithmetic.v_ISIZE_MIN
-
-/// See [`std::primitive::i8::MAX`] (and similar for other signed integer types)
-let impl_isize__MAX: isize = Rust_primitives.Arithmetic.v_ISIZE_MAX
-
-/// See [`std::primitive::i8::BITS`] (and similar for other signed integer types)
-let impl_isize__BITS: u32 = Rust_primitives.Arithmetic.v_SIZE_BITS
-
-let impl_isize__wrapping_add (x y: isize) : isize =
-  Rust_primitives.Arithmetic.wrapping_add_isize x y
-
-/// See [`std::primitive::u8::saturating_add`] (and similar for other integer types)
-let impl_isize__saturating_add (x y: isize) : isize =
-  Rust_primitives.Arithmetic.saturating_add_isize x y
-
-/// See [`std::primitive::u8::overflowing_add`] (and similar for other integer types)
-let impl_isize__overflowing_add (x y: isize) : (isize & bool) =
-  Rust_primitives.Arithmetic.overflowing_add_isize x y
-
-/// See [`std::primitive::u8::wrapping_sub`] (and similar for other integer types)
-let impl_isize__wrapping_sub (x y: isize) : isize =
-  Rust_primitives.Arithmetic.wrapping_sub_isize x y
-
-/// See [`std::primitive::u8::saturating_sub`] (and similar for other integer types)
-let impl_isize__saturating_sub (x y: isize) : isize =
-  Rust_primitives.Arithmetic.saturating_sub_isize x y
-
-/// See [`std::primitive::u8::overflowing_sub`] (and similar for other integer types)
-let impl_isize__overflowing_sub (x y: isize) : (isize & bool) =
-  Rust_primitives.Arithmetic.overflowing_sub_isize x y
-
-/// See [`std::primitive::u8::wrapping_mul`] (and similar for other integer types)
-let impl_isize__wrapping_mul (x y: isize) : isize =
-  Rust_primitives.Arithmetic.wrapping_mul_isize x y
-
-/// See [`std::primitive::u8::saturating_mul`] (and similar for other integer types)
-let impl_isize__saturating_mul (x y: isize) : isize =
-  Rust_primitives.Arithmetic.saturating_mul_isize x y
-
-/// See [`std::primitive::u8::overflowing_mul`] (and similar for other integer types)
-let impl_isize__overflowing_mul (x y: isize) : (isize & bool) =
-  Rust_primitives.Arithmetic.overflowing_mul_isize x y
-
-/// See [`std::primitive::u8::pow`] (and similar for other integer types)
-let impl_isize__pow (x: isize) (exp: u32) : isize = Rust_primitives.Arithmetic.pow_isize x exp
-
-/// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
-let impl_isize__count_ones (x: isize) : u32 = Rust_primitives.Arithmetic.count_ones_isize x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_isize__rotate_right': x: isize -> n: u32 -> isize
-
-unfold
-let impl_isize__rotate_right = impl_isize__rotate_right'
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_isize__rotate_left': x: isize -> n: u32 -> isize
-
-unfold
-let impl_isize__rotate_left = impl_isize__rotate_left'
-
-/// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
-assume
-val impl_isize__leading_zeros': x: isize -> u32
-
-unfold
-let impl_isize__leading_zeros = impl_isize__leading_zeros'
-
-/// See [`std::primitive::u8::ilog2`] (and similar for other integer types)
-assume
-val impl_isize__ilog2': x: isize -> u32
-
-unfold
-let impl_isize__ilog2 = impl_isize__ilog2'
-
-/// See [`std::primitive::u8::from_be_bytes`] (and similar for other integer types)
-assume
-val impl_isize__from_be_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
-
-unfold
-let impl_isize__from_be_bytes = impl_isize__from_be_bytes'
-
-/// See [`std::primitive::u8::from_le_bytes`] (and similar for other integer types)
-assume
-val impl_isize__from_le_bytes': bytes: t_Array u8 (mk_usize 8) -> isize
-
-unfold
-let impl_isize__from_le_bytes = impl_isize__from_le_bytes'
-
-/// See [`std::primitive::u8::to_be_bytes`] (and similar for other integer types)
-assume
-val impl_isize__to_be_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_isize__to_be_bytes = impl_isize__to_be_bytes'
-
-/// See [`std::primitive::u8::to_le_bytes`] (and similar for other integer types)
-assume
-val impl_isize__to_le_bytes': bytes: isize -> t_Array u8 (mk_usize 8)
-
-unfold
-let impl_isize__to_le_bytes = impl_isize__to_le_bytes'
-
-/// See [`std::primitive::i8::signum`] (and similar for other signed integer types)
-let impl_isize__signum (x: isize) : isize =
-  if x >. mk_isize 0 then mk_isize 1 else if x =. mk_isize 0 then mk_isize 0 else mk_isize (-1)
-
-/// See [`std::primitive::u8::unchecked_add`] (and similar for other integer types)
-let impl_isize__unchecked_add (x y: isize)
-    : Prims.Pure isize
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x +! y
-
-/// See [`std::primitive::u8::unchecked_sub`] (and similar for other integer types)
-let impl_isize__unchecked_sub (x y: isize)
-    : Prims.Pure isize
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) -
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x -! y
-
-/// See [`std::primitive::u8::unchecked_mul`] (and similar for other integer types)
-let impl_isize__unchecked_mul (x y: isize)
-    : Prims.Pure isize
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MAX <: Hax_lib.Int.t_Int) &&
-        ((Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) *
-          (Rust_primitives.Hax.Int.from_machine y <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) >=
-        (Rust_primitives.Hax.Int.from_machine impl_isize__MIN <: Hax_lib.Int.t_Int))
-      (fun _ -> Prims.l_True) = x *! y
-
-/// See [`std::primitive::u8::rem_euclid`] (and similar for other integer types)
-let impl_isize__rem_euclid (x y: isize)
-    : Prims.Pure isize (requires y <>. mk_isize 0) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.rem_euclid_isize x y
-
-/// See [`std::primitive::i8::abs`] (and similar for other signed integer types)
-let impl_isize__abs (x: isize)
-    : Prims.Pure isize (requires x >. impl_isize__MIN) (fun _ -> Prims.l_True) =
-  Rust_primitives.Arithmetic.abs_isize x
-
-/// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
-let impl_isize__unchecked_div (x y: isize)
-    : Prims.Pure isize
-      (requires y <>. mk_isize 0 && (x <>. impl_isize__MIN || y <>. mk_isize (-1)))
-      (fun _ -> Prims.l_True) = x /! y
-
-/// See [`std::primitive::u8::unchecked_rem`] (and similar for other integer types)
-let impl_isize__unchecked_rem (x y: isize)
-    : Prims.Pure isize
-      (requires y <>. mk_isize 0 && (x <>. impl_isize__MIN || y <>. mk_isize (-1)))
-      (fun _ -> Prims.l_True) = x %! y
-
-/// See [`std::primitive::i8::div_ceil`] (and similar for other signed integer types)
-let impl_isize__div_ceil (x y: isize)
-    : Prims.Pure isize
-      (requires
-        y <>. mk_isize 0 && ~.((x =. impl_isize__MIN <: bool) && (y =. mk_isize (-1) <: bool)))
-      (fun _ -> Prims.l_True) =
-  let d:isize = x /! y in
-  let r:isize = x %! y in
-  if r >. mk_isize 0 && y >. mk_isize 0 || r <. mk_isize 0 && y <. mk_isize 0
-  then d +! mk_isize 1
-  else d
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_18: Core_models.Default.t_Default u8 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: u8) -> true);
-    f_default = fun (_: Prims.unit) -> mk_u8 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_19: Core_models.Default.t_Default u16 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: u16) -> true);
-    f_default = fun (_: Prims.unit) -> mk_u16 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_20: Core_models.Default.t_Default u32 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: u32) -> true);
-    f_default = fun (_: Prims.unit) -> mk_u32 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_21: Core_models.Default.t_Default u64 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: u64) -> true);
-    f_default = fun (_: Prims.unit) -> mk_u64 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_22: Core_models.Default.t_Default u128 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: u128) -> true);
-    f_default = fun (_: Prims.unit) -> mk_u128 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_23: Core_models.Default.t_Default usize =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: usize) -> true);
-    f_default = fun (_: Prims.unit) -> mk_usize 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_24: Core_models.Default.t_Default i8 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: i8) -> true);
-    f_default = fun (_: Prims.unit) -> mk_i8 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_25: Core_models.Default.t_Default i16 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: i16) -> true);
-    f_default = fun (_: Prims.unit) -> mk_i16 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_26: Core_models.Default.t_Default i32 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: i32) -> true);
-    f_default = fun (_: Prims.unit) -> mk_i32 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_27: Core_models.Default.t_Default i64 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: i64) -> true);
-    f_default = fun (_: Prims.unit) -> mk_i64 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_28: Core_models.Default.t_Default i128 =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: i128) -> true);
-    f_default = fun (_: Prims.unit) -> mk_i128 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_29: Core_models.Default.t_Default isize =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: isize) -> true);
-    f_default = fun (_: Prims.unit) -> mk_isize 0
-  }
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_30: Core_models.Default.t_Default bool =
-  {
-    f_default_pre = (fun (_: Prims.unit) -> true);
-    f_default_post = (fun (_: Prims.unit) (out: bool) -> true);
-    f_default = fun (_: Prims.unit) -> false
-  }
+include Core_models.Bundle {impl_8__unchecked_div as impl_u32__unchecked_div}
+
+include Core_models.Bundle {impl_8__checked_rem as impl_u32__checked_rem}
+
+include Core_models.Bundle {impl_8__unchecked_rem as impl_u32__unchecked_rem}
+
+include Core_models.Bundle {impl_8__is_power_of_two as impl_u32__is_power_of_two}
+
+include Core_models.Bundle {impl_8__div_ceil as impl_u32__div_ceil}
+
+include Core_models.Bundle {impl_8__is_multiple_of as impl_u32__is_multiple_of}
+
+include Core_models.Bundle {impl_9__MIN as impl_u64__MIN}
+
+include Core_models.Bundle {impl_9__MAX as impl_u64__MAX}
+
+include Core_models.Bundle {impl_9__BITS as impl_u64__BITS}
+
+include Core_models.Bundle {impl_9__wrapping_add as impl_u64__wrapping_add}
+
+include Core_models.Bundle {impl_9__saturating_add as impl_u64__saturating_add}
+
+include Core_models.Bundle {impl_9__overflowing_add as impl_u64__overflowing_add}
+
+include Core_models.Bundle {impl_9__checked_add as impl_u64__checked_add}
+
+include Core_models.Bundle {impl_9__unchecked_add as impl_u64__unchecked_add}
+
+include Core_models.Bundle {impl_9__wrapping_sub as impl_u64__wrapping_sub}
+
+include Core_models.Bundle {impl_9__saturating_sub as impl_u64__saturating_sub}
+
+include Core_models.Bundle {impl_9__overflowing_sub as impl_u64__overflowing_sub}
+
+include Core_models.Bundle {impl_9__checked_sub as impl_u64__checked_sub}
+
+include Core_models.Bundle {impl_9__unchecked_sub as impl_u64__unchecked_sub}
+
+include Core_models.Bundle {impl_9__wrapping_mul as impl_u64__wrapping_mul}
+
+include Core_models.Bundle {impl_9__saturating_mul as impl_u64__saturating_mul}
+
+include Core_models.Bundle {impl_9__overflowing_mul as impl_u64__overflowing_mul}
+
+include Core_models.Bundle {impl_9__checked_mul as impl_u64__checked_mul}
+
+include Core_models.Bundle {impl_9__unchecked_mul as impl_u64__unchecked_mul}
+
+include Core_models.Bundle {impl_9__rem_euclid as impl_u64__rem_euclid}
+
+include Core_models.Bundle {impl_9__pow as impl_u64__pow}
+
+include Core_models.Bundle {impl_9__count_ones as impl_u64__count_ones}
+
+include Core_models.Bundle {impl_9__rotate_right as impl_u64__rotate_right}
+
+include Core_models.Bundle {impl_9__rotate_left as impl_u64__rotate_left}
+
+include Core_models.Bundle {impl_9__leading_zeros as impl_u64__leading_zeros}
+
+include Core_models.Bundle {impl_9__ilog2 as impl_u64__ilog2}
+
+include Core_models.Bundle {impl_9__from_str_radix as impl_u64__from_str_radix}
+
+include Core_models.Bundle {impl_9__from_be_bytes as impl_u64__from_be_bytes}
+
+include Core_models.Bundle {impl_9__from_le_bytes as impl_u64__from_le_bytes}
+
+include Core_models.Bundle {impl_9__to_be_bytes as impl_u64__to_be_bytes}
+
+include Core_models.Bundle {impl_9__to_le_bytes as impl_u64__to_le_bytes}
+
+include Core_models.Bundle {impl_9__checked_div as impl_u64__checked_div}
+
+include Core_models.Bundle {impl_9__unchecked_div as impl_u64__unchecked_div}
+
+include Core_models.Bundle {impl_9__checked_rem as impl_u64__checked_rem}
+
+include Core_models.Bundle {impl_9__unchecked_rem as impl_u64__unchecked_rem}
+
+include Core_models.Bundle {impl_9__is_power_of_two as impl_u64__is_power_of_two}
+
+include Core_models.Bundle {impl_9__div_ceil as impl_u64__div_ceil}
+
+include Core_models.Bundle {impl_9__is_multiple_of as impl_u64__is_multiple_of}
+
+include Core_models.Bundle {impl_10__MIN as impl_u128__MIN}
+
+include Core_models.Bundle {impl_10__MAX as impl_u128__MAX}
+
+include Core_models.Bundle {impl_10__BITS as impl_u128__BITS}
+
+include Core_models.Bundle {impl_10__wrapping_add as impl_u128__wrapping_add}
+
+include Core_models.Bundle {impl_10__saturating_add as impl_u128__saturating_add}
+
+include Core_models.Bundle {impl_10__overflowing_add as impl_u128__overflowing_add}
+
+include Core_models.Bundle {impl_10__checked_add as impl_u128__checked_add}
+
+include Core_models.Bundle {impl_10__unchecked_add as impl_u128__unchecked_add}
+
+include Core_models.Bundle {impl_10__wrapping_sub as impl_u128__wrapping_sub}
+
+include Core_models.Bundle {impl_10__saturating_sub as impl_u128__saturating_sub}
+
+include Core_models.Bundle {impl_10__overflowing_sub as impl_u128__overflowing_sub}
+
+include Core_models.Bundle {impl_10__checked_sub as impl_u128__checked_sub}
+
+include Core_models.Bundle {impl_10__unchecked_sub as impl_u128__unchecked_sub}
+
+include Core_models.Bundle {impl_10__wrapping_mul as impl_u128__wrapping_mul}
+
+include Core_models.Bundle {impl_10__saturating_mul as impl_u128__saturating_mul}
+
+include Core_models.Bundle {impl_10__overflowing_mul as impl_u128__overflowing_mul}
+
+include Core_models.Bundle {impl_10__checked_mul as impl_u128__checked_mul}
+
+include Core_models.Bundle {impl_10__unchecked_mul as impl_u128__unchecked_mul}
+
+include Core_models.Bundle {impl_10__rem_euclid as impl_u128__rem_euclid}
+
+include Core_models.Bundle {impl_10__pow as impl_u128__pow}
+
+include Core_models.Bundle {impl_10__count_ones as impl_u128__count_ones}
+
+include Core_models.Bundle {impl_10__rotate_right as impl_u128__rotate_right}
+
+include Core_models.Bundle {impl_10__rotate_left as impl_u128__rotate_left}
+
+include Core_models.Bundle {impl_10__leading_zeros as impl_u128__leading_zeros}
+
+include Core_models.Bundle {impl_10__ilog2 as impl_u128__ilog2}
+
+include Core_models.Bundle {impl_10__from_str_radix as impl_u128__from_str_radix}
+
+include Core_models.Bundle {impl_10__from_be_bytes as impl_u128__from_be_bytes}
+
+include Core_models.Bundle {impl_10__from_le_bytes as impl_u128__from_le_bytes}
+
+include Core_models.Bundle {impl_10__to_be_bytes as impl_u128__to_be_bytes}
+
+include Core_models.Bundle {impl_10__to_le_bytes as impl_u128__to_le_bytes}
+
+include Core_models.Bundle {impl_10__checked_div as impl_u128__checked_div}
+
+include Core_models.Bundle {impl_10__unchecked_div as impl_u128__unchecked_div}
+
+include Core_models.Bundle {impl_10__checked_rem as impl_u128__checked_rem}
+
+include Core_models.Bundle {impl_10__unchecked_rem as impl_u128__unchecked_rem}
+
+include Core_models.Bundle {impl_10__is_power_of_two as impl_u128__is_power_of_two}
+
+include Core_models.Bundle {impl_10__div_ceil as impl_u128__div_ceil}
+
+include Core_models.Bundle {impl_10__is_multiple_of as impl_u128__is_multiple_of}
+
+include Core_models.Bundle {impl_11__MIN as impl_usize__MIN}
+
+include Core_models.Bundle {impl_11__MAX as impl_usize__MAX}
+
+include Core_models.Bundle {impl_11__BITS as impl_usize__BITS}
+
+include Core_models.Bundle {impl_11__wrapping_add as impl_usize__wrapping_add}
+
+include Core_models.Bundle {impl_11__saturating_add as impl_usize__saturating_add}
+
+include Core_models.Bundle {impl_11__overflowing_add as impl_usize__overflowing_add}
+
+include Core_models.Bundle {impl_11__checked_add as impl_usize__checked_add}
+
+include Core_models.Bundle {impl_11__unchecked_add as impl_usize__unchecked_add}
+
+include Core_models.Bundle {impl_11__wrapping_sub as impl_usize__wrapping_sub}
+
+include Core_models.Bundle {impl_11__saturating_sub as impl_usize__saturating_sub}
+
+include Core_models.Bundle {impl_11__overflowing_sub as impl_usize__overflowing_sub}
+
+include Core_models.Bundle {impl_11__checked_sub as impl_usize__checked_sub}
+
+include Core_models.Bundle {impl_11__unchecked_sub as impl_usize__unchecked_sub}
+
+include Core_models.Bundle {impl_11__wrapping_mul as impl_usize__wrapping_mul}
+
+include Core_models.Bundle {impl_11__saturating_mul as impl_usize__saturating_mul}
+
+include Core_models.Bundle {impl_11__overflowing_mul as impl_usize__overflowing_mul}
+
+include Core_models.Bundle {impl_11__checked_mul as impl_usize__checked_mul}
+
+include Core_models.Bundle {impl_11__unchecked_mul as impl_usize__unchecked_mul}
+
+include Core_models.Bundle {impl_11__rem_euclid as impl_usize__rem_euclid}
+
+include Core_models.Bundle {impl_11__pow as impl_usize__pow}
+
+include Core_models.Bundle {impl_11__count_ones as impl_usize__count_ones}
+
+include Core_models.Bundle {impl_11__rotate_right as impl_usize__rotate_right}
+
+include Core_models.Bundle {impl_11__rotate_left as impl_usize__rotate_left}
+
+include Core_models.Bundle {impl_11__leading_zeros as impl_usize__leading_zeros}
+
+include Core_models.Bundle {impl_11__ilog2 as impl_usize__ilog2}
+
+include Core_models.Bundle {impl_11__from_str_radix as impl_usize__from_str_radix}
+
+include Core_models.Bundle {impl_11__from_be_bytes as impl_usize__from_be_bytes}
+
+include Core_models.Bundle {impl_11__from_le_bytes as impl_usize__from_le_bytes}
+
+include Core_models.Bundle {impl_11__to_be_bytes as impl_usize__to_be_bytes}
+
+include Core_models.Bundle {impl_11__to_le_bytes as impl_usize__to_le_bytes}
+
+include Core_models.Bundle {impl_11__checked_div as impl_usize__checked_div}
+
+include Core_models.Bundle {impl_11__unchecked_div as impl_usize__unchecked_div}
+
+include Core_models.Bundle {impl_11__checked_rem as impl_usize__checked_rem}
+
+include Core_models.Bundle {impl_11__unchecked_rem as impl_usize__unchecked_rem}
+
+include Core_models.Bundle {impl_11__is_power_of_two as impl_usize__is_power_of_two}
+
+include Core_models.Bundle {impl_11__div_ceil as impl_usize__div_ceil}
+
+include Core_models.Bundle {impl_11__is_multiple_of as impl_usize__is_multiple_of}
+
+include Core_models.Bundle {impl_12__MIN as impl_i8__MIN}
+
+include Core_models.Bundle {impl_12__MAX as impl_i8__MAX}
+
+include Core_models.Bundle {impl_12__BITS as impl_i8__BITS}
+
+include Core_models.Bundle {impl_12__wrapping_add as impl_i8__wrapping_add}
+
+include Core_models.Bundle {impl_12__saturating_add as impl_i8__saturating_add}
+
+include Core_models.Bundle {impl_12__overflowing_add as impl_i8__overflowing_add}
+
+include Core_models.Bundle {impl_12__checked_add as impl_i8__checked_add}
+
+include Core_models.Bundle {impl_12__unchecked_add as impl_i8__unchecked_add}
+
+include Core_models.Bundle {impl_12__wrapping_sub as impl_i8__wrapping_sub}
+
+include Core_models.Bundle {impl_12__saturating_sub as impl_i8__saturating_sub}
+
+include Core_models.Bundle {impl_12__overflowing_sub as impl_i8__overflowing_sub}
+
+include Core_models.Bundle {impl_12__checked_sub as impl_i8__checked_sub}
+
+include Core_models.Bundle {impl_12__unchecked_sub as impl_i8__unchecked_sub}
+
+include Core_models.Bundle {impl_12__checked_add_unsigned as impl_i8__checked_add_unsigned}
+
+include Core_models.Bundle {impl_12__checked_sub_unsigned as impl_i8__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_12__wrapping_mul as impl_i8__wrapping_mul}
+
+include Core_models.Bundle {impl_12__saturating_mul as impl_i8__saturating_mul}
+
+include Core_models.Bundle {impl_12__overflowing_mul as impl_i8__overflowing_mul}
+
+include Core_models.Bundle {impl_12__checked_mul as impl_i8__checked_mul}
+
+include Core_models.Bundle {impl_12__unchecked_mul as impl_i8__unchecked_mul}
+
+include Core_models.Bundle {impl_12__rem_euclid as impl_i8__rem_euclid}
+
+include Core_models.Bundle {impl_12__pow as impl_i8__pow}
+
+include Core_models.Bundle {impl_12__count_ones as impl_i8__count_ones}
+
+include Core_models.Bundle {impl_12__abs as impl_i8__abs}
+
+include Core_models.Bundle {impl_12__rotate_right as impl_i8__rotate_right}
+
+include Core_models.Bundle {impl_12__rotate_left as impl_i8__rotate_left}
+
+include Core_models.Bundle {impl_12__leading_zeros as impl_i8__leading_zeros}
+
+include Core_models.Bundle {impl_12__ilog2 as impl_i8__ilog2}
+
+include Core_models.Bundle {impl_12__from_str_radix as impl_i8__from_str_radix}
+
+include Core_models.Bundle {impl_12__from_be_bytes as impl_i8__from_be_bytes}
+
+include Core_models.Bundle {impl_12__from_le_bytes as impl_i8__from_le_bytes}
+
+include Core_models.Bundle {impl_12__to_be_bytes as impl_i8__to_be_bytes}
+
+include Core_models.Bundle {impl_12__to_le_bytes as impl_i8__to_le_bytes}
+
+include Core_models.Bundle {impl_12__checked_div as impl_i8__checked_div}
+
+include Core_models.Bundle {impl_12__unchecked_div as impl_i8__unchecked_div}
+
+include Core_models.Bundle {impl_12__checked_rem as impl_i8__checked_rem}
+
+include Core_models.Bundle {impl_12__unchecked_rem as impl_i8__unchecked_rem}
+
+include Core_models.Bundle {impl_12__signum as impl_i8__signum}
+
+include Core_models.Bundle {impl_12__div_ceil as impl_i8__div_ceil}
+
+include Core_models.Bundle {impl_13__MIN as impl_i16__MIN}
+
+include Core_models.Bundle {impl_13__MAX as impl_i16__MAX}
+
+include Core_models.Bundle {impl_13__BITS as impl_i16__BITS}
+
+include Core_models.Bundle {impl_13__wrapping_add as impl_i16__wrapping_add}
+
+include Core_models.Bundle {impl_13__saturating_add as impl_i16__saturating_add}
+
+include Core_models.Bundle {impl_13__overflowing_add as impl_i16__overflowing_add}
+
+include Core_models.Bundle {impl_13__checked_add as impl_i16__checked_add}
+
+include Core_models.Bundle {impl_13__unchecked_add as impl_i16__unchecked_add}
+
+include Core_models.Bundle {impl_13__wrapping_sub as impl_i16__wrapping_sub}
+
+include Core_models.Bundle {impl_13__saturating_sub as impl_i16__saturating_sub}
+
+include Core_models.Bundle {impl_13__overflowing_sub as impl_i16__overflowing_sub}
+
+include Core_models.Bundle {impl_13__checked_sub as impl_i16__checked_sub}
+
+include Core_models.Bundle {impl_13__unchecked_sub as impl_i16__unchecked_sub}
+
+include Core_models.Bundle {impl_13__checked_add_unsigned as impl_i16__checked_add_unsigned}
+
+include Core_models.Bundle {impl_13__checked_sub_unsigned as impl_i16__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_13__wrapping_mul as impl_i16__wrapping_mul}
+
+include Core_models.Bundle {impl_13__saturating_mul as impl_i16__saturating_mul}
+
+include Core_models.Bundle {impl_13__overflowing_mul as impl_i16__overflowing_mul}
+
+include Core_models.Bundle {impl_13__checked_mul as impl_i16__checked_mul}
+
+include Core_models.Bundle {impl_13__unchecked_mul as impl_i16__unchecked_mul}
+
+include Core_models.Bundle {impl_13__rem_euclid as impl_i16__rem_euclid}
+
+include Core_models.Bundle {impl_13__pow as impl_i16__pow}
+
+include Core_models.Bundle {impl_13__count_ones as impl_i16__count_ones}
+
+include Core_models.Bundle {impl_13__abs as impl_i16__abs}
+
+include Core_models.Bundle {impl_13__rotate_right as impl_i16__rotate_right}
+
+include Core_models.Bundle {impl_13__rotate_left as impl_i16__rotate_left}
+
+include Core_models.Bundle {impl_13__leading_zeros as impl_i16__leading_zeros}
+
+include Core_models.Bundle {impl_13__ilog2 as impl_i16__ilog2}
+
+include Core_models.Bundle {impl_13__from_str_radix as impl_i16__from_str_radix}
+
+include Core_models.Bundle {impl_13__from_be_bytes as impl_i16__from_be_bytes}
+
+include Core_models.Bundle {impl_13__from_le_bytes as impl_i16__from_le_bytes}
+
+include Core_models.Bundle {impl_13__to_be_bytes as impl_i16__to_be_bytes}
+
+include Core_models.Bundle {impl_13__to_le_bytes as impl_i16__to_le_bytes}
+
+include Core_models.Bundle {impl_13__checked_div as impl_i16__checked_div}
+
+include Core_models.Bundle {impl_13__unchecked_div as impl_i16__unchecked_div}
+
+include Core_models.Bundle {impl_13__checked_rem as impl_i16__checked_rem}
+
+include Core_models.Bundle {impl_13__unchecked_rem as impl_i16__unchecked_rem}
+
+include Core_models.Bundle {impl_13__signum as impl_i16__signum}
+
+include Core_models.Bundle {impl_13__div_ceil as impl_i16__div_ceil}
+
+include Core_models.Bundle {impl_14__MIN as impl_i32__MIN}
+
+include Core_models.Bundle {impl_14__MAX as impl_i32__MAX}
+
+include Core_models.Bundle {impl_14__BITS as impl_i32__BITS}
+
+include Core_models.Bundle {impl_14__wrapping_add as impl_i32__wrapping_add}
+
+include Core_models.Bundle {impl_14__saturating_add as impl_i32__saturating_add}
+
+include Core_models.Bundle {impl_14__overflowing_add as impl_i32__overflowing_add}
+
+include Core_models.Bundle {impl_14__checked_add as impl_i32__checked_add}
+
+include Core_models.Bundle {impl_14__unchecked_add as impl_i32__unchecked_add}
+
+include Core_models.Bundle {impl_14__wrapping_sub as impl_i32__wrapping_sub}
+
+include Core_models.Bundle {impl_14__saturating_sub as impl_i32__saturating_sub}
+
+include Core_models.Bundle {impl_14__overflowing_sub as impl_i32__overflowing_sub}
+
+include Core_models.Bundle {impl_14__checked_sub as impl_i32__checked_sub}
+
+include Core_models.Bundle {impl_14__unchecked_sub as impl_i32__unchecked_sub}
+
+include Core_models.Bundle {impl_14__checked_add_unsigned as impl_i32__checked_add_unsigned}
+
+include Core_models.Bundle {impl_14__checked_sub_unsigned as impl_i32__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_14__wrapping_mul as impl_i32__wrapping_mul}
+
+include Core_models.Bundle {impl_14__saturating_mul as impl_i32__saturating_mul}
+
+include Core_models.Bundle {impl_14__overflowing_mul as impl_i32__overflowing_mul}
+
+include Core_models.Bundle {impl_14__checked_mul as impl_i32__checked_mul}
+
+include Core_models.Bundle {impl_14__unchecked_mul as impl_i32__unchecked_mul}
+
+include Core_models.Bundle {impl_14__rem_euclid as impl_i32__rem_euclid}
+
+include Core_models.Bundle {impl_14__pow as impl_i32__pow}
+
+include Core_models.Bundle {impl_14__count_ones as impl_i32__count_ones}
+
+include Core_models.Bundle {impl_14__abs as impl_i32__abs}
+
+include Core_models.Bundle {impl_14__rotate_right as impl_i32__rotate_right}
+
+include Core_models.Bundle {impl_14__rotate_left as impl_i32__rotate_left}
+
+include Core_models.Bundle {impl_14__leading_zeros as impl_i32__leading_zeros}
+
+include Core_models.Bundle {impl_14__ilog2 as impl_i32__ilog2}
+
+include Core_models.Bundle {impl_14__from_str_radix as impl_i32__from_str_radix}
+
+include Core_models.Bundle {impl_14__from_be_bytes as impl_i32__from_be_bytes}
+
+include Core_models.Bundle {impl_14__from_le_bytes as impl_i32__from_le_bytes}
+
+include Core_models.Bundle {impl_14__to_be_bytes as impl_i32__to_be_bytes}
+
+include Core_models.Bundle {impl_14__to_le_bytes as impl_i32__to_le_bytes}
+
+include Core_models.Bundle {impl_14__checked_div as impl_i32__checked_div}
+
+include Core_models.Bundle {impl_14__unchecked_div as impl_i32__unchecked_div}
+
+include Core_models.Bundle {impl_14__checked_rem as impl_i32__checked_rem}
+
+include Core_models.Bundle {impl_14__unchecked_rem as impl_i32__unchecked_rem}
+
+include Core_models.Bundle {impl_14__signum as impl_i32__signum}
+
+include Core_models.Bundle {impl_14__div_ceil as impl_i32__div_ceil}
+
+include Core_models.Bundle {impl_15__MIN as impl_i64__MIN}
+
+include Core_models.Bundle {impl_15__MAX as impl_i64__MAX}
+
+include Core_models.Bundle {impl_15__BITS as impl_i64__BITS}
+
+include Core_models.Bundle {impl_15__wrapping_add as impl_i64__wrapping_add}
+
+include Core_models.Bundle {impl_15__saturating_add as impl_i64__saturating_add}
+
+include Core_models.Bundle {impl_15__overflowing_add as impl_i64__overflowing_add}
+
+include Core_models.Bundle {impl_15__checked_add as impl_i64__checked_add}
+
+include Core_models.Bundle {impl_15__unchecked_add as impl_i64__unchecked_add}
+
+include Core_models.Bundle {impl_15__wrapping_sub as impl_i64__wrapping_sub}
+
+include Core_models.Bundle {impl_15__saturating_sub as impl_i64__saturating_sub}
+
+include Core_models.Bundle {impl_15__overflowing_sub as impl_i64__overflowing_sub}
+
+include Core_models.Bundle {impl_15__checked_sub as impl_i64__checked_sub}
+
+include Core_models.Bundle {impl_15__unchecked_sub as impl_i64__unchecked_sub}
+
+include Core_models.Bundle {impl_15__checked_add_unsigned as impl_i64__checked_add_unsigned}
+
+include Core_models.Bundle {impl_15__checked_sub_unsigned as impl_i64__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_15__wrapping_mul as impl_i64__wrapping_mul}
+
+include Core_models.Bundle {impl_15__saturating_mul as impl_i64__saturating_mul}
+
+include Core_models.Bundle {impl_15__overflowing_mul as impl_i64__overflowing_mul}
+
+include Core_models.Bundle {impl_15__checked_mul as impl_i64__checked_mul}
+
+include Core_models.Bundle {impl_15__unchecked_mul as impl_i64__unchecked_mul}
+
+include Core_models.Bundle {impl_15__rem_euclid as impl_i64__rem_euclid}
+
+include Core_models.Bundle {impl_15__pow as impl_i64__pow}
+
+include Core_models.Bundle {impl_15__count_ones as impl_i64__count_ones}
+
+include Core_models.Bundle {impl_15__abs as impl_i64__abs}
+
+include Core_models.Bundle {impl_15__rotate_right as impl_i64__rotate_right}
+
+include Core_models.Bundle {impl_15__rotate_left as impl_i64__rotate_left}
+
+include Core_models.Bundle {impl_15__leading_zeros as impl_i64__leading_zeros}
+
+include Core_models.Bundle {impl_15__ilog2 as impl_i64__ilog2}
+
+include Core_models.Bundle {impl_15__from_str_radix as impl_i64__from_str_radix}
+
+include Core_models.Bundle {impl_15__from_be_bytes as impl_i64__from_be_bytes}
+
+include Core_models.Bundle {impl_15__from_le_bytes as impl_i64__from_le_bytes}
+
+include Core_models.Bundle {impl_15__to_be_bytes as impl_i64__to_be_bytes}
+
+include Core_models.Bundle {impl_15__to_le_bytes as impl_i64__to_le_bytes}
+
+include Core_models.Bundle {impl_15__checked_div as impl_i64__checked_div}
+
+include Core_models.Bundle {impl_15__unchecked_div as impl_i64__unchecked_div}
+
+include Core_models.Bundle {impl_15__checked_rem as impl_i64__checked_rem}
+
+include Core_models.Bundle {impl_15__unchecked_rem as impl_i64__unchecked_rem}
+
+include Core_models.Bundle {impl_15__signum as impl_i64__signum}
+
+include Core_models.Bundle {impl_15__div_ceil as impl_i64__div_ceil}
+
+include Core_models.Bundle {impl_16__MIN as impl_i128__MIN}
+
+include Core_models.Bundle {impl_16__MAX as impl_i128__MAX}
+
+include Core_models.Bundle {impl_16__BITS as impl_i128__BITS}
+
+include Core_models.Bundle {impl_16__wrapping_add as impl_i128__wrapping_add}
+
+include Core_models.Bundle {impl_16__saturating_add as impl_i128__saturating_add}
+
+include Core_models.Bundle {impl_16__overflowing_add as impl_i128__overflowing_add}
+
+include Core_models.Bundle {impl_16__checked_add as impl_i128__checked_add}
+
+include Core_models.Bundle {impl_16__unchecked_add as impl_i128__unchecked_add}
+
+include Core_models.Bundle {impl_16__wrapping_sub as impl_i128__wrapping_sub}
+
+include Core_models.Bundle {impl_16__saturating_sub as impl_i128__saturating_sub}
+
+include Core_models.Bundle {impl_16__overflowing_sub as impl_i128__overflowing_sub}
+
+include Core_models.Bundle {impl_16__checked_sub as impl_i128__checked_sub}
+
+include Core_models.Bundle {impl_16__unchecked_sub as impl_i128__unchecked_sub}
+
+include Core_models.Bundle {impl_16__checked_add_unsigned as impl_i128__checked_add_unsigned}
+
+include Core_models.Bundle {impl_16__checked_sub_unsigned as impl_i128__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_16__wrapping_mul as impl_i128__wrapping_mul}
+
+include Core_models.Bundle {impl_16__saturating_mul as impl_i128__saturating_mul}
+
+include Core_models.Bundle {impl_16__overflowing_mul as impl_i128__overflowing_mul}
+
+include Core_models.Bundle {impl_16__checked_mul as impl_i128__checked_mul}
+
+include Core_models.Bundle {impl_16__unchecked_mul as impl_i128__unchecked_mul}
+
+include Core_models.Bundle {impl_16__rem_euclid as impl_i128__rem_euclid}
+
+include Core_models.Bundle {impl_16__pow as impl_i128__pow}
+
+include Core_models.Bundle {impl_16__count_ones as impl_i128__count_ones}
+
+include Core_models.Bundle {impl_16__abs as impl_i128__abs}
+
+include Core_models.Bundle {impl_16__rotate_right as impl_i128__rotate_right}
+
+include Core_models.Bundle {impl_16__rotate_left as impl_i128__rotate_left}
+
+include Core_models.Bundle {impl_16__leading_zeros as impl_i128__leading_zeros}
+
+include Core_models.Bundle {impl_16__ilog2 as impl_i128__ilog2}
+
+include Core_models.Bundle {impl_16__from_str_radix as impl_i128__from_str_radix}
+
+include Core_models.Bundle {impl_16__from_be_bytes as impl_i128__from_be_bytes}
+
+include Core_models.Bundle {impl_16__from_le_bytes as impl_i128__from_le_bytes}
+
+include Core_models.Bundle {impl_16__to_be_bytes as impl_i128__to_be_bytes}
+
+include Core_models.Bundle {impl_16__to_le_bytes as impl_i128__to_le_bytes}
+
+include Core_models.Bundle {impl_16__checked_div as impl_i128__checked_div}
+
+include Core_models.Bundle {impl_16__unchecked_div as impl_i128__unchecked_div}
+
+include Core_models.Bundle {impl_16__checked_rem as impl_i128__checked_rem}
+
+include Core_models.Bundle {impl_16__unchecked_rem as impl_i128__unchecked_rem}
+
+include Core_models.Bundle {impl_16__signum as impl_i128__signum}
+
+include Core_models.Bundle {impl_16__div_ceil as impl_i128__div_ceil}
+
+include Core_models.Bundle {impl_17__MIN as impl_isize__MIN}
+
+include Core_models.Bundle {impl_17__MAX as impl_isize__MAX}
+
+include Core_models.Bundle {impl_17__BITS as impl_isize__BITS}
+
+include Core_models.Bundle {impl_17__wrapping_add as impl_isize__wrapping_add}
+
+include Core_models.Bundle {impl_17__saturating_add as impl_isize__saturating_add}
+
+include Core_models.Bundle {impl_17__overflowing_add as impl_isize__overflowing_add}
+
+include Core_models.Bundle {impl_17__checked_add as impl_isize__checked_add}
+
+include Core_models.Bundle {impl_17__unchecked_add as impl_isize__unchecked_add}
+
+include Core_models.Bundle {impl_17__wrapping_sub as impl_isize__wrapping_sub}
+
+include Core_models.Bundle {impl_17__saturating_sub as impl_isize__saturating_sub}
+
+include Core_models.Bundle {impl_17__overflowing_sub as impl_isize__overflowing_sub}
+
+include Core_models.Bundle {impl_17__checked_sub as impl_isize__checked_sub}
+
+include Core_models.Bundle {impl_17__unchecked_sub as impl_isize__unchecked_sub}
+
+include Core_models.Bundle {impl_17__checked_add_unsigned as impl_isize__checked_add_unsigned}
+
+include Core_models.Bundle {impl_17__checked_sub_unsigned as impl_isize__checked_sub_unsigned}
+
+include Core_models.Bundle {impl_17__wrapping_mul as impl_isize__wrapping_mul}
+
+include Core_models.Bundle {impl_17__saturating_mul as impl_isize__saturating_mul}
+
+include Core_models.Bundle {impl_17__overflowing_mul as impl_isize__overflowing_mul}
+
+include Core_models.Bundle {impl_17__checked_mul as impl_isize__checked_mul}
+
+include Core_models.Bundle {impl_17__unchecked_mul as impl_isize__unchecked_mul}
+
+include Core_models.Bundle {impl_17__rem_euclid as impl_isize__rem_euclid}
+
+include Core_models.Bundle {impl_17__pow as impl_isize__pow}
+
+include Core_models.Bundle {impl_17__count_ones as impl_isize__count_ones}
+
+include Core_models.Bundle {impl_17__abs as impl_isize__abs}
+
+include Core_models.Bundle {impl_17__rotate_right as impl_isize__rotate_right}
+
+include Core_models.Bundle {impl_17__rotate_left as impl_isize__rotate_left}
+
+include Core_models.Bundle {impl_17__leading_zeros as impl_isize__leading_zeros}
+
+include Core_models.Bundle {impl_17__ilog2 as impl_isize__ilog2}
+
+include Core_models.Bundle {impl_17__from_str_radix as impl_isize__from_str_radix}
+
+include Core_models.Bundle {impl_17__from_be_bytes as impl_isize__from_be_bytes}
+
+include Core_models.Bundle {impl_17__from_le_bytes as impl_isize__from_le_bytes}
+
+include Core_models.Bundle {impl_17__to_be_bytes as impl_isize__to_be_bytes}
+
+include Core_models.Bundle {impl_17__to_le_bytes as impl_isize__to_le_bytes}
+
+include Core_models.Bundle {impl_17__checked_div as impl_isize__checked_div}
+
+include Core_models.Bundle {impl_17__unchecked_div as impl_isize__unchecked_div}
+
+include Core_models.Bundle {impl_17__checked_rem as impl_isize__checked_rem}
+
+include Core_models.Bundle {impl_17__unchecked_rem as impl_isize__unchecked_rem}
+
+include Core_models.Bundle {impl_17__signum as impl_isize__signum}
+
+include Core_models.Bundle {impl_17__div_ceil as impl_isize__div_ceil}
+
+include Core_models.Bundle {impl_18__from__num as impl_18}
+
+include Core_models.Bundle {impl_19__from__num as impl_19}
+
+include Core_models.Bundle {impl_20__from__num as impl_20}
+
+include Core_models.Bundle {impl_21__from__num as impl_21}
+
+include Core_models.Bundle {impl_22__from__num as impl_22}
+
+include Core_models.Bundle {impl_23__from__num as impl_23}
+
+include Core_models.Bundle {impl_24__from__num as impl_24}
+
+include Core_models.Bundle {impl_25__from__num as impl_25}
+
+include Core_models.Bundle {impl_26__from__num as impl_26}
+
+include Core_models.Bundle {impl_27__from__num as impl_27}
+
+include Core_models.Bundle {impl_28__from__num as impl_28}
+
+include Core_models.Bundle {impl_29__from__num as impl_29}
+
+include Core_models.Bundle {impl_30__from__num as impl_30}

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -1844,14 +1844,14 @@ def U64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MAX : Std.I8 := 127#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MIN : Std.I8 := (-128)#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1904,14 +1904,14 @@ def I8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MAX : Std.I16 := 32767#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MIN : Std.I16 := (-32768)#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1991,14 +1991,14 @@ def I16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MAX : Std.I32 := 2147483647#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MIN : Std.I32 := (-2147483648)#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2030,7 +2030,7 @@ def I32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
@@ -2038,7 +2038,7 @@ def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MIN : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MIN
@@ -2148,7 +2148,7 @@ def I32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MAX : Std.I64 := 9223372036854775807#i64
@@ -2156,7 +2156,7 @@ def num.I64.MAX : Std.I64 := 9223372036854775807#i64
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MIN : Std.I64 := (-9223372036854775808)#i64
@@ -2674,7 +2674,7 @@ def I64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Source: 'core-models/src/core/num/mod.rs', lines 250:12-250:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MAX : Std.I128 := 170141183460469231731687303715884105727#i128
@@ -5385,14 +5385,14 @@ def option.Option.unwrap {T : Type} (self : option.Option T) : Result T := do
   | option.Option.None => panicking.internal.panic T
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.I8.overflowing_add
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.I8.checked_add_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5413,14 +5413,14 @@ def I8.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.I16.overflowing_add
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.I16.checked_add_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5441,14 +5441,14 @@ def I16.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.I32.overflowing_add
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.I32.checked_add_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5469,14 +5469,14 @@ def I32.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.I64.overflowing_add
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.I64.checked_add_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5497,14 +5497,14 @@ def I64.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.Isize.overflowing_add
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.Isize.checked_add_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5525,14 +5525,14 @@ def Isize.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.I128.overflowing_add
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
+    Source: 'core-models/src/core/num/mod.rs', lines 305:12-314:13
     Visibility: public -/
 def num.I128.checked_add_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5553,14 +5553,14 @@ def I128.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.I8.overflowing_sub
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.I8.checked_sub_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5581,14 +5581,14 @@ def I8.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.I16.overflowing_sub
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.I16.checked_sub_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5609,14 +5609,14 @@ def I16.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.I32.overflowing_sub
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.I32.checked_sub_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5637,14 +5637,14 @@ def I32.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.I64.overflowing_sub
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.I64.checked_sub_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5665,14 +5665,14 @@ def I64.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.Isize.overflowing_sub
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.Isize.checked_sub_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5693,14 +5693,14 @@ def Isize.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
     Visibility: public -/
 def num.I128.overflowing_sub
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
+    Source: 'core-models/src/core/num/mod.rs', lines 316:12-323:13
     Visibility: public -/
 def num.I128.checked_sub_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5721,7 +5721,7 @@ def I128.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.U8.unchecked_add (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x + y
@@ -5735,7 +5735,7 @@ def U8.Insts.CoreIterRangeStep.forward_unchecked
   num.U8.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.U16.unchecked_add (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x + y
@@ -5749,7 +5749,7 @@ def U16.Insts.CoreIterRangeStep.forward_unchecked
   num.U16.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.U32.unchecked_add (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x + y
@@ -5763,7 +5763,7 @@ def U32.Insts.CoreIterRangeStep.forward_unchecked
   num.U32.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.U64.unchecked_add (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x + y
@@ -5777,7 +5777,7 @@ def U64.Insts.CoreIterRangeStep.forward_unchecked
   num.U64.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.Usize.unchecked_add
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
@@ -5791,7 +5791,7 @@ def Usize.Insts.CoreIterRangeStep.forward_unchecked
   num.Usize.unchecked_add start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
+    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
     Visibility: public -/
 def num.U128.unchecked_add
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
@@ -5806,7 +5806,7 @@ def U128.Insts.CoreIterRangeStep.forward_unchecked
   num.U128.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.U8.unchecked_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x - y
@@ -5820,7 +5820,7 @@ def U8.Insts.CoreIterRangeStep.backward_unchecked
   num.U8.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.U16.unchecked_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x - y
@@ -5834,7 +5834,7 @@ def U16.Insts.CoreIterRangeStep.backward_unchecked
   num.U16.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.U32.unchecked_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x - y
@@ -5848,7 +5848,7 @@ def U32.Insts.CoreIterRangeStep.backward_unchecked
   num.U32.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.U64.unchecked_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x - y
@@ -5862,7 +5862,7 @@ def U64.Insts.CoreIterRangeStep.backward_unchecked
   num.U64.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.Usize.unchecked_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
@@ -5876,7 +5876,7 @@ def Usize.Insts.CoreIterRangeStep.backward_unchecked
   num.Usize.unchecked_sub start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
+    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
     Visibility: public -/
 def num.U128.unchecked_sub
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
@@ -5898,7 +5898,7 @@ def num.U8.overflowing_add
   rust_primitives.arithmetic.overflowing_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.U8.checked_add
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -5926,7 +5926,7 @@ def U8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.I8.wrapping_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_add_i8 x y
@@ -5962,7 +5962,7 @@ def num.U16.overflowing_add
   rust_primitives.arithmetic.overflowing_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.U16.checked_add
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -5990,7 +5990,7 @@ def U16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.I16.wrapping_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_add_i16 x y
@@ -6026,7 +6026,7 @@ def num.U32.overflowing_add
   rust_primitives.arithmetic.overflowing_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.U32.checked_add
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -6054,7 +6054,7 @@ def U32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.I32.wrapping_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_add_i32 x y
@@ -6090,7 +6090,7 @@ def num.U64.overflowing_add
   rust_primitives.arithmetic.overflowing_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.U64.checked_add
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -6118,7 +6118,7 @@ def U64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.I64.wrapping_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_add_i64 x y
@@ -6154,7 +6154,7 @@ def num.Usize.overflowing_add
   rust_primitives.arithmetic.overflowing_add_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.Usize.checked_add
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -6184,7 +6184,7 @@ def Usize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.Isize.wrapping_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6223,7 +6223,7 @@ def num.U128.overflowing_add
   rust_primitives.arithmetic.overflowing_add_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
+    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
     Visibility: public -/
 def num.U128.checked_add
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -6249,7 +6249,7 @@ def U128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.I128.checked_add
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -6275,14 +6275,14 @@ def I128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.U8.overflowing_sub
   (x : Std.U8) (y : Std.U8) : Result (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.U8.checked_sub
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -6310,7 +6310,7 @@ def U8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.I8.wrapping_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_sub_i8 x y
@@ -6339,14 +6339,14 @@ def I8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.U16.overflowing_sub
   (x : Std.U16) (y : Std.U16) : Result (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.U16.checked_sub
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -6374,7 +6374,7 @@ def U16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.I16.wrapping_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_sub_i16 x y
@@ -6403,14 +6403,14 @@ def I16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.U32.overflowing_sub
   (x : Std.U32) (y : Std.U32) : Result (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.U32.checked_sub
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -6438,7 +6438,7 @@ def U32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.I32.wrapping_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_sub_i32 x y
@@ -6467,14 +6467,14 @@ def I32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.U64.overflowing_sub
   (x : Std.U64) (y : Std.U64) : Result (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.U64.checked_sub
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -6502,7 +6502,7 @@ def U64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.I64.wrapping_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_sub_i64 x y
@@ -6531,14 +6531,14 @@ def I64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.Usize.overflowing_sub
   (x : Std.Usize) (y : Std.Usize) : Result (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.Usize.checked_sub
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -6568,7 +6568,7 @@ def Usize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.Isize.wrapping_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6600,14 +6600,14 @@ def Isize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
+    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
     Visibility: public -/
 def num.U128.overflowing_sub
   (x : Std.U128) (y : Std.U128) : Result (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
+    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
     Visibility: public -/
 def num.U128.checked_sub
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -6633,7 +6633,7 @@ def U128.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.I128.checked_sub
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -7340,199 +7340,199 @@ def num.Usize.saturating_add
   rust_primitives.arithmetic.saturating_add_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.U8.wrapping_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.wrapping_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.U16.wrapping_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.wrapping_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.U32.wrapping_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.wrapping_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.U64.wrapping_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.wrapping_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.U128.wrapping_sub (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.wrapping_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
+    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
     Visibility: public -/
 def num.Usize.wrapping_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.wrapping_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.U8.saturating_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.saturating_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.U16.saturating_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.saturating_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.U32.saturating_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.saturating_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.U64.saturating_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.saturating_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.U128.saturating_sub
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.saturating_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
+    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
     Visibility: public -/
 def num.Usize.saturating_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.saturating_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.U8.wrapping_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.wrapping_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.U16.wrapping_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.wrapping_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.U32.wrapping_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.wrapping_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.U64.wrapping_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.wrapping_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.U128.wrapping_mul (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.wrapping_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
+    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
     Visibility: public -/
 def num.Usize.wrapping_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.wrapping_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.U8.saturating_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.saturating_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.U16.saturating_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.saturating_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.U32.saturating_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.saturating_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.U64.saturating_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.saturating_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.U128.saturating_mul
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.saturating_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
+    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
     Visibility: public -/
 def num.Usize.saturating_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.saturating_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.U8.overflowing_mul
   (x : Std.U8) (y : Std.U8) : Result (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.U16.overflowing_mul
   (x : Std.U16) (y : Std.U16) : Result (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.U32.overflowing_mul
   (x : Std.U32) (y : Std.U32) : Result (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.U64.overflowing_mul
   (x : Std.U64) (y : Std.U64) : Result (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.U128.overflowing_mul
   (x : Std.U128) (y : Std.U128) : Result (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
+    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
     Visibility: public -/
 def num.Usize.overflowing_mul
   (x : Std.Usize) (y : Std.Usize) : Result (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.U8.checked_mul
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -7542,7 +7542,7 @@ def num.U8.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.U16.checked_mul
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -7552,7 +7552,7 @@ def num.U16.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.U32.checked_mul
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -7562,7 +7562,7 @@ def num.U32.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.U64.checked_mul
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -7572,7 +7572,7 @@ def num.U64.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.U128.checked_mul
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -7582,7 +7582,7 @@ def num.U128.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::usize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
+    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
     Visibility: public -/
 def num.Usize.checked_mul
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -7592,300 +7592,300 @@ def num.Usize.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.U8.unchecked_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.U16.unchecked_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.U32.unchecked_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.U64.unchecked_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.U128.unchecked_mul
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
+    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
     Visibility: public -/
 def num.Usize.unchecked_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x * y
 
 /-- [core_models::num::{core_models::num::u8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.U8.rem_euclid (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.rem_euclid_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.U16.rem_euclid (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.rem_euclid_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.U32.rem_euclid (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rem_euclid_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.U64.rem_euclid (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.rem_euclid_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.U128.rem_euclid (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.rem_euclid_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
+    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
     Visibility: public -/
 def num.Usize.rem_euclid
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.rem_euclid_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.U8.pow (x : Std.U8) (exp : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.pow_u8 x exp
 
 /-- [core_models::num::{core_models::num::u16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.U16.pow (x : Std.U16) (exp : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.pow_u16 x exp
 
 /-- [core_models::num::{core_models::num::u32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.U32.pow (x : Std.U32) (exp : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.pow_u32 x exp
 
 /-- [core_models::num::{core_models::num::u64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.U64.pow (x : Std.U64) (exp : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.pow_u64 x exp
 
 /-- [core_models::num::{core_models::num::u128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.U128.pow (x : Std.U128) (exp : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.pow_u128 x exp
 
 /-- [core_models::num::{core_models::num::usize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
+    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
     Visibility: public -/
 def num.Usize.pow (x : Std.Usize) (exp : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.pow_usize x exp
 
 /-- [core_models::num::{core_models::num::u8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.U8.count_ones (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.U16.count_ones (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.U32.count_ones (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.U64.count_ones (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.U128.count_ones (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
+    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
     Visibility: public -/
 def num.Usize.count_ones (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_usize x
 
 /-- [core_models::num::{core_models::num::u8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.U8.rotate_right (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_right_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.U16.rotate_right (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_right_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.U32.rotate_right (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_right_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.U64.rotate_right (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_right_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.U128.rotate_right (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_right_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
+    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
     Visibility: public -/
 def num.Usize.rotate_right
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_right_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.U8.rotate_left (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_left_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.U16.rotate_left (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_left_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.U32.rotate_left (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_left_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.U64.rotate_left (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_left_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.U128.rotate_left (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_left_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
+    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
     Visibility: public -/
 def num.Usize.rotate_left
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_left_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U8.leading_zeros (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U16.leading_zeros (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U32.leading_zeros (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U64.leading_zeros (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U128.leading_zeros (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.Usize.leading_zeros (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_usize x
 
 /-- [core_models::num::{core_models::num::u8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.U8.ilog2 (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.U16.ilog2 (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.U32.ilog2 (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.U64.ilog2 (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.U128.ilog2 (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
     Visibility: public -/
 def num.Usize.ilog2 (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_usize x
 
 /-- [core_models::num::{core_models::num::u8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.U8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7894,7 +7894,7 @@ def num.U8.from_str_radix
   panicking.internal.panic (result.Result Std.U8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.U16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7903,7 +7903,7 @@ def num.U16.from_str_radix
   panicking.internal.panic (result.Result Std.U16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.U32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7912,7 +7912,7 @@ def num.U32.from_str_radix
   panicking.internal.panic (result.Result Std.U32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.U64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7921,7 +7921,7 @@ def num.U64.from_str_radix
   panicking.internal.panic (result.Result Std.U64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.U128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7930,7 +7930,7 @@ def num.U128.from_str_radix
   panicking.internal.panic (result.Result Std.U128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::usize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
+    Source: 'core-models/src/core/num/mod.rs', lines 143:12-148:13
     Visibility: public -/
 def num.Usize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7939,159 +7939,159 @@ def num.Usize.from_str_radix
   panicking.internal.panic (result.Result Std.Usize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.U8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.U16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.U32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.U64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.U128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
+    Source: 'core-models/src/core/num/mod.rs', lines 151:12-153:13
     Visibility: public -/
 def num.Usize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.U8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.U16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.U32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.U64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.U128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
+    Source: 'core-models/src/core/num/mod.rs', lines 156:12-158:13
     Visibility: public -/
 def num.Usize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.U8.to_be_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.U16.to_be_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.U32.to_be_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.U64.to_be_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.U128.to_be_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
+    Source: 'core-models/src/core/num/mod.rs', lines 161:12-163:13
     Visibility: public -/
 def num.Usize.to_be_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.U8.to_le_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.U16.to_le_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.U32.to_le_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.U64.to_le_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.U128.to_le_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
+    Source: 'core-models/src/core/num/mod.rs', lines 166:12-168:13
     Visibility: public -/
 def num.Usize.to_le_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.U8.checked_div
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8101,7 +8101,7 @@ def num.U8.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.U16.checked_div
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8111,7 +8111,7 @@ def num.U16.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.U32.checked_div
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8121,7 +8121,7 @@ def num.U32.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.U64.checked_div
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8131,7 +8131,7 @@ def num.U64.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.U128.checked_div
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8141,7 +8141,7 @@ def num.U128.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-176:13
     Visibility: public -/
 def num.Usize.checked_div
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8151,45 +8151,45 @@ def num.Usize.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.U8.unchecked_div (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.U16.unchecked_div (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.U32.unchecked_div (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.U64.unchecked_div (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.U128.unchecked_div
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
+    Source: 'core-models/src/core/num/mod.rs', lines 179:12-181:13
     Visibility: public -/
 def num.Usize.unchecked_div
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x / y
 
 /-- [core_models::num::{core_models::num::u8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.U8.checked_rem
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8199,7 +8199,7 @@ def num.U8.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.U16.checked_rem
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8209,7 +8209,7 @@ def num.U16.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.U32.checked_rem
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8219,7 +8219,7 @@ def num.U32.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.U64.checked_rem
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8229,7 +8229,7 @@ def num.U64.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.U128.checked_rem
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8239,7 +8239,7 @@ def num.U128.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
+    Source: 'core-models/src/core/num/mod.rs', lines 183:12-189:13
     Visibility: public -/
 def num.Usize.checked_rem
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8249,45 +8249,45 @@ def num.Usize.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.U8.unchecked_rem (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.U16.unchecked_rem (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.U32.unchecked_rem (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.U64.unchecked_rem (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.U128.unchecked_rem
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
+    Source: 'core-models/src/core/num/mod.rs', lines 192:12-194:13
     Visibility: public -/
 def num.Usize.unchecked_rem
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x % y
 
 /-- [core_models::num::{core_models::num::u8}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   if x != 0#u8
@@ -8297,7 +8297,7 @@ def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u16}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   if x != 0#u16
@@ -8307,7 +8307,7 @@ def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u32}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   if x != 0#u32
@@ -8317,7 +8317,7 @@ def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u64}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   if x != 0#u64
@@ -8327,7 +8327,7 @@ def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u128}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   if x != 0#u128
@@ -8337,7 +8337,7 @@ def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::usize}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
+    Source: 'core-models/src/core/num/mod.rs', lines 196:12-198:13
     Visibility: public -/
 def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   if x != 0#usize
@@ -8347,7 +8347,7 @@ def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   let d ← x / y
@@ -8357,7 +8357,7 @@ def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   let d ← x / y
@@ -8367,7 +8367,7 @@ def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   let d ← x / y
@@ -8377,7 +8377,7 @@ def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   let d ← x / y
@@ -8387,7 +8387,7 @@ def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   let d ← x / y
@@ -8397,7 +8397,7 @@ def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::usize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 201:12-205:13
     Visibility: public -/
 def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   let d ← x / y
@@ -8407,7 +8407,7 @@ def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u8}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
   if y = 0#u8
@@ -8416,7 +8416,7 @@ def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
        ok (i = 0#u8)
 
 /-- [core_models::num::{core_models::num::u16}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
   if y = 0#u16
@@ -8425,7 +8425,7 @@ def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
        ok (i = 0#u16)
 
 /-- [core_models::num::{core_models::num::u32}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
   if y = 0#u32
@@ -8434,7 +8434,7 @@ def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
        ok (i = 0#u32)
 
 /-- [core_models::num::{core_models::num::u64}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
   if y = 0#u64
@@ -8443,7 +8443,7 @@ def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
        ok (i = 0#u64)
 
 /-- [core_models::num::{core_models::num::u128}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
   if y = 0#u128
@@ -8452,7 +8452,7 @@ def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
        ok (i = 0#u128)
 
 /-- [core_models::num::{core_models::num::usize}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-213:13
     Visibility: public -/
 def num.Usize.is_multiple_of
   (x : Std.Usize) (y : Std.Usize) : Result Bool := do
@@ -8463,89 +8463,89 @@ def num.Usize.is_multiple_of
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Source: 'core-models/src/core/num/mod.rs', lines 248:12-248:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MIN : Std.I128 := (-170141183460469231731687303715884105728)#i128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-- [core_models::num::{core_models::num::i8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::i16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::i32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::i64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::i128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::isize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
+    Source: 'core-models/src/core/num/mod.rs', lines 252:12-252:57
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.BITS : Result Std.U32 := rust_primitives.arithmetic.SIZE_BITS
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
+    Source: 'core-models/src/core/num/mod.rs', lines 253:12-255:13
     Visibility: public -/
 def num.I128.wrapping_add (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.I8.saturating_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.I16.saturating_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.I32.saturating_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.I64.saturating_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.I128.saturating_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_add_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
+    Source: 'core-models/src/core/num/mod.rs', lines 257:12-259:13
     Visibility: public -/
 def num.Isize.saturating_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_add_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.I8.checked_add
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8555,7 +8555,7 @@ def num.I8.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.I16.checked_add
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8565,7 +8565,7 @@ def num.I16.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.I32.checked_add
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8575,7 +8575,7 @@ def num.I32.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.I64.checked_add
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8585,7 +8585,7 @@ def num.I64.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 265:12-272:13
     Visibility: public -/
 def num.Isize.checked_add
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8595,89 +8595,89 @@ def num.Isize.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I8.unchecked_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I16.unchecked_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I32.unchecked_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I64.unchecked_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.I128.unchecked_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x + y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
+    Source: 'core-models/src/core/num/mod.rs', lines 275:12-277:13
     Visibility: public -/
 def num.Isize.unchecked_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
+    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
     Visibility: public -/
 def num.I128.wrapping_sub (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.I8.saturating_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.I16.saturating_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.I32.saturating_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.I64.saturating_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.I128.saturating_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
     Visibility: public -/
 def num.Isize.saturating_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_sub_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.I8.checked_sub
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8687,7 +8687,7 @@ def num.I8.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.I16.checked_sub
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8697,7 +8697,7 @@ def num.I16.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.I32.checked_sub
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8707,7 +8707,7 @@ def num.I32.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.I64.checked_sub
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8717,7 +8717,7 @@ def num.I64.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
+    Source: 'core-models/src/core/num/mod.rs', lines 291:12-298:13
     Visibility: public -/
 def num.Isize.checked_sub
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8727,162 +8727,162 @@ def num.Isize.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I8.unchecked_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I16.unchecked_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I32.unchecked_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I64.unchecked_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.I128.unchecked_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x - y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
+    Source: 'core-models/src/core/num/mod.rs', lines 301:12-303:13
     Visibility: public -/
 def num.Isize.unchecked_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x - y
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.I8.wrapping_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.I16.wrapping_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.I32.wrapping_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.I64.wrapping_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.I128.wrapping_mul (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
+    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
     Visibility: public -/
 def num.Isize.wrapping_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.wrapping_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.I8.saturating_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.I16.saturating_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.I32.saturating_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.I64.saturating_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.I128.saturating_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
+    Source: 'core-models/src/core/num/mod.rs', lines 329:12-331:13
     Visibility: public -/
 def num.Isize.saturating_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.I8.overflowing_mul
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.I16.overflowing_mul
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.I32.overflowing_mul
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.I64.overflowing_mul
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.I128.overflowing_mul
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
+    Source: 'core-models/src/core/num/mod.rs', lines 333:12-335:13
     Visibility: public -/
 def num.Isize.overflowing_mul
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.I8.checked_mul
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8892,7 +8892,7 @@ def num.I8.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.I16.checked_mul
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8902,7 +8902,7 @@ def num.I16.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.I32.checked_mul
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8912,7 +8912,7 @@ def num.I32.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.I64.checked_mul
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8922,7 +8922,7 @@ def num.I64.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.I128.checked_mul
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -8932,7 +8932,7 @@ def num.I128.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 337:12-344:13
     Visibility: public -/
 def num.Isize.checked_mul
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8942,336 +8942,336 @@ def num.Isize.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I8.unchecked_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I16.unchecked_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I32.unchecked_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I64.unchecked_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.I128.unchecked_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
+    Source: 'core-models/src/core/num/mod.rs', lines 347:12-349:13
     Visibility: public -/
 def num.Isize.unchecked_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x * y
 
 /-- [core_models::num::{core_models::num::i8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.I8.rem_euclid (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.rem_euclid_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.I16.rem_euclid (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.rem_euclid_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.I32.rem_euclid (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.rem_euclid_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.I64.rem_euclid (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.rem_euclid_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.I128.rem_euclid (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.rem_euclid_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
+    Source: 'core-models/src/core/num/mod.rs', lines 352:12-354:13
     Visibility: public -/
 def num.Isize.rem_euclid
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.rem_euclid_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.I8.pow (x : Std.I8) (exp : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.pow_i8 x exp
 
 /-- [core_models::num::{core_models::num::i16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.I16.pow (x : Std.I16) (exp : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.pow_i16 x exp
 
 /-- [core_models::num::{core_models::num::i32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.I32.pow (x : Std.I32) (exp : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.pow_i32 x exp
 
 /-- [core_models::num::{core_models::num::i64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.I64.pow (x : Std.I64) (exp : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.pow_i64 x exp
 
 /-- [core_models::num::{core_models::num::i128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.I128.pow (x : Std.I128) (exp : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.pow_i128 x exp
 
 /-- [core_models::num::{core_models::num::isize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
+    Source: 'core-models/src/core/num/mod.rs', lines 356:12-358:13
     Visibility: public -/
 def num.Isize.pow (x : Std.Isize) (exp : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.pow_isize x exp
 
 /-- [core_models::num::{core_models::num::i8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I8.count_ones (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I16.count_ones (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I32.count_ones (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I64.count_ones (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I128.count_ones (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.Isize.count_ones (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_isize x
 
 /-- [core_models::num::{core_models::num::i8}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.I8.abs (x : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.abs_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.I16.abs (x : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.abs_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.I32.abs (x : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.abs_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.I64.abs (x : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.abs_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.I128.abs (x : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.abs_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
+    Source: 'core-models/src/core/num/mod.rs', lines 365:12-367:13
     Visibility: public -/
 def num.Isize.abs (x : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.abs_isize x
 
 /-- [core_models::num::{core_models::num::i8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I8.rotate_right (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_right_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I16.rotate_right (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_right_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I32.rotate_right (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_right_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I64.rotate_right (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_right_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.I128.rotate_right (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_right_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 370:12-372:13
     Visibility: public -/
 def num.Isize.rotate_right
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_right_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.I8.rotate_left (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_left_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.I16.rotate_left (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_left_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.I32.rotate_left (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_left_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.I64.rotate_left (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_left_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.I128.rotate_left (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_left_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
+    Source: 'core-models/src/core/num/mod.rs', lines 375:12-377:13
     Visibility: public -/
 def num.Isize.rotate_left
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_left_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.I8.leading_zeros (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.I16.leading_zeros (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.I32.leading_zeros (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.I64.leading_zeros (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.I128.leading_zeros (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
+    Source: 'core-models/src/core/num/mod.rs', lines 380:12-382:13
     Visibility: public -/
 def num.Isize.leading_zeros (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_isize x
 
 /-- [core_models::num::{core_models::num::i8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.I8.ilog2 (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.I16.ilog2 (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.I32.ilog2 (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.I64.ilog2 (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.I128.ilog2 (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
+    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
     Visibility: public -/
 def num.Isize.ilog2 (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_isize x
 
 /-- [core_models::num::{core_models::num::i8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.I8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9280,7 +9280,7 @@ def num.I8.from_str_radix
   panicking.internal.panic (result.Result Std.I8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.I16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9289,7 +9289,7 @@ def num.I16.from_str_radix
   panicking.internal.panic (result.Result Std.I16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.I32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9298,7 +9298,7 @@ def num.I32.from_str_radix
   panicking.internal.panic (result.Result Std.I32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.I64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9307,7 +9307,7 @@ def num.I64.from_str_radix
   panicking.internal.panic (result.Result Std.I64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.I128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9316,7 +9316,7 @@ def num.I128.from_str_radix
   panicking.internal.panic (result.Result Std.I128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::isize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
+    Source: 'core-models/src/core/num/mod.rs', lines 390:12-395:13
     Visibility: public -/
 def num.Isize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9325,159 +9325,159 @@ def num.Isize.from_str_radix
   panicking.internal.panic (result.Result Std.Isize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.I128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
+    Source: 'core-models/src/core/num/mod.rs', lines 398:12-400:13
     Visibility: public -/
 def num.Isize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.I128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
+    Source: 'core-models/src/core/num/mod.rs', lines 403:12-405:13
     Visibility: public -/
 def num.Isize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I8.to_be_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I16.to_be_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I32.to_be_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I64.to_be_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.I128.to_be_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
+    Source: 'core-models/src/core/num/mod.rs', lines 408:12-410:13
     Visibility: public -/
 def num.Isize.to_be_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I8.to_le_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I16.to_le_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I32.to_le_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I64.to_le_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.I128.to_le_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
+    Source: 'core-models/src/core/num/mod.rs', lines 413:12-415:13
     Visibility: public -/
 def num.Isize.to_le_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.I8.checked_div
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9494,7 +9494,7 @@ def num.I8.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.I16.checked_div
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9511,7 +9511,7 @@ def num.I16.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.I32.checked_div
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9528,7 +9528,7 @@ def num.I32.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.I64.checked_div
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9545,7 +9545,7 @@ def num.I64.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.I128.checked_div
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9562,7 +9562,7 @@ def num.I128.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
+    Source: 'core-models/src/core/num/mod.rs', lines 417:12-423:13
     Visibility: public -/
 def num.Isize.checked_div
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9580,45 +9580,45 @@ def num.Isize.checked_div
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I8.unchecked_div (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I16.unchecked_div (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I32.unchecked_div (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I64.unchecked_div (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.I128.unchecked_div
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
+    Source: 'core-models/src/core/num/mod.rs', lines 426:12-428:13
     Visibility: public -/
 def num.Isize.unchecked_div
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x / y
 
 /-- [core_models::num::{core_models::num::i8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I8.checked_rem
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9635,7 +9635,7 @@ def num.I8.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I16.checked_rem
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9652,7 +9652,7 @@ def num.I16.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I32.checked_rem
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9669,7 +9669,7 @@ def num.I32.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I64.checked_rem
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9686,7 +9686,7 @@ def num.I64.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I128.checked_rem
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9703,7 +9703,7 @@ def num.I128.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.Isize.checked_rem
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9721,45 +9721,45 @@ def num.Isize.checked_rem
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I8.unchecked_rem (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I16.unchecked_rem (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I32.unchecked_rem (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I64.unchecked_rem (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I128.unchecked_rem
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.Isize.unchecked_rem
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x % y
 
 /-- [core_models::num::{core_models::num::i8}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.I8.signum (x : Std.I8) : Result Std.I8 := do
   if x > 0#i8
@@ -9769,7 +9769,7 @@ def num.I8.signum (x : Std.I8) : Result Std.I8 := do
        else ok (-1)#i8
 
 /-- [core_models::num::{core_models::num::i16}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.I16.signum (x : Std.I16) : Result Std.I16 := do
   if x > 0#i16
@@ -9779,7 +9779,7 @@ def num.I16.signum (x : Std.I16) : Result Std.I16 := do
        else ok (-1)#i16
 
 /-- [core_models::num::{core_models::num::i32}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.I32.signum (x : Std.I32) : Result Std.I32 := do
   if x > 0#i32
@@ -9789,7 +9789,7 @@ def num.I32.signum (x : Std.I32) : Result Std.I32 := do
        else ok (-1)#i32
 
 /-- [core_models::num::{core_models::num::i64}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.I64.signum (x : Std.I64) : Result Std.I64 := do
   if x > 0#i64
@@ -9799,7 +9799,7 @@ def num.I64.signum (x : Std.I64) : Result Std.I64 := do
        else ok (-1)#i64
 
 /-- [core_models::num::{core_models::num::i128}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.I128.signum (x : Std.I128) : Result Std.I128 := do
   if x > 0#i128
@@ -9809,7 +9809,7 @@ def num.I128.signum (x : Std.I128) : Result Std.I128 := do
        else ok (-1)#i128
 
 /-- [core_models::num::{core_models::num::isize}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
+    Source: 'core-models/src/core/num/mod.rs', lines 443:12-451:13
     Visibility: public -/
 def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
   if x > 0#isize
@@ -9819,7 +9819,7 @@ def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
        else ok (-1)#isize
 
 /-- [core_models::num::{core_models::num::i8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   let d ← x / y
@@ -9840,7 +9840,7 @@ def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   let d ← x / y
@@ -9861,7 +9861,7 @@ def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   let d ← x / y
@@ -9882,7 +9882,7 @@ def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   let d ← x / y
@@ -9903,7 +9903,7 @@ def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   let d ← x / y
@@ -9924,7 +9924,7 @@ def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::isize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
+    Source: 'core-models/src/core/num/mod.rs', lines 455:12-464:13
     Visibility: public -/
 def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   let d ← x / y
@@ -9946,169 +9946,169 @@ def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
        else ok d
 
 /-- [core_models::num::{impl core_models::default::Default for u8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def U8.Insts.CoreDefaultDefault.default : Result Std.U8 := do
   ok 0#u8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def U8.Insts.CoreDefaultDefault : default.Default Std.U8 := {
   default := U8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def U16.Insts.CoreDefaultDefault.default : Result Std.U16 := do
   ok 0#u16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def U16.Insts.CoreDefaultDefault : default.Default Std.U16 := {
   default := U16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def U32.Insts.CoreDefaultDefault.default : Result Std.U32 := do
   ok 0#u32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def U32.Insts.CoreDefaultDefault : default.Default Std.U32 := {
   default := U32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def U64.Insts.CoreDefaultDefault.default : Result Std.U64 := do
   ok 0#u64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def U64.Insts.CoreDefaultDefault : default.Default Std.U64 := {
   default := U64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def U128.Insts.CoreDefaultDefault.default : Result Std.U128 := do
   ok 0#u128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def U128.Insts.CoreDefaultDefault : default.Default Std.U128 := {
   default := U128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for usize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def Usize.Insts.CoreDefaultDefault.default : Result Std.Usize := do
   ok 0#usize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for usize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def Usize.Insts.CoreDefaultDefault : default.Default Std.Usize := {
   default := Usize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def I8.Insts.CoreDefaultDefault.default : Result Std.I8 := do
   ok 0#i8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def I8.Insts.CoreDefaultDefault : default.Default Std.I8 := {
   default := I8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def I16.Insts.CoreDefaultDefault.default : Result Std.I16 := do
   ok 0#i16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def I16.Insts.CoreDefaultDefault : default.Default Std.I16 := {
   default := I16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def I32.Insts.CoreDefaultDefault.default : Result Std.I32 := do
   ok 0#i32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def I32.Insts.CoreDefaultDefault : default.Default Std.I32 := {
   default := I32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def I64.Insts.CoreDefaultDefault.default : Result Std.I64 := do
   ok 0#i64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def I64.Insts.CoreDefaultDefault : default.Default Std.I64 := {
   default := I64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def I128.Insts.CoreDefaultDefault.default : Result Std.I128 := do
   ok 0#i128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def I128.Insts.CoreDefaultDefault : default.Default Std.I128 := {
   default := I128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for isize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
+    Source: 'core-models/src/core/num/mod.rs', lines 650:16-652:17
     Visibility: public -/
 def Isize.Insts.CoreDefaultDefault.default : Result Std.Isize := do
   ok 0#isize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for isize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 649:12-653:13 -/
 @[reducible]
 def Isize.Insts.CoreDefaultDefault : default.Default Std.Isize := {
   default := Isize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for bool}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 690:4-692:5
+    Source: 'core-models/src/core/num/mod.rs', lines 676:4-678:5
     Visibility: public -/
 def Bool.Insts.CoreDefaultDefault.default : Result Bool := do
   ok false
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for bool}]
-    Source: 'core-models/src/core/num/mod.rs', lines 688:0-693:1 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 674:0-679:1 -/
 @[reducible]
 def Bool.Insts.CoreDefaultDefault : default.Default Bool := {
   default := Bool.Insts.CoreDefaultDefault.default

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -1374,23 +1374,37 @@ def I128.Insts.CoreConvertFromU64 : convert.From Std.I128 Std.U64 := {
   «from» := I128.Insts.CoreConvertFromU64.from
 }
 
+/-
+/-- [core_models::num::{core_models::num::u8}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.U8.MAX : Std.U8 := 255#u8
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::u8}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Visibility: public -/
+@[global_simps, irreducible] def num.U8.MIN : Std.U8 := 0#u8
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromU16TryFromIntError.try_from
   (x : Std.U16) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
-  let i ← lift (UScalar.cast .U16 core.num.U8.MAX)
+  let i ← lift (UScalar.cast .U16 num.U8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U16 core.num.U8.MIN)
+    let i1 ← lift (UScalar.cast .U16 num.U8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
   Std.U8 Std.U16 num.error.TryFromIntError := {
@@ -1398,47 +1412,61 @@ def U8.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
-  let i ← lift (UScalar.cast .U32 core.num.U8.MAX)
+  let i ← lift (UScalar.cast .U32 num.U8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U32 core.num.U8.MIN)
+    let i1 ← lift (UScalar.cast .U32 num.U8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.U8 Std.U32 num.error.TryFromIntError := {
   try_from := U8.Insts.CoreConvertTryFromU32TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::u16}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.U16.MAX : Std.U16 := 65535#u16
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::u16}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Visibility: public -/
+@[global_simps, irreducible] def num.U16.MIN : Std.U16 := 0#u16
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) :
   Result (result.Result Std.U16 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U32 core.num.U16.MAX)
+  let i ← lift (UScalar.cast .U32 num.U16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U32 core.num.U16.MIN)
+    let i1 ← lift (UScalar.cast .U32 num.U16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.U16 Std.U32 num.error.TryFromIntError := {
@@ -1446,22 +1474,22 @@ def U16.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
-  let i ← lift (UScalar.cast .U64 core.num.U8.MAX)
+  let i ← lift (UScalar.cast .U64 num.U8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U64 core.num.U8.MIN)
+    let i1 ← lift (UScalar.cast .U64 num.U8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.U8 Std.U64 num.error.TryFromIntError := {
@@ -1469,74 +1497,104 @@ def U8.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.U16 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U64 core.num.U16.MAX)
+  let i ← lift (UScalar.cast .U64 num.U16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U64 core.num.U16.MIN)
+    let i1 ← lift (UScalar.cast .U64 num.U16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.U16 Std.U64 num.error.TryFromIntError := {
   try_from := U16.Insts.CoreConvertTryFromU64TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::u32}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.U32.MAX : Std.U32 := 4294967295#u32
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::u32}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Visibility: public -/
+@[global_simps, irreducible] def num.U32.MIN : Std.U32 := 0#u32
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.U32 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U64 core.num.U32.MAX)
+  let i ← lift (UScalar.cast .U64 num.U32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U64 core.num.U32.MIN)
+    let i1 ← lift (UScalar.cast .U64 num.U32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.U32 Std.U64 num.error.TryFromIntError := {
   try_from := U32.Insts.CoreConvertTryFromU64TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::usize}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.Usize.MAX : Result Std.Usize := rust_primitives.arithmetic.USIZE_MAX
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::usize}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Visibility: public -/
+@[global_simps, irreducible] def num.Usize.MIN : Std.Usize := 0#usize
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.Usize num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U64 core.num.Usize.MAX)
-  if x > i
+  let i := num.Usize.MAX
+  let i1 ← lift (UScalar.cast .U64 i)
+  if x > i1
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U64 core.num.Usize.MIN)
-    if x < i1
+    let i2 ← lift (UScalar.cast .U64 num.Usize.MIN)
+    if x < i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (UScalar.cast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (UScalar.cast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.Usize Std.U64 num.error.TryFromIntError := {
@@ -1544,24 +1602,24 @@ def Usize.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.U8 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U128 core.num.U8.MAX)
+  let i ← lift (UScalar.cast .U128 num.U8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MIN)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.U8 Std.U128 num.error.TryFromIntError := {
@@ -1569,24 +1627,24 @@ def U8.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.U16 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U128 core.num.U16.MAX)
+  let i ← lift (UScalar.cast .U128 num.U16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MIN)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.U16 Std.U128 num.error.TryFromIntError := {
@@ -1594,49 +1652,64 @@ def U16.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.U32 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U128 core.num.U32.MAX)
+  let i ← lift (UScalar.cast .U128 num.U32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MIN)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.U32 Std.U128 num.error.TryFromIntError := {
   try_from := U32.Insts.CoreConvertTryFromU128TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::u64}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.U64.MAX : Std.U64 := 18446744073709551615#u64
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::u64}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Visibility: public -/
+@[global_simps, irreducible] def num.U64.MIN : Std.U64 := 0#u64
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.U64 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U128 core.num.U64.MAX)
+  let i ← lift (UScalar.cast .U128 num.U64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MIN)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.U64 Std.U128 num.error.TryFromIntError := {
@@ -1644,24 +1717,25 @@ def U64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.Usize num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-  if x > i
+  let i := num.Usize.MAX
+  let i1 ← lift (UScalar.cast .U128 i)
+  if x > i1
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MIN)
-    if x < i1
+    let i2 ← lift (UScalar.cast .U128 num.Usize.MIN)
+    if x < i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (UScalar.cast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (UScalar.cast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.Usize Std.U128 num.error.TryFromIntError := {
@@ -1669,24 +1743,24 @@ def Usize.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.U8 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .Usize core.num.U8.MAX)
+  let i ← lift (UScalar.cast .Usize num.U8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .Usize core.num.U8.MIN)
+    let i1 ← lift (UScalar.cast .Usize num.U8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.U8 Std.Usize num.error.TryFromIntError := {
@@ -1694,24 +1768,24 @@ def U8.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.U16 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .Usize core.num.U16.MAX)
+  let i ← lift (UScalar.cast .Usize num.U16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .Usize core.num.U16.MIN)
+    let i1 ← lift (UScalar.cast .Usize num.U16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.U16 Std.Usize num.error.TryFromIntError := {
@@ -1719,24 +1793,24 @@ def U16.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.U32 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .Usize core.num.U32.MAX)
+  let i ← lift (UScalar.cast .Usize num.U32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .Usize core.num.U32.MIN)
+    let i1 ← lift (UScalar.cast .Usize num.U32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.U32 Std.Usize num.error.TryFromIntError := {
@@ -1744,47 +1818,61 @@ def U32.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.U64 num.error.TryFromIntError)
   := do
-  let i ← lift (UScalar.cast .Usize core.num.U64.MAX)
+  let i ← lift (UScalar.cast .Usize num.U64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (UScalar.cast .Usize core.num.U64.MIN)
+    let i1 ← lift (UScalar.cast .Usize num.U64.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (UScalar.cast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.U64 Std.Usize num.error.TryFromIntError := {
   try_from := U64.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::i8}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I8.MAX : Std.I8 := 127#i8
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::i8}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I8.MIN : Std.I8 := (-128)#i8
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.cast .I16 core.num.I8.MAX)
+  let i ← lift (IScalar.cast .I16 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I16 core.num.I8.MIN)
+    let i1 ← lift (IScalar.cast .I16 num.I8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.I8 Std.I16 num.error.TryFromIntError := {
@@ -1792,47 +1880,61 @@ def I8.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.cast .I32 core.num.I8.MAX)
+  let i ← lift (IScalar.cast .I32 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I32 core.num.I8.MIN)
+    let i1 ← lift (IScalar.cast .I32 num.I8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.I8 Std.I32 num.error.TryFromIntError := {
   try_from := I8.Insts.CoreConvertTryFromI32TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::i16}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I16.MAX : Std.I16 := 32767#i16
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::i16}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I16.MIN : Std.I16 := (-32768)#i16
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I32 core.num.I16.MAX)
+  let i ← lift (IScalar.cast .I32 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I32 core.num.I16.MIN)
+    let i1 ← lift (IScalar.cast .I32 num.I16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.I16 Std.I32 num.error.TryFromIntError := {
@@ -1840,22 +1942,22 @@ def I16.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.cast .I64 core.num.I8.MAX)
+  let i ← lift (IScalar.cast .I64 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I64 core.num.I8.MIN)
+    let i1 ← lift (IScalar.cast .I64 num.I8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.I8 Std.I64 num.error.TryFromIntError := {
@@ -1863,74 +1965,106 @@ def I8.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I64 core.num.I16.MAX)
+  let i ← lift (IScalar.cast .I64 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I64 core.num.I16.MIN)
+    let i1 ← lift (IScalar.cast .I64 num.I16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.I16 Std.I64 num.error.TryFromIntError := {
   try_from := I16.Insts.CoreConvertTryFromI64TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::i32}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I32.MAX : Std.I32 := 2147483647#i32
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::i32}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Visibility: public -/
+@[global_simps, irreducible] def num.I32.MIN : Std.I32 := (-2147483648)#i32
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I64 core.num.I32.MAX)
+  let i ← lift (IScalar.cast .I64 num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I64 core.num.I32.MIN)
+    let i1 ← lift (IScalar.cast .I64 num.I32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.I32 Std.I64 num.error.TryFromIntError := {
   try_from := I32.Insts.CoreConvertTryFromI64TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::isize}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::isize}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.Isize.MIN : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MIN
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for isize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def Isize.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
   Result (result.Result Std.Isize num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I64 core.num.Isize.MAX)
-  if x > i
+  let i := num.Isize.MAX
+  let i1 ← lift (IScalar.cast .I64 i)
+  if x > i1
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I64 core.num.Isize.MIN)
-    if x < i1
+    let i2 := num.Isize.MIN
+    let i3 ← lift (IScalar.cast .I64 i2)
+    if x < i3
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.cast .Isize x)
-         ok (result.Result.Ok i2)
+    else let i4 ← lift (IScalar.cast .Isize x)
+         ok (result.Result.Ok i4)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for isize}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def Isize.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.Isize Std.I64 num.error.TryFromIntError := {
@@ -1938,24 +2072,24 @@ def Isize.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
   Result (result.Result Std.I8 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I128 core.num.I8.MAX)
+  let i ← lift (IScalar.cast .I128 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I128 core.num.I8.MIN)
+    let i1 ← lift (IScalar.cast .I128 num.I8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.I8 Std.I128 num.error.TryFromIntError := {
@@ -1963,24 +2097,24 @@ def I8.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I128 core.num.I16.MAX)
+  let i ← lift (IScalar.cast .I128 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I128 core.num.I16.MIN)
+    let i1 ← lift (IScalar.cast .I128 num.I16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.I16 Std.I128 num.error.TryFromIntError := {
@@ -1988,49 +2122,65 @@ def I16.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I128 core.num.I32.MAX)
+  let i ← lift (IScalar.cast .I128 num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I128 core.num.I32.MIN)
+    let i1 ← lift (IScalar.cast .I128 num.I32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.I32 Std.I128 num.error.TryFromIntError := {
   try_from := I32.Insts.CoreConvertTryFromI128TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::i64}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.I64.MAX : Std.I64 := 9223372036854775807#i64
+-/  -- provided by CoreModels.Core.FunsPrologue
+
+/-
+/-- [core_models::num::{core_models::num::i64}::MIN]
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.I64.MIN : Std.I64 := (-9223372036854775808)#i64
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I64.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
   Result (result.Result Std.I64 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I128 core.num.I64.MAX)
+  let i ← lift (IScalar.cast .I128 num.I64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I128 core.num.I64.MIN)
+    let i1 ← lift (IScalar.cast .I128 num.I64.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for i64}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I64.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.I64 Std.I128 num.error.TryFromIntError := {
@@ -2038,24 +2188,26 @@ def I64.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for isize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def Isize.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
   Result (result.Result Std.Isize num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .I128 core.num.Isize.MAX)
-  if x > i
+  let i := num.Isize.MAX
+  let i1 ← lift (IScalar.cast .I128 i)
+  if x > i1
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .I128 core.num.Isize.MIN)
-    if x < i1
+    let i2 := num.Isize.MIN
+    let i3 ← lift (IScalar.cast .I128 i2)
+    if x < i3
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.cast .Isize x)
-         ok (result.Result.Ok i2)
+    else let i4 ← lift (IScalar.cast .Isize x)
+         ok (result.Result.Ok i4)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for isize}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def Isize.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.Isize Std.I128 num.error.TryFromIntError := {
@@ -2063,24 +2215,24 @@ def Isize.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
   Result (result.Result Std.I8 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .Isize core.num.I8.MAX)
+  let i ← lift (IScalar.cast .Isize num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .Isize core.num.I8.MIN)
+    let i1 ← lift (IScalar.cast .Isize num.I8.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.I8 Std.Isize num.error.TryFromIntError := {
@@ -2088,24 +2240,24 @@ def I8.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .Isize core.num.I16.MAX)
+  let i ← lift (IScalar.cast .Isize num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .Isize core.num.I16.MIN)
+    let i1 ← lift (IScalar.cast .Isize num.I16.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.I16 Std.Isize num.error.TryFromIntError := {
@@ -2113,24 +2265,24 @@ def I16.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .Isize core.num.I32.MAX)
+  let i ← lift (IScalar.cast .Isize num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .Isize core.num.I32.MIN)
+    let i1 ← lift (IScalar.cast .Isize num.I32.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.I32 Std.Isize num.error.TryFromIntError := {
@@ -2138,24 +2290,24 @@ def I32.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 124:16-130:17
+    Source: 'core-models/src/core/convert.rs', lines 126:16-132:17
     Visibility: public -/
 def I64.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
   Result (result.Result Std.I64 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.cast .Isize core.num.I64.MAX)
+  let i ← lift (IScalar.cast .Isize num.I64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else
-    let i1 ← lift (IScalar.cast .Isize core.num.I64.MIN)
+    let i1 ← lift (IScalar.cast .Isize num.I64.MIN)
     if x < i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.cast .I64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i64}]
-    Source: 'core-models/src/core/convert.rs', lines 122:12-131:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 124:12-133:13 -/
 @[reducible]
 def I64.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.I64 Std.Isize num.error.TryFromIntError := {
@@ -2163,7 +2315,7 @@ def I64.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for isize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 145:16-147:17
+    Source: 'core-models/src/core/convert.rs', lines 147:16-149:17
     Visibility: public -/
 def Isize.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -2173,7 +2325,7 @@ def Isize.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   ok (result.Result.Ok i)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for isize}]
-    Source: 'core-models/src/core/convert.rs', lines 143:12-148:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 145:12-150:13 -/
 @[reducible]
 def Isize.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.Isize Std.I32 num.error.TryFromIntError := {
@@ -2181,7 +2333,7 @@ def Isize.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 145:16-147:17
+    Source: 'core-models/src/core/convert.rs', lines 147:16-149:17
     Visibility: public -/
 def I128.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -2191,7 +2343,7 @@ def I128.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   ok (result.Result.Ok i)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for i128}]
-    Source: 'core-models/src/core/convert.rs', lines 143:12-148:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 145:12-150:13 -/
 @[reducible]
 def I128.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.I128 Std.Isize num.error.TryFromIntError := {
@@ -2199,7 +2351,7 @@ def I128.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 145:16-147:17
+    Source: 'core-models/src/core/convert.rs', lines 147:16-149:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) :
@@ -2209,7 +2361,7 @@ def Usize.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   ok (result.Result.Ok i)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 143:12-148:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 145:12-150:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.Usize Std.U32 num.error.TryFromIntError := {
@@ -2217,7 +2369,7 @@ def Usize.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 145:16-147:17
+    Source: 'core-models/src/core/convert.rs', lines 147:16-149:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
@@ -2227,7 +2379,7 @@ def U128.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   ok (result.Result.Ok i)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 143:12-148:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 145:12-150:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.U128 Std.Usize num.error.TryFromIntError := {
@@ -2235,18 +2387,18 @@ def U128.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u8, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromU8TryFromIntError.try_from
   (x : Std.U8) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.hcast .U8 core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .U8 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u8, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromU8TryFromIntError : convert.TryFrom
   Std.I8 Std.U8 num.error.TryFromIntError := {
@@ -2254,18 +2406,18 @@ def I8.Insts.CoreConvertTryFromU8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromU16TryFromIntError.try_from
   (x : Std.U16) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.hcast .U16 core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .U16 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
   Std.I8 Std.U16 num.error.TryFromIntError := {
@@ -2273,20 +2425,20 @@ def I8.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromU16TryFromIntError.try_from
   (x : Std.U16) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U16 core.num.I16.MAX)
+  let i ← lift (IScalar.hcast .U16 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I16 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u16, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
   Std.I16 Std.U16 num.error.TryFromIntError := {
@@ -2294,18 +2446,18 @@ def I16.Insts.CoreConvertTryFromU16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.hcast .U32 core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .U32 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.I8 Std.U32 num.error.TryFromIntError := {
@@ -2313,20 +2465,20 @@ def I8.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U32 core.num.I16.MAX)
+  let i ← lift (IScalar.hcast .U32 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I16 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.I16 Std.U32 num.error.TryFromIntError := {
@@ -2334,20 +2486,20 @@ def I16.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromU32TryFromIntError.try_from
   (x : Std.U32) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U32 core.num.I32.MAX)
+  let i ← lift (IScalar.hcast .U32 num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I32 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u32, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
   Std.I32 Std.U32 num.error.TryFromIntError := {
@@ -2355,18 +2507,18 @@ def I32.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) : Result (result.Result Std.I8 num.error.TryFromIntError) := do
-  let i ← lift (IScalar.hcast .U64 core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .U64 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.I8 Std.U64 num.error.TryFromIntError := {
@@ -2374,20 +2526,20 @@ def I8.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U64 core.num.I16.MAX)
+  let i ← lift (IScalar.hcast .U64 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I16 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.I16 Std.U64 num.error.TryFromIntError := {
@@ -2395,20 +2547,20 @@ def I16.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U64 core.num.I32.MAX)
+  let i ← lift (IScalar.hcast .U64 num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I32 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.I32 Std.U64 num.error.TryFromIntError := {
@@ -2416,20 +2568,20 @@ def I32.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I64.Insts.CoreConvertTryFromU64TryFromIntError.try_from
   (x : Std.U64) :
   Result (result.Result Std.I64 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U64 core.num.I64.MAX)
+  let i ← lift (IScalar.hcast .U64 num.I64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I64 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u64, core_models::num::error::TryFromIntError> for i64}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I64.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
   Std.I64 Std.U64 num.error.TryFromIntError := {
@@ -2437,20 +2589,20 @@ def I64.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.I8 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U128 core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .U128 num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.I8 Std.U128 num.error.TryFromIntError := {
@@ -2458,20 +2610,20 @@ def I8.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U128 core.num.I16.MAX)
+  let i ← lift (IScalar.hcast .U128 num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I16 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.I16 Std.U128 num.error.TryFromIntError := {
@@ -2479,20 +2631,20 @@ def I16.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U128 core.num.I32.MAX)
+  let i ← lift (IScalar.hcast .U128 num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I32 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.I32 Std.U128 num.error.TryFromIntError := {
@@ -2500,41 +2652,49 @@ def I32.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I64.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.I64 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U128 core.num.I64.MAX)
+  let i ← lift (IScalar.hcast .U128 num.I64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I64 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i64}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.I64 Std.U128 num.error.TryFromIntError := {
   try_from := I64.Insts.CoreConvertTryFromU128TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::i128}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 256:12-256:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.I128.MAX : Std.I128 := 170141183460469231731687303715884105727#i128
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I128.Insts.CoreConvertTryFromU128TryFromIntError.try_from
   (x : Std.U128) :
   Result (result.Result Std.I128 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .U128 core.num.I128.MAX)
+  let i ← lift (IScalar.hcast .U128 num.I128.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I128 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<u128, core_models::num::error::TryFromIntError> for i128}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I128.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
   Std.I128 Std.U128 num.error.TryFromIntError := {
@@ -2542,20 +2702,20 @@ def I128.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I8.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.I8 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .Usize core.num.I8.MAX)
+  let i ← lift (IScalar.hcast .Usize num.I8.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I8 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i8}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I8.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.I8 Std.Usize num.error.TryFromIntError := {
@@ -2563,20 +2723,20 @@ def I8.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I16.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.I16 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .Usize core.num.I16.MAX)
+  let i ← lift (IScalar.hcast .Usize num.I16.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I16 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i16}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I16.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.I16 Std.Usize num.error.TryFromIntError := {
@@ -2584,20 +2744,20 @@ def I16.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I32.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.I32 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .Usize core.num.I32.MAX)
+  let i ← lift (IScalar.hcast .Usize num.I32.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I32 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i32}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I32.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.I32 Std.Usize num.error.TryFromIntError := {
@@ -2605,20 +2765,20 @@ def I32.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def I64.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.I64 num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .Usize core.num.I64.MAX)
+  let i ← lift (IScalar.hcast .Usize num.I64.MAX)
   if x > i
   then ok (result.Result.Err ())
   else let i1 ← lift (UScalar.hcast .I64 x)
        ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for i64}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def I64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.I64 Std.Usize num.error.TryFromIntError := {
@@ -2626,20 +2786,21 @@ def I64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for isize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 193:16-199:17
+    Source: 'core-models/src/core/convert.rs', lines 195:16-201:17
     Visibility: public -/
 def Isize.Insts.CoreConvertTryFromUsizeTryFromIntError.try_from
   (x : Std.Usize) :
   Result (result.Result Std.Isize num.error.TryFromIntError)
   := do
-  let i ← lift (IScalar.hcast .Usize core.num.Isize.MAX)
-  if x > i
+  let i := num.Isize.MAX
+  let i1 ← lift (IScalar.hcast .Usize i)
+  if x > i1
   then ok (result.Result.Err ())
-  else let i1 ← lift (UScalar.hcast .Isize x)
-       ok (result.Result.Ok i1)
+  else let i2 ← lift (UScalar.hcast .Isize x)
+       ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<usize, core_models::num::error::TryFromIntError> for isize}]
-    Source: 'core-models/src/core/convert.rs', lines 191:12-200:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 193:12-202:13 -/
 @[reducible]
 def Isize.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
   Std.Isize Std.Usize num.error.TryFromIntError := {
@@ -2648,7 +2809,7 @@ def Isize.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
@@ -2656,14 +2817,14 @@ def U8.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.U8 Std.I8 num.error.TryFromIntError := {
@@ -2671,7 +2832,7 @@ def U8.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) : Result (result.Result Std.U16 num.error.TryFromIntError) := do
@@ -2679,14 +2840,14 @@ def U16.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.U16 Std.I8 num.error.TryFromIntError := {
@@ -2694,7 +2855,7 @@ def U16.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) : Result (result.Result Std.U32 num.error.TryFromIntError) := do
@@ -2702,14 +2863,14 @@ def U32.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.U32 Std.I8 num.error.TryFromIntError := {
@@ -2717,7 +2878,7 @@ def U32.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) : Result (result.Result Std.U64 num.error.TryFromIntError) := do
@@ -2725,22 +2886,30 @@ def U64.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.U64 Std.I8 num.error.TryFromIntError := {
   try_from := U64.Insts.CoreConvertTryFromI8TryFromIntError.try_from
 }
 
+/-
+/-- [core_models::num::{core_models::num::u128}::MAX]
+    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Visibility: public -/
+@[global_simps, irreducible]
+def num.U128.MAX : Std.U128 := 340282366920938463463374607431768211455#u128
+-/  -- provided by CoreModels.Core.FunsPrologue
+
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) :
@@ -2750,13 +2919,13 @@ def U128.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.U128 Std.I8 num.error.TryFromIntError := {
@@ -2764,7 +2933,7 @@ def U128.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   (x : Std.I8) :
@@ -2774,14 +2943,15 @@ def Usize.Insts.CoreConvertTryFromI8TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i8, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
   Std.Usize Std.I8 num.error.TryFromIntError := {
@@ -2789,7 +2959,7 @@ def Usize.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
@@ -2797,14 +2967,14 @@ def U8.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.U8 Std.I16 num.error.TryFromIntError := {
@@ -2812,7 +2982,7 @@ def U8.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) :
@@ -2822,14 +2992,14 @@ def U16.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.U16 Std.I16 num.error.TryFromIntError := {
@@ -2837,7 +3007,7 @@ def U16.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) :
@@ -2847,14 +3017,14 @@ def U32.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.U32 Std.I16 num.error.TryFromIntError := {
@@ -2862,7 +3032,7 @@ def U32.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) :
@@ -2872,14 +3042,14 @@ def U64.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.U64 Std.I16 num.error.TryFromIntError := {
@@ -2887,7 +3057,7 @@ def U64.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) :
@@ -2897,13 +3067,13 @@ def U128.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.U128 Std.I16 num.error.TryFromIntError := {
@@ -2911,7 +3081,7 @@ def U128.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   (x : Std.I16) :
@@ -2921,14 +3091,15 @@ def Usize.Insts.CoreConvertTryFromI16TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i16, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
   Std.Usize Std.I16 num.error.TryFromIntError := {
@@ -2936,7 +3107,7 @@ def Usize.Insts.CoreConvertTryFromI16TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
@@ -2944,14 +3115,14 @@ def U8.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.U8 Std.I32 num.error.TryFromIntError := {
@@ -2959,7 +3130,7 @@ def U8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -2969,14 +3140,14 @@ def U16.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.U16 Std.I32 num.error.TryFromIntError := {
@@ -2984,7 +3155,7 @@ def U16.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -2994,14 +3165,14 @@ def U32.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.U32 Std.I32 num.error.TryFromIntError := {
@@ -3009,7 +3180,7 @@ def U32.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -3019,14 +3190,14 @@ def U64.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.U64 Std.I32 num.error.TryFromIntError := {
@@ -3034,7 +3205,7 @@ def U64.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -3044,13 +3215,13 @@ def U128.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.U128 Std.I32 num.error.TryFromIntError := {
@@ -3058,7 +3229,7 @@ def U128.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   (x : Std.I32) :
@@ -3068,14 +3239,15 @@ def Usize.Insts.CoreConvertTryFromI32TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i32, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
   Std.Usize Std.I32 num.error.TryFromIntError := {
@@ -3083,7 +3255,7 @@ def Usize.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) : Result (result.Result Std.U8 num.error.TryFromIntError) := do
@@ -3091,14 +3263,14 @@ def U8.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.U8 Std.I64 num.error.TryFromIntError := {
@@ -3106,7 +3278,7 @@ def U8.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
@@ -3116,14 +3288,14 @@ def U16.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.U16 Std.I64 num.error.TryFromIntError := {
@@ -3131,7 +3303,7 @@ def U16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
@@ -3141,14 +3313,14 @@ def U32.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.U32 Std.I64 num.error.TryFromIntError := {
@@ -3156,7 +3328,7 @@ def U32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
@@ -3166,14 +3338,14 @@ def U64.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.U64 Std.I64 num.error.TryFromIntError := {
@@ -3181,7 +3353,7 @@ def U64.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
@@ -3191,13 +3363,13 @@ def U128.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.U128 Std.I64 num.error.TryFromIntError := {
@@ -3205,7 +3377,7 @@ def U128.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   (x : Std.I64) :
@@ -3215,14 +3387,15 @@ def Usize.Insts.CoreConvertTryFromI64TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i64, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
   Std.Usize Std.I64 num.error.TryFromIntError := {
@@ -3230,7 +3403,7 @@ def Usize.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3240,14 +3413,14 @@ def U8.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.U8 Std.I128 num.error.TryFromIntError := {
@@ -3255,7 +3428,7 @@ def U8.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3265,14 +3438,14 @@ def U16.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.U16 Std.I128 num.error.TryFromIntError := {
@@ -3280,7 +3453,7 @@ def U16.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3290,14 +3463,14 @@ def U32.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.U32 Std.I128 num.error.TryFromIntError := {
@@ -3305,7 +3478,7 @@ def U32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3315,14 +3488,14 @@ def U64.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.U64 Std.I128 num.error.TryFromIntError := {
@@ -3330,7 +3503,7 @@ def U64.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3340,13 +3513,13 @@ def U128.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.U128 Std.I128 num.error.TryFromIntError := {
@@ -3354,7 +3527,7 @@ def U128.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   (x : Std.I128) :
@@ -3364,14 +3537,15 @@ def Usize.Insts.CoreConvertTryFromI128TryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<i128, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
   Std.Usize Std.I128 num.error.TryFromIntError := {
@@ -3379,7 +3553,7 @@ def Usize.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u8}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U8.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3389,14 +3563,14 @@ def U8.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U8.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U8.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U8 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u8}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U8.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.U8 Std.Isize num.error.TryFromIntError := {
@@ -3404,7 +3578,7 @@ def U8.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u16}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U16.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3414,14 +3588,14 @@ def U16.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U16.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U16.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U16 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u16}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U16.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.U16 Std.Isize num.error.TryFromIntError := {
@@ -3429,7 +3603,7 @@ def U16.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u32}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U32.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3439,14 +3613,14 @@ def U32.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U32.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U32.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U32 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u32}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U32.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.U32 Std.Isize num.error.TryFromIntError := {
@@ -3454,7 +3628,7 @@ def U32.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u64}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U64.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3464,14 +3638,14 @@ def U64.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.U64.MAX)
+    let i1 ← lift (UScalar.cast .U128 num.U64.MAX)
     if i > i1
     then ok (result.Result.Err ())
     else let i2 ← lift (IScalar.hcast .U64 x)
          ok (result.Result.Ok i2)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u64}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U64.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.U64 Std.Isize num.error.TryFromIntError := {
@@ -3479,7 +3653,7 @@ def U64.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u128}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def U128.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3489,13 +3663,13 @@ def U128.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    if i > core.num.U128.MAX
+    if i > num.U128.MAX
     then ok (result.Result.Err ())
     else let i1 ← lift (IScalar.hcast .U128 x)
          ok (result.Result.Ok i1)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for u128}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def U128.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.U128 Std.Isize num.error.TryFromIntError := {
@@ -3503,7 +3677,7 @@ def U128.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
 }
 
 /-- [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for usize}::try_from]:
-    Source: 'core-models/src/core/convert.rs', lines 215:16-221:17
+    Source: 'core-models/src/core/convert.rs', lines 217:16-223:17
     Visibility: public -/
 def Usize.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   (x : Std.Isize) :
@@ -3513,14 +3687,15 @@ def Usize.Insts.CoreConvertTryFromIsizeTryFromIntError.try_from
   then ok (result.Result.Err ())
   else
     let i ← lift (IScalar.hcast .U128 x)
-    let i1 ← lift (UScalar.cast .U128 core.num.Usize.MAX)
-    if i > i1
+    let i1 := num.Usize.MAX
+    let i2 ← lift (UScalar.cast .U128 i1)
+    if i > i2
     then ok (result.Result.Err ())
-    else let i2 ← lift (IScalar.hcast .Usize x)
-         ok (result.Result.Ok i2)
+    else let i3 ← lift (IScalar.hcast .Usize x)
+         ok (result.Result.Ok i3)
 
 /-- Trait implementation: [core_models::convert::{impl core_models::convert::TryFrom<isize, core_models::num::error::TryFromIntError> for usize}]
-    Source: 'core-models/src/core/convert.rs', lines 212:12-222:13 -/
+    Source: 'core-models/src/core/convert.rs', lines 214:12-224:13 -/
 @[reducible]
 def Usize.Insts.CoreConvertTryFromIsizeTryFromIntError : convert.TryFrom
   Std.Usize Std.Isize num.error.TryFromIntError := {
@@ -5210,21 +5385,14 @@ def option.Option.unwrap {T : Type} (self : option.Option T) : Result T := do
   | option.Option.None => panicking.internal.panic T
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I8.overflowing_add
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i8 x y
 
-/-
-/-- [core_models::num::{core_models::num::i8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I8.MAX : Std.I8 := 127#i8
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i8}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.I8.checked_add_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5245,21 +5413,14 @@ def I8.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I16.overflowing_add
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i16 x y
 
-/-
-/-- [core_models::num::{core_models::num::i16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I16.MAX : Std.I16 := 32767#i16
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i16}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.I16.checked_add_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5280,21 +5441,14 @@ def I16.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I32.overflowing_add
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i32 x y
 
-/-
-/-- [core_models::num::{core_models::num::i32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I32.MAX : Std.I32 := 2147483647#i32
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i32}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.I32.checked_add_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5315,22 +5469,14 @@ def I32.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I64.overflowing_add
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i64 x y
 
-/-
-/-- [core_models::num::{core_models::num::i64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.I64.MAX : Std.I64 := 9223372036854775807#i64
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i64}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.I64.checked_add_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5351,22 +5497,14 @@ def I64.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.Isize.overflowing_add
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_isize x y
 
-/-
-/-- [core_models::num::{core_models::num::isize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.Isize.MAX : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::isize}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.Isize.checked_add_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5387,22 +5525,14 @@ def Isize.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 264:12-266:13
+    Source: 'core-models/src/core/num/mod.rs', lines 267:12-269:13
     Visibility: public -/
 def num.I128.overflowing_add
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i128 x y
 
-/-
-/-- [core_models::num::{core_models::num::i128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 253:12-253:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.I128.MAX : Std.I128 := 170141183460469231731687303715884105727#i128
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i128}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-320:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-323:13
     Visibility: public -/
 def num.I128.checked_add_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5423,14 +5553,14 @@ def I128.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.I8.overflowing_sub
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I8.checked_sub_unsigned
   (x : Std.I8) (y : Std.U8) : Result (option.Option Std.I8) := do
@@ -5451,14 +5581,14 @@ def I8.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.I16.overflowing_sub
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I16.checked_sub_unsigned
   (x : Std.I16) (y : Std.U16) : Result (option.Option Std.I16) := do
@@ -5479,14 +5609,14 @@ def I16.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.I32.overflowing_sub
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I32.checked_sub_unsigned
   (x : Std.I32) (y : Std.U32) : Result (option.Option Std.I32) := do
@@ -5507,14 +5637,14 @@ def I32.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.I64.overflowing_sub
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I64.checked_sub_unsigned
   (x : Std.I64) (y : Std.U64) : Result (option.Option Std.I64) := do
@@ -5535,14 +5665,14 @@ def I64.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.Isize.overflowing_sub
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.Isize.checked_sub_unsigned
   (x : Std.Isize) (y : Std.Usize) : Result (option.Option Std.Isize) := do
@@ -5563,14 +5693,14 @@ def Isize.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 291:12-293:13
+    Source: 'core-models/src/core/num/mod.rs', lines 294:12-296:13
     Visibility: public -/
 def num.I128.overflowing_sub
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 323:12-330:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I128.checked_sub_unsigned
   (x : Std.I128) (y : Std.U128) : Result (option.Option Std.I128) := do
@@ -5591,7 +5721,7 @@ def I128.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U8.unchecked_add (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x + y
@@ -5605,7 +5735,7 @@ def U8.Insts.CoreIterRangeStep.forward_unchecked
   num.U8.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U16.unchecked_add (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x + y
@@ -5619,7 +5749,7 @@ def U16.Insts.CoreIterRangeStep.forward_unchecked
   num.U16.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U32.unchecked_add (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x + y
@@ -5633,7 +5763,7 @@ def U32.Insts.CoreIterRangeStep.forward_unchecked
   num.U32.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U64.unchecked_add (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x + y
@@ -5647,7 +5777,7 @@ def U64.Insts.CoreIterRangeStep.forward_unchecked
   num.U64.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.Usize.unchecked_add
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
@@ -5661,7 +5791,7 @@ def Usize.Insts.CoreIterRangeStep.forward_unchecked
   num.Usize.unchecked_add start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 51:12-53:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U128.unchecked_add
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
@@ -5676,7 +5806,7 @@ def U128.Insts.CoreIterRangeStep.forward_unchecked
   num.U128.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.U8.unchecked_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x - y
@@ -5690,7 +5820,7 @@ def U8.Insts.CoreIterRangeStep.backward_unchecked
   num.U8.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.U16.unchecked_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x - y
@@ -5704,7 +5834,7 @@ def U16.Insts.CoreIterRangeStep.backward_unchecked
   num.U16.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.U32.unchecked_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x - y
@@ -5718,7 +5848,7 @@ def U32.Insts.CoreIterRangeStep.backward_unchecked
   num.U32.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.U64.unchecked_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x - y
@@ -5732,7 +5862,7 @@ def U64.Insts.CoreIterRangeStep.backward_unchecked
   num.U64.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.Usize.unchecked_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
@@ -5746,7 +5876,7 @@ def Usize.Insts.CoreIterRangeStep.backward_unchecked
   num.Usize.unchecked_sub start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 78:12-80:13
+    Source: 'core-models/src/core/num/mod.rs', lines 81:12-83:13
     Visibility: public -/
 def num.U128.unchecked_sub
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
@@ -5761,14 +5891,14 @@ def U128.Insts.CoreIterRangeStep.backward_unchecked
   num.U128.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.U8.overflowing_add
   (x : Std.U8) (y : Std.U8) : Result (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U8.checked_add
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -5796,7 +5926,7 @@ def U8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.I8.wrapping_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_add_i8 x y
@@ -5825,14 +5955,14 @@ def I8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.U16.overflowing_add
   (x : Std.U16) (y : Std.U16) : Result (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U16.checked_add
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -5860,7 +5990,7 @@ def U16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.I16.wrapping_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_add_i16 x y
@@ -5889,14 +6019,14 @@ def I16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.U32.overflowing_add
   (x : Std.U32) (y : Std.U32) : Result (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U32.checked_add
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -5924,7 +6054,7 @@ def U32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.I32.wrapping_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_add_i32 x y
@@ -5953,14 +6083,14 @@ def I32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.U64.overflowing_add
   (x : Std.U64) (y : Std.U64) : Result (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U64.checked_add
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -5988,7 +6118,7 @@ def U64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.I64.wrapping_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_add_i64 x y
@@ -6017,14 +6147,14 @@ def I64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.Usize.overflowing_add
   (x : Std.Usize) (y : Std.Usize) : Result (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.Usize.checked_add
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -6054,7 +6184,7 @@ def Usize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.Isize.wrapping_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6086,14 +6216,14 @@ def Isize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
+    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
     Visibility: public -/
 def num.U128.overflowing_add
   (x : Std.U128) (y : Std.U128) : Result (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 41:12-48:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U128.checked_add
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -6119,7 +6249,7 @@ def U128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.I128.checked_add
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -6145,14 +6275,14 @@ def I128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U8.overflowing_sub
   (x : Std.U8) (y : Std.U8) : Result (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.U8.checked_sub
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -6180,7 +6310,7 @@ def U8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.I8.wrapping_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_sub_i8 x y
@@ -6209,14 +6339,14 @@ def I8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U16.overflowing_sub
   (x : Std.U16) (y : Std.U16) : Result (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.U16.checked_sub
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -6244,7 +6374,7 @@ def U16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.I16.wrapping_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_sub_i16 x y
@@ -6273,14 +6403,14 @@ def I16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U32.overflowing_sub
   (x : Std.U32) (y : Std.U32) : Result (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.U32.checked_sub
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -6308,7 +6438,7 @@ def U32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.I32.wrapping_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_sub_i32 x y
@@ -6337,14 +6467,14 @@ def I32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U64.overflowing_sub
   (x : Std.U64) (y : Std.U64) : Result (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.U64.checked_sub
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -6372,7 +6502,7 @@ def U64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.I64.wrapping_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_sub_i64 x y
@@ -6401,14 +6531,14 @@ def I64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.Usize.overflowing_sub
   (x : Std.Usize) (y : Std.Usize) : Result (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.Usize.checked_sub
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -6438,7 +6568,7 @@ def Usize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.Isize.wrapping_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
@@ -6470,14 +6600,14 @@ def Isize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 63:12-65:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U128.overflowing_sub
   (x : Std.U128) (y : Std.U128) : Result (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 68:12-75:13
+    Source: 'core-models/src/core/num/mod.rs', lines 71:12-78:13
     Visibility: public -/
 def num.U128.checked_sub
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -6503,7 +6633,7 @@ def U128.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.I128.checked_sub
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -7097,392 +7227,312 @@ def mem.transmute {Src : Type} (Dst : Type) (src : Src) : Result Dst := do
   fail Error.panic
 
 /-
-/-- [core_models::num::{core_models::num::u8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
-    Visibility: public -/
-@[global_simps, irreducible] def num.U8.MIN : Std.U8 := 0#u8
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
-    Visibility: public -/
-@[global_simps, irreducible] def num.U16.MIN : Std.U16 := 0#u16
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
-    Visibility: public -/
-@[global_simps, irreducible] def num.U32.MIN : Std.U32 := 0#u32
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
-    Visibility: public -/
-@[global_simps, irreducible] def num.U64.MIN : Std.U64 := 0#u64
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
 /-- [core_models::num::{core_models::num::u128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
+    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U128.MIN : Std.U128 := 0#u128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
-/-
-/-- [core_models::num::{core_models::num::usize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 22:12-22:37
-    Visibility: public -/
-@[global_simps, irreducible] def num.Usize.MIN : Std.Usize := 0#usize
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.U8.MAX : Std.U8 := 255#u8
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.U16.MAX : Std.U16 := 65535#u16
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.U32.MAX : Std.U32 := 4294967295#u32
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.U64.MAX : Std.U64 := 18446744073709551615#u64
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::u128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.U128.MAX : Std.U128 := 340282366920938463463374607431768211455#u128
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::usize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 24:12-24:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.Usize.MAX : Result Std.Usize := rust_primitives.arithmetic.USIZE_MAX
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::u8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::u16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::u32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::u64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::u128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::usize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:57
+    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Usize.BITS : Result Std.U32 := rust_primitives.arithmetic.SIZE_BITS
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.U8.wrapping_add (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.wrapping_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.U16.wrapping_add (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.wrapping_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.U32.wrapping_add (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.wrapping_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.U64.wrapping_add (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.wrapping_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.U128.wrapping_add (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.wrapping_add_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 28:12-30:13
+    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
     Visibility: public -/
 def num.Usize.wrapping_add
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.wrapping_add_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.U8.saturating_add (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.saturating_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.U16.saturating_add (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.saturating_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.U32.saturating_add (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.saturating_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.U64.saturating_add (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.saturating_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.U128.saturating_add
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.saturating_add_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
+    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
     Visibility: public -/
 def num.Usize.saturating_add
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.saturating_add_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U8.wrapping_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.wrapping_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U16.wrapping_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.wrapping_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U32.wrapping_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.wrapping_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U64.wrapping_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.wrapping_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U128.wrapping_sub (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.wrapping_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 55:12-57:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.Usize.wrapping_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.wrapping_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U8.saturating_sub (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.saturating_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U16.saturating_sub (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.saturating_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U32.saturating_sub (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.saturating_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U64.saturating_sub (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.saturating_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U128.saturating_sub
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.saturating_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 59:12-61:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.Usize.saturating_sub
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.saturating_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.U8.wrapping_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.wrapping_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.U16.wrapping_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.wrapping_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.U32.wrapping_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.wrapping_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.U64.wrapping_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.wrapping_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.U128.wrapping_mul (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.wrapping_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 82:12-84:13
+    Source: 'core-models/src/core/num/mod.rs', lines 85:12-87:13
     Visibility: public -/
 def num.Usize.wrapping_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.wrapping_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.U8.saturating_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.saturating_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.U16.saturating_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.saturating_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.U32.saturating_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.saturating_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.U64.saturating_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.saturating_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.U128.saturating_mul
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.saturating_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 86:12-88:13
+    Source: 'core-models/src/core/num/mod.rs', lines 89:12-91:13
     Visibility: public -/
 def num.Usize.saturating_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.saturating_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.U8.overflowing_mul
   (x : Std.U8) (y : Std.U8) : Result (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.U16.overflowing_mul
   (x : Std.U16) (y : Std.U16) : Result (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.U32.overflowing_mul
   (x : Std.U32) (y : Std.U32) : Result (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.U64.overflowing_mul
   (x : Std.U64) (y : Std.U64) : Result (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.U128.overflowing_mul
   (x : Std.U128) (y : Std.U128) : Result (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 90:12-92:13
+    Source: 'core-models/src/core/num/mod.rs', lines 93:12-95:13
     Visibility: public -/
 def num.Usize.overflowing_mul
   (x : Std.Usize) (y : Std.Usize) : Result (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.U8.checked_mul
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -7492,7 +7542,7 @@ def num.U8.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.U16.checked_mul
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -7502,7 +7552,7 @@ def num.U16.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.U32.checked_mul
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -7512,7 +7562,7 @@ def num.U32.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.U64.checked_mul
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -7522,7 +7572,7 @@ def num.U64.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.U128.checked_mul
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -7532,7 +7582,7 @@ def num.U128.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::usize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 98:12-105:13
     Visibility: public -/
 def num.Usize.checked_mul
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -7542,300 +7592,300 @@ def num.Usize.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.U8.unchecked_mul (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.U16.unchecked_mul (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.U32.unchecked_mul (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.U64.unchecked_mul (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.U128.unchecked_mul
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 108:12-110:13
     Visibility: public -/
 def num.Usize.unchecked_mul
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x * y
 
 /-- [core_models::num::{core_models::num::u8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.U8.rem_euclid (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   rust_primitives.arithmetic.rem_euclid_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.U16.rem_euclid (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   rust_primitives.arithmetic.rem_euclid_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.U32.rem_euclid (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rem_euclid_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.U64.rem_euclid (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   rust_primitives.arithmetic.rem_euclid_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.U128.rem_euclid (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   rust_primitives.arithmetic.rem_euclid_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 113:12-115:13
     Visibility: public -/
 def num.Usize.rem_euclid
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   rust_primitives.arithmetic.rem_euclid_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.U8.pow (x : Std.U8) (exp : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.pow_u8 x exp
 
 /-- [core_models::num::{core_models::num::u16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.U16.pow (x : Std.U16) (exp : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.pow_u16 x exp
 
 /-- [core_models::num::{core_models::num::u32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.U32.pow (x : Std.U32) (exp : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.pow_u32 x exp
 
 /-- [core_models::num::{core_models::num::u64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.U64.pow (x : Std.U64) (exp : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.pow_u64 x exp
 
 /-- [core_models::num::{core_models::num::u128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.U128.pow (x : Std.U128) (exp : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.pow_u128 x exp
 
 /-- [core_models::num::{core_models::num::usize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 117:12-119:13
     Visibility: public -/
 def num.Usize.pow (x : Std.Usize) (exp : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.pow_usize x exp
 
 /-- [core_models::num::{core_models::num::u8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.U8.count_ones (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.U16.count_ones (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.U32.count_ones (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.U64.count_ones (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.U128.count_ones (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 121:12-123:13
     Visibility: public -/
 def num.Usize.count_ones (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_usize x
 
 /-- [core_models::num::{core_models::num::u8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.U8.rotate_right (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_right_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.U16.rotate_right (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_right_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.U32.rotate_right (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_right_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.U64.rotate_right (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_right_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.U128.rotate_right (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_right_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-125:13
+    Source: 'core-models/src/core/num/mod.rs', lines 126:12-128:13
     Visibility: public -/
 def num.Usize.rotate_right
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_right_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.U8.rotate_left (x : Std.U8) (n : Std.U32) : Result Std.U8 := do
   rust_primitives.arithmetic.rotate_left_u8 x n
 
 /-- [core_models::num::{core_models::num::u16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.U16.rotate_left (x : Std.U16) (n : Std.U32) : Result Std.U16 := do
   rust_primitives.arithmetic.rotate_left_u16 x n
 
 /-- [core_models::num::{core_models::num::u32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.U32.rotate_left (x : Std.U32) (n : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.rotate_left_u32 x n
 
 /-- [core_models::num::{core_models::num::u64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.U64.rotate_left (x : Std.U64) (n : Std.U32) : Result Std.U64 := do
   rust_primitives.arithmetic.rotate_left_u64 x n
 
 /-- [core_models::num::{core_models::num::u128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.U128.rotate_left (x : Std.U128) (n : Std.U32) : Result Std.U128 := do
   rust_primitives.arithmetic.rotate_left_u128 x n
 
 /-- [core_models::num::{core_models::num::usize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 128:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 131:12-133:13
     Visibility: public -/
 def num.Usize.rotate_left
   (x : Std.Usize) (n : Std.U32) : Result Std.Usize := do
   rust_primitives.arithmetic.rotate_left_usize x n
 
 /-- [core_models::num::{core_models::num::u8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.U8.leading_zeros (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.U16.leading_zeros (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.U32.leading_zeros (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.U64.leading_zeros (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.U128.leading_zeros (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
+    Source: 'core-models/src/core/num/mod.rs', lines 136:12-138:13
     Visibility: public -/
 def num.Usize.leading_zeros (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_usize x
 
 /-- [core_models::num::{core_models::num::u8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.U8.ilog2 (x : Std.U8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.U16.ilog2 (x : Std.U16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.U32.ilog2 (x : Std.U32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.U64.ilog2 (x : Std.U64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.U128.ilog2 (x : Std.U128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 138:12-140:13
+    Source: 'core-models/src/core/num/mod.rs', lines 141:12-143:13
     Visibility: public -/
 def num.Usize.ilog2 (x : Std.Usize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_usize x
 
 /-- [core_models::num::{core_models::num::u8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.U8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7844,7 +7894,7 @@ def num.U8.from_str_radix
   panicking.internal.panic (result.Result Std.U8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.U16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7853,7 +7903,7 @@ def num.U16.from_str_radix
   panicking.internal.panic (result.Result Std.U16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.U32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7862,7 +7912,7 @@ def num.U32.from_str_radix
   panicking.internal.panic (result.Result Std.U32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.U64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7871,7 +7921,7 @@ def num.U64.from_str_radix
   panicking.internal.panic (result.Result Std.U64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.U128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7880,7 +7930,7 @@ def num.U128.from_str_radix
   panicking.internal.panic (result.Result Std.U128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::usize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 144:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 147:12-152:13
     Visibility: public -/
 def num.Usize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -7889,159 +7939,159 @@ def num.Usize.from_str_radix
   panicking.internal.panic (result.Result Std.Usize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::u8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.U8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.U16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.U32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.U64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.U128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 155:12-157:13
     Visibility: public -/
 def num.Usize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.U8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.U8 := do
   rust_primitives.arithmetic.from_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.U16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.U16 := do
   rust_primitives.arithmetic.from_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.U32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.U32 := do
   rust_primitives.arithmetic.from_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.U64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.U64 := do
   rust_primitives.arithmetic.from_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.U128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.U128 := do
   rust_primitives.arithmetic.from_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 157:12-159:13
+    Source: 'core-models/src/core/num/mod.rs', lines 160:12-162:13
     Visibility: public -/
 def num.Usize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Usize := do
   rust_primitives.arithmetic.from_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U8.to_be_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U16.to_be_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U32.to_be_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U64.to_be_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.U128.to_be_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 162:12-164:13
+    Source: 'core-models/src/core/num/mod.rs', lines 165:12-167:13
     Visibility: public -/
 def num.Usize.to_be_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U8.to_le_bytes (bytes : Std.U8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U16.to_le_bytes (bytes : Std.U16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U32.to_le_bytes (bytes : Std.U32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U64.to_le_bytes (bytes : Std.U64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.U128.to_le_bytes
   (bytes : Std.U128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 167:12-169:13
+    Source: 'core-models/src/core/num/mod.rs', lines 170:12-172:13
     Visibility: public -/
 def num.Usize.to_le_bytes
   (bytes : Std.Usize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.U8.checked_div
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8051,7 +8101,7 @@ def num.U8.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.U16.checked_div
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8061,7 +8111,7 @@ def num.U16.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.U32.checked_div
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8071,7 +8121,7 @@ def num.U32.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.U64.checked_div
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8081,7 +8131,7 @@ def num.U64.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.U128.checked_div
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8091,7 +8141,7 @@ def num.U128.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 172:12-178:13
+    Source: 'core-models/src/core/num/mod.rs', lines 175:12-181:13
     Visibility: public -/
 def num.Usize.checked_div
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8101,45 +8151,45 @@ def num.Usize.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U8.unchecked_div (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U16.unchecked_div (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U32.unchecked_div (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U64.unchecked_div (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U128.unchecked_div
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 181:12-183:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.Usize.unchecked_div
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x / y
 
 /-- [core_models::num::{core_models::num::u8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.U8.checked_rem
   (x : Std.U8) (y : Std.U8) : Result (option.Option Std.U8) := do
@@ -8149,7 +8199,7 @@ def num.U8.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.U16.checked_rem
   (x : Std.U16) (y : Std.U16) : Result (option.Option Std.U16) := do
@@ -8159,7 +8209,7 @@ def num.U16.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.U32.checked_rem
   (x : Std.U32) (y : Std.U32) : Result (option.Option Std.U32) := do
@@ -8169,7 +8219,7 @@ def num.U32.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.U64.checked_rem
   (x : Std.U64) (y : Std.U64) : Result (option.Option Std.U64) := do
@@ -8179,7 +8229,7 @@ def num.U64.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.U128.checked_rem
   (x : Std.U128) (y : Std.U128) : Result (option.Option Std.U128) := do
@@ -8189,7 +8239,7 @@ def num.U128.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 186:12-192:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-195:13
     Visibility: public -/
 def num.Usize.checked_rem
   (x : Std.Usize) (y : Std.Usize) : Result (option.Option Std.Usize) := do
@@ -8199,45 +8249,45 @@ def num.Usize.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.U8.unchecked_rem (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.U16.unchecked_rem (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.U32.unchecked_rem (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.U64.unchecked_rem (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.U128.unchecked_rem
   (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 195:12-197:13
+    Source: 'core-models/src/core/num/mod.rs', lines 198:12-200:13
     Visibility: public -/
 def num.Usize.unchecked_rem
   (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   x % y
 
 /-- [core_models::num::{core_models::num::u8}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   if x != 0#u8
@@ -8247,7 +8297,7 @@ def num.U8.is_power_of_two (x : Std.U8) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u16}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   if x != 0#u16
@@ -8257,7 +8307,7 @@ def num.U16.is_power_of_two (x : Std.U16) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u32}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   if x != 0#u32
@@ -8267,7 +8317,7 @@ def num.U32.is_power_of_two (x : Std.U32) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u64}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   if x != 0#u64
@@ -8277,7 +8327,7 @@ def num.U64.is_power_of_two (x : Std.U64) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u128}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   if x != 0#u128
@@ -8287,7 +8337,7 @@ def num.U128.is_power_of_two (x : Std.U128) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::usize}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
+    Source: 'core-models/src/core/num/mod.rs', lines 202:12-204:13
     Visibility: public -/
 def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   if x != 0#usize
@@ -8297,7 +8347,7 @@ def num.Usize.is_power_of_two (x : Std.Usize) : Result Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   let d ← x / y
@@ -8307,7 +8357,7 @@ def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : Result Std.U8 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   let d ← x / y
@@ -8317,7 +8367,7 @@ def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : Result Std.U16 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   let d ← x / y
@@ -8327,7 +8377,7 @@ def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : Result Std.U32 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   let d ← x / y
@@ -8337,7 +8387,7 @@ def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : Result Std.U64 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   let d ← x / y
@@ -8347,7 +8397,7 @@ def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : Result Std.U128 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::usize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 204:12-208:13
+    Source: 'core-models/src/core/num/mod.rs', lines 207:12-211:13
     Visibility: public -/
 def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   let d ← x / y
@@ -8357,7 +8407,7 @@ def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : Result Std.Usize := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u8}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
   if y = 0#u8
@@ -8366,7 +8416,7 @@ def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : Result Bool := do
        ok (i = 0#u8)
 
 /-- [core_models::num::{core_models::num::u16}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
   if y = 0#u16
@@ -8375,7 +8425,7 @@ def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : Result Bool := do
        ok (i = 0#u16)
 
 /-- [core_models::num::{core_models::num::u32}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
   if y = 0#u32
@@ -8384,7 +8434,7 @@ def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : Result Bool := do
        ok (i = 0#u32)
 
 /-- [core_models::num::{core_models::num::u64}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
   if y = 0#u64
@@ -8393,7 +8443,7 @@ def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : Result Bool := do
        ok (i = 0#u64)
 
 /-- [core_models::num::{core_models::num::u128}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
   if y = 0#u128
@@ -8402,7 +8452,7 @@ def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : Result Bool := do
        ok (i = 0#u128)
 
 /-- [core_models::num::{core_models::num::usize}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 210:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 213:12-219:13
     Visibility: public -/
 def num.Usize.is_multiple_of
   (x : Std.Usize) (y : Std.Usize) : Result Bool := do
@@ -8412,127 +8462,90 @@ def num.Usize.is_multiple_of
        ok (i = 0#usize)
 
 /-
-/-- [core_models::num::{core_models::num::i8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I8.MIN : Std.I8 := (-128)#i8
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::i16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I16.MIN : Std.I16 := (-32768)#i16
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::i32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
-    Visibility: public -/
-@[global_simps, irreducible] def num.I32.MIN : Std.I32 := (-2147483648)#i32
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
-/-- [core_models::num::{core_models::num::i64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.I64.MIN : Std.I64 := (-9223372036854775808)#i64
--/  -- provided by CoreModels.Core.FunsPrologue
-
-/-
 /-- [core_models::num::{core_models::num::i128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
+    Source: 'core-models/src/core/num/mod.rs', lines 254:12-254:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MIN : Std.I128 := (-170141183460469231731687303715884105728)#i128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
-/-
-/-- [core_models::num::{core_models::num::isize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 251:12-251:40
-    Visibility: public -/
-@[global_simps, irreducible]
-def num.Isize.MIN : Result Std.Isize := rust_primitives.arithmetic.ISIZE_MIN
--/  -- provided by CoreModels.Core.FunsPrologue
-
 /-- [core_models::num::{core_models::num::i8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::i16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::i32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::i64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::i128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::isize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 255:12-255:57
+    Source: 'core-models/src/core/num/mod.rs', lines 258:12-258:57
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.BITS : Result Std.U32 := rust_primitives.arithmetic.SIZE_BITS
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 256:12-258:13
+    Source: 'core-models/src/core/num/mod.rs', lines 259:12-261:13
     Visibility: public -/
 def num.I128.wrapping_add (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.I8.saturating_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.I16.saturating_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.I32.saturating_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.I64.saturating_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.I128.saturating_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_add_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 260:12-262:13
+    Source: 'core-models/src/core/num/mod.rs', lines 263:12-265:13
     Visibility: public -/
 def num.Isize.saturating_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_add_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.I8.checked_add
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8542,7 +8555,7 @@ def num.I8.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.I16.checked_add
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8552,7 +8565,7 @@ def num.I16.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.I32.checked_add
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8562,7 +8575,7 @@ def num.I32.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.I64.checked_add
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8572,7 +8585,7 @@ def num.I64.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 269:12-276:13
+    Source: 'core-models/src/core/num/mod.rs', lines 272:12-279:13
     Visibility: public -/
 def num.Isize.checked_add
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8582,89 +8595,89 @@ def num.Isize.checked_add
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.I8.unchecked_add (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.I16.unchecked_add (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.I32.unchecked_add (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.I64.unchecked_add (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.I128.unchecked_add
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x + y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 279:12-281:13
+    Source: 'core-models/src/core/num/mod.rs', lines 282:12-284:13
     Visibility: public -/
 def num.Isize.unchecked_add
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 283:12-285:13
+    Source: 'core-models/src/core/num/mod.rs', lines 286:12-288:13
     Visibility: public -/
 def num.I128.wrapping_sub (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.I8.saturating_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.I16.saturating_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.I32.saturating_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.I64.saturating_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.I128.saturating_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 287:12-289:13
+    Source: 'core-models/src/core/num/mod.rs', lines 290:12-292:13
     Visibility: public -/
 def num.Isize.saturating_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_sub_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.I8.checked_sub
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8674,7 +8687,7 @@ def num.I8.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.I16.checked_sub
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8684,7 +8697,7 @@ def num.I16.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.I32.checked_sub
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8694,7 +8707,7 @@ def num.I32.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.I64.checked_sub
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8704,7 +8717,7 @@ def num.I64.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 296:12-303:13
+    Source: 'core-models/src/core/num/mod.rs', lines 299:12-306:13
     Visibility: public -/
 def num.Isize.checked_sub
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8714,162 +8727,162 @@ def num.Isize.checked_sub
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.I8.unchecked_sub (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.I16.unchecked_sub (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.I32.unchecked_sub (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.I64.unchecked_sub (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.I128.unchecked_sub
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x - y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 306:12-308:13
+    Source: 'core-models/src/core/num/mod.rs', lines 309:12-311:13
     Visibility: public -/
 def num.Isize.unchecked_sub
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x - y
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.I8.wrapping_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.wrapping_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.I16.wrapping_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.wrapping_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.I32.wrapping_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.wrapping_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.I64.wrapping_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.wrapping_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.I128.wrapping_mul (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.wrapping_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 332:12-334:13
+    Source: 'core-models/src/core/num/mod.rs', lines 335:12-337:13
     Visibility: public -/
 def num.Isize.wrapping_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.wrapping_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I8.saturating_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.saturating_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I16.saturating_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.saturating_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I32.saturating_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.saturating_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I64.saturating_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.saturating_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.I128.saturating_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.saturating_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 339:12-341:13
     Visibility: public -/
 def num.Isize.saturating_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.saturating_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I8.overflowing_mul
   (x : Std.I8) (y : Std.I8) : Result (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I16.overflowing_mul
   (x : Std.I16) (y : Std.I16) : Result (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I32.overflowing_mul
   (x : Std.I32) (y : Std.I32) : Result (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I64.overflowing_mul
   (x : Std.I64) (y : Std.I64) : Result (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.I128.overflowing_mul
   (x : Std.I128) (y : Std.I128) : Result (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-342:13
+    Source: 'core-models/src/core/num/mod.rs', lines 343:12-345:13
     Visibility: public -/
 def num.Isize.overflowing_mul
   (x : Std.Isize) (y : Std.Isize) : Result (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.I8.checked_mul
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -8879,7 +8892,7 @@ def num.I8.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.I16.checked_mul
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -8889,7 +8902,7 @@ def num.I16.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.I32.checked_mul
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -8899,7 +8912,7 @@ def num.I32.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.I64.checked_mul
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -8909,7 +8922,7 @@ def num.I64.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.I128.checked_mul
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -8919,7 +8932,7 @@ def num.I128.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::isize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 345:12-352:13
+    Source: 'core-models/src/core/num/mod.rs', lines 348:12-355:13
     Visibility: public -/
 def num.Isize.checked_mul
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -8929,336 +8942,336 @@ def num.Isize.checked_mul
   else ok (option.Option.Some result)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.I8.unchecked_mul (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.I16.unchecked_mul (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.I32.unchecked_mul (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.I64.unchecked_mul (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.I128.unchecked_mul
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 355:12-357:13
+    Source: 'core-models/src/core/num/mod.rs', lines 358:12-360:13
     Visibility: public -/
 def num.Isize.unchecked_mul
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x * y
 
 /-- [core_models::num::{core_models::num::i8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.I8.rem_euclid (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.rem_euclid_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.I16.rem_euclid (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.rem_euclid_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.I32.rem_euclid (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.rem_euclid_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.I64.rem_euclid (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.rem_euclid_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.I128.rem_euclid (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.rem_euclid_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
+    Source: 'core-models/src/core/num/mod.rs', lines 363:12-365:13
     Visibility: public -/
 def num.Isize.rem_euclid
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.rem_euclid_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.I8.pow (x : Std.I8) (exp : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.pow_i8 x exp
 
 /-- [core_models::num::{core_models::num::i16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.I16.pow (x : Std.I16) (exp : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.pow_i16 x exp
 
 /-- [core_models::num::{core_models::num::i32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.I32.pow (x : Std.I32) (exp : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.pow_i32 x exp
 
 /-- [core_models::num::{core_models::num::i64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.I64.pow (x : Std.I64) (exp : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.pow_i64 x exp
 
 /-- [core_models::num::{core_models::num::i128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.I128.pow (x : Std.I128) (exp : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.pow_i128 x exp
 
 /-- [core_models::num::{core_models::num::isize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
+    Source: 'core-models/src/core/num/mod.rs', lines 367:12-369:13
     Visibility: public -/
 def num.Isize.pow (x : Std.Isize) (exp : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.pow_isize x exp
 
 /-- [core_models::num::{core_models::num::i8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.I8.count_ones (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.I16.count_ones (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.I32.count_ones (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.I64.count_ones (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.I128.count_ones (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
+    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
     Visibility: public -/
 def num.Isize.count_ones (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.count_ones_isize x
 
 /-- [core_models::num::{core_models::num::i8}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.I8.abs (x : Std.I8) : Result Std.I8 := do
   rust_primitives.arithmetic.abs_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.I16.abs (x : Std.I16) : Result Std.I16 := do
   rust_primitives.arithmetic.abs_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.I32.abs (x : Std.I32) : Result Std.I32 := do
   rust_primitives.arithmetic.abs_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.I64.abs (x : Std.I64) : Result Std.I64 := do
   rust_primitives.arithmetic.abs_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.I128.abs (x : Std.I128) : Result Std.I128 := do
   rust_primitives.arithmetic.abs_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 373:12-375:13
+    Source: 'core-models/src/core/num/mod.rs', lines 376:12-378:13
     Visibility: public -/
 def num.Isize.abs (x : Std.Isize) : Result Std.Isize := do
   rust_primitives.arithmetic.abs_isize x
 
 /-- [core_models::num::{core_models::num::i8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.I8.rotate_right (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_right_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.I16.rotate_right (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_right_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.I32.rotate_right (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_right_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.I64.rotate_right (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_right_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.I128.rotate_right (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_right_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 378:12-380:13
+    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
     Visibility: public -/
 def num.Isize.rotate_right
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_right_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.I8.rotate_left (x : Std.I8) (n : Std.U32) : Result Std.I8 := do
   rust_primitives.arithmetic.rotate_left_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.I16.rotate_left (x : Std.I16) (n : Std.U32) : Result Std.I16 := do
   rust_primitives.arithmetic.rotate_left_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.I32.rotate_left (x : Std.I32) (n : Std.U32) : Result Std.I32 := do
   rust_primitives.arithmetic.rotate_left_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.I64.rotate_left (x : Std.I64) (n : Std.U32) : Result Std.I64 := do
   rust_primitives.arithmetic.rotate_left_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.I128.rotate_left (x : Std.I128) (n : Std.U32) : Result Std.I128 := do
   rust_primitives.arithmetic.rotate_left_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 383:12-385:13
+    Source: 'core-models/src/core/num/mod.rs', lines 386:12-388:13
     Visibility: public -/
 def num.Isize.rotate_left
   (x : Std.Isize) (n : Std.U32) : Result Std.Isize := do
   rust_primitives.arithmetic.rotate_left_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.I8.leading_zeros (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.I16.leading_zeros (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.I32.leading_zeros (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.I64.leading_zeros (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.I128.leading_zeros (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
+    Source: 'core-models/src/core/num/mod.rs', lines 391:12-393:13
     Visibility: public -/
 def num.Isize.leading_zeros (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_isize x
 
 /-- [core_models::num::{core_models::num::i8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I8.ilog2 (x : Std.I8) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I16.ilog2 (x : Std.I16) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I32.ilog2 (x : Std.I32) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I64.ilog2 (x : Std.I64) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I128.ilog2 (x : Std.I128) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 393:12-395:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.Isize.ilog2 (x : Std.Isize) : Result Std.U32 := do
   rust_primitives.arithmetic.ilog2_isize x
 
 /-- [core_models::num::{core_models::num::i8}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.I8.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9267,7 +9280,7 @@ def num.I8.from_str_radix
   panicking.internal.panic (result.Result Std.I8 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i16}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.I16.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9276,7 +9289,7 @@ def num.I16.from_str_radix
   panicking.internal.panic (result.Result Std.I16 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i32}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.I32.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9285,7 +9298,7 @@ def num.I32.from_str_radix
   panicking.internal.panic (result.Result Std.I32 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i64}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.I64.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9294,7 +9307,7 @@ def num.I64.from_str_radix
   panicking.internal.panic (result.Result Std.I64 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i128}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.I128.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9303,7 +9316,7 @@ def num.I128.from_str_radix
   panicking.internal.panic (result.Result Std.I128 num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::isize}::from_str_radix]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-404:13
+    Source: 'core-models/src/core/num/mod.rs', lines 402:12-407:13
     Visibility: public -/
 def num.Isize.from_str_radix
   (src : Str) (radix : Std.U32) :
@@ -9312,159 +9325,159 @@ def num.Isize.from_str_radix
   panicking.internal.panic (result.Result Std.Isize num.error.ParseIntError)
 
 /-- [core_models::num::{core_models::num::i8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I8.from_be_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I16.from_be_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I32.from_be_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I64.from_be_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 407:12-409:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.Isize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I8.from_le_bytes (bytes : Array Std.U8 1#usize) : Result Std.I8 := do
   rust_primitives.arithmetic.from_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I16.from_le_bytes (bytes : Array Std.U8 2#usize) : Result Std.I16 := do
   rust_primitives.arithmetic.from_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I32.from_le_bytes (bytes : Array Std.U8 4#usize) : Result Std.I32 := do
   rust_primitives.arithmetic.from_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I64.from_le_bytes (bytes : Array Std.U8 8#usize) : Result Std.I64 := do
   rust_primitives.arithmetic.from_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : Result Std.I128 := do
   rust_primitives.arithmetic.from_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 412:12-414:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.Isize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : Result Std.Isize := do
   rust_primitives.arithmetic.from_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I8.to_be_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I16.to_be_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I32.to_be_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I64.to_be_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I128.to_be_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 417:12-419:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.Isize.to_be_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I8.to_le_bytes (bytes : Std.I8) : Result (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I16.to_le_bytes (bytes : Std.I16) : Result (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I32.to_le_bytes (bytes : Std.I32) : Result (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I64.to_le_bytes (bytes : Std.I64) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I128.to_le_bytes
   (bytes : Std.I128) : Result (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 422:12-424:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.Isize.to_le_bytes
   (bytes : Std.Isize) : Result (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I8.checked_div
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9481,7 +9494,7 @@ def num.I8.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I16.checked_div
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9498,7 +9511,7 @@ def num.I16.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I32.checked_div
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9515,7 +9528,7 @@ def num.I32.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I64.checked_div
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9532,7 +9545,7 @@ def num.I64.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.I128.checked_div
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9549,7 +9562,7 @@ def num.I128.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 427:12-433:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-436:13
     Visibility: public -/
 def num.Isize.checked_div
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9567,45 +9580,45 @@ def num.Isize.checked_div
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I8.unchecked_div (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I16.unchecked_div (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I32.unchecked_div (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I64.unchecked_div (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.I128.unchecked_div
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 436:12-438:13
+    Source: 'core-models/src/core/num/mod.rs', lines 439:12-441:13
     Visibility: public -/
 def num.Isize.unchecked_div
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x / y
 
 /-- [core_models::num::{core_models::num::i8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.I8.checked_rem
   (x : Std.I8) (y : Std.I8) : Result (option.Option Std.I8) := do
@@ -9622,7 +9635,7 @@ def num.I8.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.I16.checked_rem
   (x : Std.I16) (y : Std.I16) : Result (option.Option Std.I16) := do
@@ -9639,7 +9652,7 @@ def num.I16.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.I32.checked_rem
   (x : Std.I32) (y : Std.I32) : Result (option.Option Std.I32) := do
@@ -9656,7 +9669,7 @@ def num.I32.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.I64.checked_rem
   (x : Std.I64) (y : Std.I64) : Result (option.Option Std.I64) := do
@@ -9673,7 +9686,7 @@ def num.I64.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.I128.checked_rem
   (x : Std.I128) (y : Std.I128) : Result (option.Option Std.I128) := do
@@ -9690,7 +9703,7 @@ def num.I128.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 441:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 444:12-450:13
     Visibility: public -/
 def num.Isize.checked_rem
   (x : Std.Isize) (y : Std.Isize) : Result (option.Option Std.Isize) := do
@@ -9708,45 +9721,45 @@ def num.Isize.checked_rem
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.I8.unchecked_rem (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.I16.unchecked_rem (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.I32.unchecked_rem (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.I64.unchecked_rem (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.I128.unchecked_rem
   (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 453:12-455:13
     Visibility: public -/
 def num.Isize.unchecked_rem
   (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   x % y
 
 /-- [core_models::num::{core_models::num::i8}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.I8.signum (x : Std.I8) : Result Std.I8 := do
   if x > 0#i8
@@ -9756,7 +9769,7 @@ def num.I8.signum (x : Std.I8) : Result Std.I8 := do
        else ok (-1)#i8
 
 /-- [core_models::num::{core_models::num::i16}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.I16.signum (x : Std.I16) : Result Std.I16 := do
   if x > 0#i16
@@ -9766,7 +9779,7 @@ def num.I16.signum (x : Std.I16) : Result Std.I16 := do
        else ok (-1)#i16
 
 /-- [core_models::num::{core_models::num::i32}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.I32.signum (x : Std.I32) : Result Std.I32 := do
   if x > 0#i32
@@ -9776,7 +9789,7 @@ def num.I32.signum (x : Std.I32) : Result Std.I32 := do
        else ok (-1)#i32
 
 /-- [core_models::num::{core_models::num::i64}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.I64.signum (x : Std.I64) : Result Std.I64 := do
   if x > 0#i64
@@ -9786,7 +9799,7 @@ def num.I64.signum (x : Std.I64) : Result Std.I64 := do
        else ok (-1)#i64
 
 /-- [core_models::num::{core_models::num::i128}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.I128.signum (x : Std.I128) : Result Std.I128 := do
   if x > 0#i128
@@ -9796,7 +9809,7 @@ def num.I128.signum (x : Std.I128) : Result Std.I128 := do
        else ok (-1)#i128
 
 /-- [core_models::num::{core_models::num::isize}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 454:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 457:12-465:13
     Visibility: public -/
 def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
   if x > 0#isize
@@ -9806,7 +9819,7 @@ def num.Isize.signum (x : Std.Isize) : Result Std.Isize := do
        else ok (-1)#isize
 
 /-- [core_models::num::{core_models::num::i8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
   let d ← x / y
@@ -9827,7 +9840,7 @@ def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : Result Std.I8 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
   let d ← x / y
@@ -9848,7 +9861,7 @@ def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : Result Std.I16 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
   let d ← x / y
@@ -9869,7 +9882,7 @@ def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : Result Std.I32 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
   let d ← x / y
@@ -9890,7 +9903,7 @@ def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : Result Std.I64 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
   let d ← x / y
@@ -9911,7 +9924,7 @@ def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : Result Std.I128 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::isize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 466:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 469:12-478:13
     Visibility: public -/
 def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
   let d ← x / y
@@ -9933,169 +9946,169 @@ def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : Result Std.Isize := do
        else ok d
 
 /-- [core_models::num::{impl core_models::default::Default for u8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def U8.Insts.CoreDefaultDefault.default : Result Std.U8 := do
   ok 0#u8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def U8.Insts.CoreDefaultDefault : default.Default Std.U8 := {
   default := U8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def U16.Insts.CoreDefaultDefault.default : Result Std.U16 := do
   ok 0#u16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def U16.Insts.CoreDefaultDefault : default.Default Std.U16 := {
   default := U16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def U32.Insts.CoreDefaultDefault.default : Result Std.U32 := do
   ok 0#u32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def U32.Insts.CoreDefaultDefault : default.Default Std.U32 := {
   default := U32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def U64.Insts.CoreDefaultDefault.default : Result Std.U64 := do
   ok 0#u64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def U64.Insts.CoreDefaultDefault : default.Default Std.U64 := {
   default := U64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def U128.Insts.CoreDefaultDefault.default : Result Std.U128 := do
   ok 0#u128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def U128.Insts.CoreDefaultDefault : default.Default Std.U128 := {
   default := U128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for usize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def Usize.Insts.CoreDefaultDefault.default : Result Std.Usize := do
   ok 0#usize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for usize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def Usize.Insts.CoreDefaultDefault : default.Default Std.Usize := {
   default := Usize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def I8.Insts.CoreDefaultDefault.default : Result Std.I8 := do
   ok 0#i8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def I8.Insts.CoreDefaultDefault : default.Default Std.I8 := {
   default := I8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def I16.Insts.CoreDefaultDefault.default : Result Std.I16 := do
   ok 0#i16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def I16.Insts.CoreDefaultDefault : default.Default Std.I16 := {
   default := I16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def I32.Insts.CoreDefaultDefault.default : Result Std.I32 := do
   ok 0#i32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def I32.Insts.CoreDefaultDefault : default.Default Std.I32 := {
   default := I32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def I64.Insts.CoreDefaultDefault.default : Result Std.I64 := do
   ok 0#i64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def I64.Insts.CoreDefaultDefault : default.Default Std.I64 := {
   default := I64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def I128.Insts.CoreDefaultDefault.default : Result Std.I128 := do
   ok 0#i128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def I128.Insts.CoreDefaultDefault : default.Default Std.I128 := {
   default := I128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for isize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 661:16-663:17
+    Source: 'core-models/src/core/num/mod.rs', lines 664:16-666:17
     Visibility: public -/
 def Isize.Insts.CoreDefaultDefault.default : Result Std.Isize := do
   ok 0#isize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for isize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 660:12-664:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 663:12-667:13 -/
 @[reducible]
 def Isize.Insts.CoreDefaultDefault : default.Default Std.Isize := {
   default := Isize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for bool}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 687:4-689:5
+    Source: 'core-models/src/core/num/mod.rs', lines 690:4-692:5
     Visibility: public -/
 def Bool.Insts.CoreDefaultDefault.default : Result Bool := do
   ok false
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for bool}]
-    Source: 'core-models/src/core/num/mod.rs', lines 685:0-690:1 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 688:0-693:1 -/
 @[reducible]
 def Bool.Insts.CoreDefaultDefault : default.Default Bool := {
   default := Bool.Insts.CoreDefaultDefault.default

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -505,73 +505,73 @@ structure num.error.ParseIntError where
   kind : num.error.IntErrorKind
 
 /-- [core_models::num::u8]
-    Source: 'core-models/src/core/num/mod.rs', lines 499:0-499:14
+    Source: 'core-models/src/core/num/mod.rs', lines 502:0-502:14
     Visibility: public -/
 @[reducible]
 def num.u8 := Unit
 
 /-- [core_models::num::u16]
-    Source: 'core-models/src/core/num/mod.rs', lines 502:0-502:15
+    Source: 'core-models/src/core/num/mod.rs', lines 505:0-505:15
     Visibility: public -/
 @[reducible]
 def num.u16 := Unit
 
 /-- [core_models::num::u32]
-    Source: 'core-models/src/core/num/mod.rs', lines 505:0-505:15
+    Source: 'core-models/src/core/num/mod.rs', lines 508:0-508:15
     Visibility: public -/
 @[reducible]
 def num.u32 := Unit
 
 /-- [core_models::num::u64]
-    Source: 'core-models/src/core/num/mod.rs', lines 508:0-508:15
+    Source: 'core-models/src/core/num/mod.rs', lines 511:0-511:15
     Visibility: public -/
 @[reducible]
 def num.u64 := Unit
 
 /-- [core_models::num::u128]
-    Source: 'core-models/src/core/num/mod.rs', lines 511:0-511:16
+    Source: 'core-models/src/core/num/mod.rs', lines 514:0-514:16
     Visibility: public -/
 @[reducible]
 def num.u128 := Unit
 
 /-- [core_models::num::usize]
-    Source: 'core-models/src/core/num/mod.rs', lines 514:0-514:17
+    Source: 'core-models/src/core/num/mod.rs', lines 517:0-517:17
     Visibility: public -/
 @[reducible]
 def num.usize := Unit
 
 /-- [core_models::num::i8]
-    Source: 'core-models/src/core/num/mod.rs', lines 517:0-517:14
+    Source: 'core-models/src/core/num/mod.rs', lines 520:0-520:14
     Visibility: public -/
 @[reducible]
 def num.i8 := Unit
 
 /-- [core_models::num::i16]
-    Source: 'core-models/src/core/num/mod.rs', lines 520:0-520:15
+    Source: 'core-models/src/core/num/mod.rs', lines 523:0-523:15
     Visibility: public -/
 @[reducible]
 def num.i16 := Unit
 
 /-- [core_models::num::i32]
-    Source: 'core-models/src/core/num/mod.rs', lines 523:0-523:15
+    Source: 'core-models/src/core/num/mod.rs', lines 526:0-526:15
     Visibility: public -/
 @[reducible]
 def num.i32 := Unit
 
 /-- [core_models::num::i64]
-    Source: 'core-models/src/core/num/mod.rs', lines 526:0-526:15
+    Source: 'core-models/src/core/num/mod.rs', lines 529:0-529:15
     Visibility: public -/
 @[reducible]
 def num.i64 := Unit
 
 /-- [core_models::num::i128]
-    Source: 'core-models/src/core/num/mod.rs', lines 529:0-529:16
+    Source: 'core-models/src/core/num/mod.rs', lines 532:0-532:16
     Visibility: public -/
 @[reducible]
 def num.i128 := Unit
 
 /-- [core_models::num::isize]
-    Source: 'core-models/src/core/num/mod.rs', lines 532:0-532:17
+    Source: 'core-models/src/core/num/mod.rs', lines 535:0-535:17
     Visibility: public -/
 @[reducible]
 def num.isize := Unit

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -505,73 +505,73 @@ structure num.error.ParseIntError where
   kind : num.error.IntErrorKind
 
 /-- [core_models::num::u8]
-    Source: 'core-models/src/core/num/mod.rs', lines 502:0-502:14
+    Source: 'core-models/src/core/num/mod.rs', lines 488:0-488:14
     Visibility: public -/
 @[reducible]
 def num.u8 := Unit
 
 /-- [core_models::num::u16]
-    Source: 'core-models/src/core/num/mod.rs', lines 505:0-505:15
+    Source: 'core-models/src/core/num/mod.rs', lines 491:0-491:15
     Visibility: public -/
 @[reducible]
 def num.u16 := Unit
 
 /-- [core_models::num::u32]
-    Source: 'core-models/src/core/num/mod.rs', lines 508:0-508:15
+    Source: 'core-models/src/core/num/mod.rs', lines 494:0-494:15
     Visibility: public -/
 @[reducible]
 def num.u32 := Unit
 
 /-- [core_models::num::u64]
-    Source: 'core-models/src/core/num/mod.rs', lines 511:0-511:15
+    Source: 'core-models/src/core/num/mod.rs', lines 497:0-497:15
     Visibility: public -/
 @[reducible]
 def num.u64 := Unit
 
 /-- [core_models::num::u128]
-    Source: 'core-models/src/core/num/mod.rs', lines 514:0-514:16
+    Source: 'core-models/src/core/num/mod.rs', lines 500:0-500:16
     Visibility: public -/
 @[reducible]
 def num.u128 := Unit
 
 /-- [core_models::num::usize]
-    Source: 'core-models/src/core/num/mod.rs', lines 517:0-517:17
+    Source: 'core-models/src/core/num/mod.rs', lines 503:0-503:17
     Visibility: public -/
 @[reducible]
 def num.usize := Unit
 
 /-- [core_models::num::i8]
-    Source: 'core-models/src/core/num/mod.rs', lines 520:0-520:14
+    Source: 'core-models/src/core/num/mod.rs', lines 506:0-506:14
     Visibility: public -/
 @[reducible]
 def num.i8 := Unit
 
 /-- [core_models::num::i16]
-    Source: 'core-models/src/core/num/mod.rs', lines 523:0-523:15
+    Source: 'core-models/src/core/num/mod.rs', lines 509:0-509:15
     Visibility: public -/
 @[reducible]
 def num.i16 := Unit
 
 /-- [core_models::num::i32]
-    Source: 'core-models/src/core/num/mod.rs', lines 526:0-526:15
+    Source: 'core-models/src/core/num/mod.rs', lines 512:0-512:15
     Visibility: public -/
 @[reducible]
 def num.i32 := Unit
 
 /-- [core_models::num::i64]
-    Source: 'core-models/src/core/num/mod.rs', lines 529:0-529:15
+    Source: 'core-models/src/core/num/mod.rs', lines 515:0-515:15
     Visibility: public -/
 @[reducible]
 def num.i64 := Unit
 
 /-- [core_models::num::i128]
-    Source: 'core-models/src/core/num/mod.rs', lines 532:0-532:16
+    Source: 'core-models/src/core/num/mod.rs', lines 518:0-518:16
     Visibility: public -/
 @[reducible]
 def num.i128 := Unit
 
 /-- [core_models::num::isize]
-    Source: 'core-models/src/core/num/mod.rs', lines 535:0-535:17
+    Source: 'core-models/src/core/num/mod.rs', lines 521:0-521:17
     Visibility: public -/
 @[reducible]
 def num.isize := Unit


### PR DESCRIPTION
The `core::convert` module defines conversions for integer types on the real types from `core` not `core_models` which is doesn't induce a dependency in the bundling phase. This means that adding a dependency in the other direction leads to cyclic F* modules. This PR fixes that by using the `MAX/MIN` values from `core_models` instead of `core` in `convert`. It materializes the dependency so that bundling sees it. This allows activating models for `checked_` arithmetic in the F* backend, and more (fixes https://github.com/cryspen/hax/issues/2120)

[skip changelog]