### PR TITLE
fix(proof-libs/fstar): specify the overflowing add/sub primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes to hax-lib:
  - New infrastructure for extraction of the F* proof-lib from the migrated core-models, unified with the lean core-lib infrastructure(#2077)
  - Support quote annotations (`before`, `after`, `options`) on inherent `impl` blocks and on their items (#1698)
  - Fix some regressions in the F* proof lib (particularly the `vec_deque` models)
+ - Specify the F* `overflowing_add`/`overflowing_sub` primitives, which were left uninterpreted. The `checked_*` integer models route through them, so they could not be used in a proof (#2127)
 
 Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)

--- a/hax-lib/proof-libs/fstar/core/Core_models.Num.Overflow_spec.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Num.Overflow_spec.fst
@@ -1,0 +1,53 @@
+module Core_models.Num.Overflow_spec
+
+/// Behavioural contract of the `checked_*` integer models, which route
+/// through `Rust_primitives.Arithmetic.overflowing_{add,sub}_*`.
+///
+/// Every lemma here is a proof obligation, not runtime code: the file exists
+/// so that leaving one of those primitives uninterpreted is a build failure
+/// rather than a silently unusable model (#2127).
+
+open FStar.Mul
+open Rust_primitives
+
+/// unsigned add — in range
+let checked_add_u64_some (x y: u64) : Lemma
+  (requires v x + v y <= maxint U64)
+  (ensures Core_models.Num.impl_u64__checked_add x y
+           == Core_models.Option.Option_Some (x +! y))
+  = ()
+
+/// unsigned add — overflow
+let checked_add_u64_none (x y: u64) : Lemma
+  (requires v x + v y > maxint U64)
+  (ensures Core_models.Num.impl_u64__checked_add x y
+           == Core_models.Option.Option_None)
+  = ()
+
+/// signed add — in range
+let checked_add_i32_some (x y: i32) : Lemma
+  (requires v x + v y <= maxint I32 /\ v x + v y >= minint I32)
+  (ensures Core_models.Num.impl_i32__checked_add x y
+           == Core_models.Option.Option_Some (x +! y))
+  = ()
+
+/// signed sub — in range
+let checked_sub_i32_some (x y: i32) : Lemma
+  (requires v x - v y <= maxint I32 /\ v x - v y >= minint I32)
+  (ensures Core_models.Num.impl_i32__checked_sub x y
+           == Core_models.Option.Option_Some (x -! y))
+  = ()
+
+/// signed sub — underflow
+let checked_sub_i32_none (x y: i32) : Lemma
+  (requires v x - v y < minint I32)
+  (ensures Core_models.Num.impl_i32__checked_sub x y
+           == Core_models.Option.Option_None)
+  = ()
+
+/// unsigned sub already had a definition — guard against regressing it
+let checked_sub_u64_some (x y: u64) : Lemma
+  (requires v y <= v x)
+  (ensures Core_models.Num.impl_u64__checked_sub x y
+           == Core_models.Option.Option_Some (x -! y))
+  = ()

--- a/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
+++ b/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
@@ -5,7 +5,7 @@ open Rust_primitives.Integers
 
 let wrapping_add_u8 : u8 -> u8 -> u8 = add_mod
 let saturating_add_u8 : u8 -> u8 -> u8 = add_sat
-val overflowing_add_u8 : u8 -> u8 -> u8 & bool
+let overflowing_add_u8 : u8 -> u8 -> u8 & bool = add_overflow
 let wrapping_sub_u8 : u8 -> u8 -> u8 = sub_mod
 let saturating_sub_u8 : u8 -> u8 -> u8 = sub_sat
 let overflowing_sub_u8 (x y: u8): u8 & bool
@@ -24,7 +24,7 @@ let rotate_left_u8 = rotate_left_u #U8
 
 let wrapping_add_u16 : u16 -> u16 -> u16 = add_mod
 let saturating_add_u16 : u16 -> u16 -> u16 = add_sat
-val overflowing_add_u16 : u16 -> u16 -> u16 & bool
+let overflowing_add_u16 : u16 -> u16 -> u16 & bool = add_overflow
 let wrapping_sub_u16 : u16 -> u16 -> u16 = sub_mod
 let saturating_sub_u16 : u16 -> u16 -> u16 = sub_sat
 let overflowing_sub_u16 (x y: u16): u16 & bool
@@ -43,7 +43,7 @@ let rotate_left_u16 = rotate_left_u #U16
 
 let wrapping_add_u32 : u32 -> u32 -> u32 = add_mod
 let saturating_add_u32 : u32 -> u32 -> u32 = add_sat
-val overflowing_add_u32 : u32 -> u32 -> u32 & bool
+let overflowing_add_u32 : u32 -> u32 -> u32 & bool = add_overflow
 let wrapping_sub_u32 : u32 -> u32 -> u32 = sub_mod
 let saturating_sub_u32 : u32 -> u32 -> u32 = sub_sat
 let overflowing_sub_u32 (x y: u32): u32 & bool
@@ -62,7 +62,7 @@ let rotate_left_u32 = rotate_left_u #U32
 
 let wrapping_add_u64 : u64 -> u64 -> u64 = add_mod
 let saturating_add_u64 : u64 -> u64 -> u64 = add_sat
-val overflowing_add_u64 : u64 -> u64 -> u64 & bool
+let overflowing_add_u64 : u64 -> u64 -> u64 & bool = add_overflow
 let wrapping_sub_u64 : u64 -> u64 -> u64 = sub_mod
 let saturating_sub_u64 : u64 -> u64 -> u64 = sub_sat
 let overflowing_sub_u64 (x y: u64): u64 & bool
@@ -81,7 +81,7 @@ let rotate_left_u64 = rotate_left_u #U64
 
 let wrapping_add_u128 : u128 -> u128 -> u128 = add_mod
 let saturating_add_u128 : u128 -> u128 -> u128 = add_sat
-val overflowing_add_u128 : u128 -> u128 -> u128 & bool
+let overflowing_add_u128 : u128 -> u128 -> u128 & bool = add_overflow
 let wrapping_sub_u128 : u128 -> u128 -> u128 = sub_mod
 let saturating_sub_u128 : u128 -> u128 -> u128 = sub_sat
 let overflowing_sub_u128 (x y: u128): u128 & bool
@@ -100,7 +100,7 @@ let rotate_left_u128 = rotate_left_u #U128
 
 let wrapping_add_usize : usize -> usize -> usize = add_mod
 let saturating_add_usize : usize -> usize -> usize = add_sat
-val overflowing_add_usize : usize -> usize -> usize & bool
+let overflowing_add_usize : usize -> usize -> usize & bool = add_overflow
 let wrapping_sub_usize : usize -> usize -> usize = sub_mod
 let saturating_sub_usize : usize -> usize -> usize = sub_sat
 let overflowing_sub_usize (x y: usize): usize & bool
@@ -119,10 +119,10 @@ let rotate_left_usize = rotate_left_u #USIZE
 
 let wrapping_add_i8 : i8 -> i8 -> i8 = add_mod
 let saturating_add_i8 : i8 -> i8 -> i8 = add_sat
-val overflowing_add_i8 : i8 -> i8 -> i8 & bool
+let overflowing_add_i8 : i8 -> i8 -> i8 & bool = add_overflow
 let wrapping_sub_i8 : i8 -> i8 -> i8 = sub_mod
 let saturating_sub_i8 : i8 -> i8 -> i8 = sub_sat
-val overflowing_sub_i8 (x y: i8): i8 & bool
+let overflowing_sub_i8 : i8 -> i8 -> i8 & bool = sub_overflow
 let wrapping_mul_i8 : i8 -> i8 -> i8 = mul_mod
 val saturating_mul_i8 : i8 -> i8 -> i8
 let overflowing_mul_i8 : i8 -> i8 -> i8 & bool = mul_overflow
@@ -133,10 +133,10 @@ val abs_i8 : i8 -> i8
 
 let wrapping_add_i16 : i16 -> i16 -> i16 = add_mod
 let saturating_add_i16 : i16 -> i16 -> i16 = add_sat
-val overflowing_add_i16 : i16 -> i16 -> i16 & bool
+let overflowing_add_i16 : i16 -> i16 -> i16 & bool = add_overflow
 let wrapping_sub_i16 : i16 -> i16 -> i16 = sub_mod
 let saturating_sub_i16 : i16 -> i16 -> i16 = sub_sat
-val overflowing_sub_i16 (x y: i16): i16 & bool
+let overflowing_sub_i16 : i16 -> i16 -> i16 & bool = sub_overflow
 let wrapping_mul_i16 : i16 -> i16 -> i16 = mul_mod
 val saturating_mul_i16 : i16 -> i16 -> i16
 let overflowing_mul_i16 : i16 -> i16 -> i16 & bool = mul_overflow
@@ -147,10 +147,10 @@ val abs_i16 : i16 -> i16
 
 let wrapping_add_i32 : i32 -> i32 -> i32 = add_mod
 let saturating_add_i32 : i32 -> i32 -> i32 = add_sat
-val overflowing_add_i32 : i32 -> i32 -> i32 & bool
+let overflowing_add_i32 : i32 -> i32 -> i32 & bool = add_overflow
 let wrapping_sub_i32 : i32 -> i32 -> i32 = sub_mod
 let saturating_sub_i32 : i32 -> i32 -> i32 = sub_sat
-val overflowing_sub_i32 (x y: i32): i32 & bool
+let overflowing_sub_i32 : i32 -> i32 -> i32 & bool = sub_overflow
 let wrapping_mul_i32 : i32 -> i32 -> i32 = mul_mod
 val saturating_mul_i32 : i32 -> i32 -> i32
 let overflowing_mul_i32 : i32 -> i32 -> i32 & bool = mul_overflow
@@ -161,10 +161,10 @@ val abs_i32 : i32 -> i32
 
 let wrapping_add_i64 : i64 -> i64 -> i64 = add_mod
 let saturating_add_i64 : i64 -> i64 -> i64 = add_sat
-val overflowing_add_i64 : i64 -> i64 -> i64 & bool
+let overflowing_add_i64 : i64 -> i64 -> i64 & bool = add_overflow
 let wrapping_sub_i64 : i64 -> i64 -> i64 = sub_mod
 let saturating_sub_i64 : i64 -> i64 -> i64 = sub_sat
-val overflowing_sub_i64 (x y: i64): i64 & bool
+let overflowing_sub_i64 : i64 -> i64 -> i64 & bool = sub_overflow
 let wrapping_mul_i64 : i64 -> i64 -> i64 = mul_mod
 val saturating_mul_i64 : i64 -> i64 -> i64
 let overflowing_mul_i64 : i64 -> i64 -> i64 & bool = mul_overflow
@@ -175,10 +175,10 @@ val abs_i64 : i64 -> i64
 
 let wrapping_add_i128 : i128 -> i128 -> i128 = add_mod
 let saturating_add_i128 : i128 -> i128 -> i128 = add_sat
-val overflowing_add_i128 : i128 -> i128 -> i128 & bool
+let overflowing_add_i128 : i128 -> i128 -> i128 & bool = add_overflow
 let wrapping_sub_i128 : i128 -> i128 -> i128 = sub_mod
 let saturating_sub_i128 : i128 -> i128 -> i128 = sub_sat
-val overflowing_sub_i128 (x y: i128): i128 & bool
+let overflowing_sub_i128 : i128 -> i128 -> i128 & bool = sub_overflow
 let wrapping_mul_i128 : i128 -> i128 -> i128 = mul_mod
 val saturating_mul_i128 : i128 -> i128 -> i128
 let overflowing_mul_i128 : i128 -> i128 -> i128 & bool = mul_overflow
@@ -189,10 +189,10 @@ val abs_i128 : i128 -> i128
 
 let wrapping_add_isize : isize -> isize -> isize = add_mod
 let saturating_add_isize : isize -> isize -> isize = add_sat
-val overflowing_add_isize : isize -> isize -> isize & bool
+let overflowing_add_isize : isize -> isize -> isize & bool = add_overflow
 let wrapping_sub_isize : isize -> isize -> isize = sub_mod
 let saturating_sub_isize : isize -> isize -> isize = sub_sat
-val overflowing_sub_isize (x y: isize): isize & bool
+let overflowing_sub_isize : isize -> isize -> isize & bool = sub_overflow
 let wrapping_mul_isize : isize -> isize -> isize = mul_mod
 val saturating_mul_isize : isize -> isize -> isize
 let overflowing_mul_isize : isize -> isize -> isize & bool = mul_overflow

--- a/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -218,6 +218,14 @@ let mul_mod (#t:inttype) (a:int_t t)
 let mul_overflow (#t:inttype) (a:int_t t)
                  (b:int_t t) =
                  (mk_int #t (v a * v b @%. t), (v a * v b > maxint t || v a * v b < maxint t))
+
+let add_overflow (#t:inttype) (a:int_t t)
+                 (b:int_t t) =
+                 (mk_int #t ((v a + v b) @%. t), (v a + v b > maxint t || v a + v b < minint t))
+
+let sub_overflow (#t:inttype) (a:int_t t)
+                 (b:int_t t) =
+                 (mk_int #t ((v a - v b) @%. t), (v a - v b > maxint t || v a - v b < minint t))
 let mul (#t:inttype) (a:int_t t)
         (b:int_t t{range (v a * v b) t}) =
         mk_int #t (v a * v b)


### PR DESCRIPTION
Fixes #2127.

#2124 broke the `convert`/`num` module cycle and activated the `checked_*`
integer models for F\*. The models resolve, but they carry no specification:
`Core_models.Num.impl_u64__checked_add` reduces to
`Rust_primitives.Arithmetic.overflowing_add_u64`, which is declared `val` with
no `.fst` realizing it. Neither direction of

```
checked_add x y == Some r  <==>  v r == v x + v y
```

is provable. The same holds for `overflowing_add_*` on all twelve integer types
and `overflowing_sub_*` on the six signed ones. Only unsigned
`overflowing_sub_*` had a definition, which is why `checked_sub` worked on
unsigned types and nothing else did.

## The change

`Rust_primitives.Integers` already has a generic `mul_overflow`. This adds its
two missing siblings next to it:

```fstar
let add_overflow (#t:inttype) (a:int_t t) (b:int_t t) =
  (mk_int #t ((v a + v b) @%. t), (v a + v b > maxint t || v a + v b < minint t))
```

and points the eighteen declarations at them, exactly the way
`overflowing_mul_*` is already wired up:

```diff
-val overflowing_add_u64 : u64 -> u64 -> u64 & bool
+let overflowing_add_u64 : u64 -> u64 -> u64 & bool = add_overflow
```

The six unsigned `overflowing_sub_*` that already had explicit definitions are
left untouched, to keep the diff to the symbols that were actually unspecified.

## Testing

The second commit adds `Core_models.Num.Overflow_spec`, which states the
intended meaning of the models as proof obligations: the `Some` and `None`
branches of `checked_add` on `u64`, the signed `checked_add`/`checked_sub`
cases, and unsigned `checked_sub` as a guard against regressing what already
worked. The `core` Makefile globs `*.fst`, so CI runs this as-is via
`make -C hax-lib/proof-libs/fstar/core` — no workflow change needed.

Checking out the first commit's parent for the two `.fsti` files makes that
target fail (`Error 19: Could not prove post-condition`), so the file is a real
regression test rather than a restatement of the fix.

Also run locally:

- `proof-libs/fstar/rust_primitives` and `proof-libs/fstar/core` Makefiles: all
  verification conditions discharged.
- `examples/barrett`: verifies.
- An out-of-tree crate carrying `requires`/`ensures` contracts over
  `u64::checked_add`/`checked_sub` (supply conservation, atomicity on failure,
  panic-freedom) verifies end to end. Before this change it needed a local
  helper module and a call-site rewrite to work around the unspecified models;
  with it, no post-extraction patching at all.

`hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.Num_traits.fst`
fails to typecheck with `Duplicate top-level names [f_Output]`. That is
pre-existing — it reproduces identically with this branch stashed — and looks
like a stale committed extraction, unrelated to arithmetic.

## AI disclosure

Per CONTRIBUTING.md: Claude Opus 5 (via Claude Code) was used to write the
patch, the commit message, and this description, and to run the verification
above. The uninterpreted `val`s were found by bisecting a real proof failure in
the downstream crate mentioned above, not by reading the file. Every claim in
the Testing section is a command that was run; the `hax-bounded-integers`
failure was baselined against an unmodified tree specifically to check it was
not caused by this patch. I have reviewed the diff and take responsibility for
it.
