### PR TITLE
Make the tool end-to-end check requirable and pass on macOS

### DIFF
--- a/.github/workflows/tools_end_to_end.yml
+++ b/.github/workflows/tools_end_to_end.yml
@@ -52,7 +52,7 @@ jobs:
             cli/cargo-hax/src/tools \
             hax-types \
             justfile \
-            examples/chacha20 \
+            examples/barrett \
             .github/workflows/tools_end_to_end.yml
           then
             echo relevant=true >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tools_end_to_end.yml
+++ b/.github/workflows/tools_end_to_end.yml
@@ -3,11 +3,17 @@ name: Tool management end-to-end
 # Installs the managed tools from their real artifacts and runs them, natively
 # on every supported platform.
 #
-# One runner per platform, each downloading real artifacts, so it runs before
-# a merge lands rather than on every push, plus nightly: the artifacts live
+# One runner per platform, each downloading real artifacts, so it runs where
+# the outcome can change rather than on every push: on a pull request touching
+# tool management, before a merge lands, and nightly, since the artifacts live
 # upstream and can change under an entry that was correct when written.
+#
+# The paths gate is a job rather than a trigger filter: a required check that
+# a filtered trigger never reports would block every other pull request from
+# merging, while a skipped job reports and passes.
 
 on:
+  pull_request:
   merge_group:
   schedule:
     - cron: '41 5 * * *'
@@ -18,7 +24,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Whether this run can change the outcome: on a pull request, only one
+  # touching tool management can; every other event runs unconditionally.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.diff.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          # The merge commit and both of its parents, for the diff against
+          # the base branch.
+          fetch-depth: 2
+      - id: diff
+        env:
+          EVENT: ${{ github.event_name }}
+        # `git diff --quiet` exits non-zero both on a match and on an error,
+        # so a failing diff marks the change relevant rather than skipping
+        # the check.
+        run: |
+          if [ "$EVENT" != pull_request ] || ! git diff --quiet HEAD^1 HEAD -- \
+            cli/cargo-hax/tools-manifest.toml \
+            cli/cargo-hax/defaults.toml \
+            cli/cargo-hax/src/cargo_hax.rs \
+            cli/cargo-hax/src/tools.rs \
+            cli/cargo-hax/src/tools \
+            hax-types \
+            justfile \
+            examples/chacha20 \
+            .github/workflows/tools_end_to_end.yml
+          then
+            echo relevant=true >> "$GITHUB_OUTPUT"
+          else
+            echo relevant=false >> "$GITHUB_OUTPUT"
+          fi
+
   install-and-run:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       # One runner per platform key, since the platform key selects the
@@ -48,3 +92,21 @@ jobs:
 
       - name: Walk the documented setup flow in a project
         run: just test-tools-cli
+
+  # The status check to require on `main`: one context, named after nothing that
+  # moves, where the matrix leg names follow the runner images. Requiring it is
+  # a repository setting; without that, a failure here does not stop a merge.
+  # The matrix must have succeeded, or been skipped because the change is not
+  # relevant; anything else, including a cancelled or unexplained skip, fails.
+  install-and-run-result:
+    if: always()
+    needs: [changes, install-and-run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the results
+        env:
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          RESULT: ${{ needs.install-and-run.result }}
+        run: |
+          echo "$RELEVANT $RESULT"
+          [ "$RESULT" = success ] || { [ "$RESULT" = skipped ] && [ "$RELEVANT" = false ]; }

--- a/.github/workflows/tools_manifest.yml
+++ b/.github/workflows/tools_manifest.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - cli/cargo-hax/tools-manifest.toml
       - cli/cargo-hax/defaults.toml
+      - cli/cargo-hax/src/tools.rs
       - cli/cargo-hax/src/tools/**
       - .github/workflows/tools_manifest.yml
   schedule:

--- a/cli/cargo-hax/src/tools/install/host_install.rs
+++ b/cli/cargo-hax/src/tools/install/host_install.rs
@@ -57,9 +57,43 @@ fn default_tools_install_and_run_on_this_platform() {
         for executable in tool_executables(tool) {
             let path = cache::executable_path(&dir, executable)
                 .unwrap_or_else(|e| panic!("{tool} {version}: {e}"));
-            assert_runs(&path);
+            if runs_on_its_own(executable) {
+                assert_runs(&path);
+            } else {
+                assert_executable(&path);
+            }
         }
     }
+}
+
+/// Whether the system can be asked to run an executable on its own.
+///
+/// `charon-driver` cannot: it links against the `librustc_driver` shared
+/// library of the toolchain it was built with, which the archive does not
+/// ship, so only `charon` can load it, through that toolchain. On Linux the
+/// dynamic loader reports the missing library through an ordinary exit,
+/// which `assert_runs` accepts, so spawning it still catches a file built
+/// for another platform; macOS kills it by signal, indistinguishable from a
+/// refused binary, so there being present and executable is all that can be
+/// asked of it.
+fn runs_on_its_own(executable: &str) -> bool {
+    executable != "charon-driver" || cfg!(not(target_os = "macos"))
+}
+
+/// Assert a file carries an execute bit, for executables that cannot be
+/// held to actually running.
+fn assert_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)
+        .unwrap_or_else(|e| panic!("could not stat {}: {e}", path.display()))
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "{} is not executable (mode {mode:o})",
+        path.display()
+    );
 }
 
 /// Assert the operating system can load and run an executable.
@@ -117,5 +151,21 @@ mod tests {
         let path = dir.path().join("charon");
         std::fs::write(&path, "not an executable").unwrap();
         assert_runs(&path);
+    }
+
+    /// `assert_executable` accepts a file with an execute bit.
+    #[test]
+    fn assert_executable_accepts_a_system_executable() {
+        assert_executable(Path::new("/bin/sh"));
+    }
+
+    /// And rejects a file without one.
+    #[test]
+    #[should_panic(expected = "is not executable")]
+    fn assert_executable_rejects_a_plain_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("charon-driver");
+        std::fs::write(&path, "not an executable").unwrap();
+        assert_executable(&path);
     }
 }

--- a/justfile
+++ b/justfile
@@ -112,7 +112,7 @@ test-tools-cli:
   cargo build -q -p cargo-hax --bin cargo-hax
   # `examples/` is its own workspace, so the binary is invoked by path.
   HAX="$PWD/target/debug/cargo-hax"
-  cd examples/chacha20
+  cd examples/barrett
   "$HAX" tools show
   "$HAX" tools install
   "$HAX" tools list --installed


### PR DESCRIPTION
The tool end-to-end workflow now reports a single status check on every pull request, so it can be required on `main`: a paths gate in a job replaces the trigger filter, which would have left the check pending on pull requests it never runs on. The gate lists what the jobs actually exercise and fails closed on a git error.

On macOS, `charon-driver` is only checked for its execute bit, since it cannot load without the `librustc_driver` of its toolchain and macOS kills it by signal, indistinguishable from a broken binary.

The manifest workflow also watches `cli/cargo-hax/src/tools.rs` now, where the tool definitions live.

*Assisted by AI. Reviewed and tested manually.*

[skip changelog]