### PR TITLE
Release prebuilt `cargo-hax` binaries and support `cargo-binstall`

### DIFF
--- a/.github/cargo-hax-targets.json
+++ b/.github/cargo-hax-targets.json
@@ -1,0 +1,5 @@
+[
+  { "os": "ubuntu-22.04", "target": "x86_64-unknown-linux-gnu" },
+  { "os": "ubuntu-22.04-arm", "target": "aarch64-unknown-linux-gnu" },
+  { "os": "macos-latest", "target": "aarch64-apple-darwin" }
+]

--- a/.github/cargo-hax-targets.json
+++ b/.github/cargo-hax-targets.json
@@ -1,0 +1,6 @@
+[
+  { "os": "ubuntu-22.04", "target": "x86_64-unknown-linux-gnu" },
+  { "os": "ubuntu-22.04-arm", "target": "aarch64-unknown-linux-gnu" },
+  { "os": "macos-latest", "target": "aarch64-apple-darwin" },
+  { "os": "macos-15-intel", "target": "x86_64-apple-darwin" }
+]

--- a/.github/workflows/binstall.yml
+++ b/.github/workflows/binstall.yml
@@ -1,0 +1,104 @@
+name: Install a release with cargo-binstall
+
+# Installs a published `cargo-hax` release the way `cargo binstall` does, on
+# every supported platform, and extracts with it.
+#
+# `cargo binstall` builds from source when it cannot find the release asset the
+# published manifest points at, so a release whose archives are missing or
+# misnamed still installs, only slowly: nothing but fetching them tells the two
+# apart. `--strategies crate-meta-data` is what makes that a failure here.
+#
+# Called by the `release` workflow once every archive is published; a manual
+# dispatch re-checks a released version at any time.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The released `cargo-hax` version to install, e.g. `0.3.7`
+        required: true
+  workflow_call:
+    inputs:
+      version:
+        description: The released `cargo-hax` version to install, e.g. `0.3.7`
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version }}
+  cancel-in-progress: true
+
+jobs:
+  # The platforms the release workflow builds archives for, read from the file
+  # both workflows share, so a release is tested on every platform it ships.
+  targets:
+    if: github.repository == 'cryspen/hax'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      # `cargo release` pushes the tag right after publishing, and the sparse
+      # index can lag the publish: until the version is in the index, every
+      # `cargo binstall` below fails to resolve it.
+      - name: Wait for the version on the crates.io index
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          crate=cargo-hax
+          for _ in $(seq 40); do
+            if curl -fsSL \
+                "https://index.crates.io/${crate:0:2}/${crate:2:2}/$crate" \
+                | jq -se --arg v "$VERSION" 'any(.vers == $v)' > /dev/null; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::cargo-hax $VERSION is not on the crates.io index"
+          exit 1
+
+      - uses: actions/checkout@v4
+      - id: targets
+        run: |
+          echo "matrix=$(jq -c '{include: .}' .github/cargo-hax-targets.json)" \
+            >> "$GITHUB_OUTPUT"
+
+  binstall:
+    needs: targets
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.targets.outputs.matrix) }}
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    # Outranks the `rust-toolchain.toml` of the checked-out release, which the
+    # project discovery below would otherwise resolve, fetching a nightly
+    # toolchain that this binary does not need.
+    env:
+      RUSTUP_TOOLCHAIN: stable
+
+    steps:
+      # The example below comes from the released tree, matching the version
+      # installed from crates.io.
+      - uses: actions/checkout@v4
+        with:
+          ref: cargo-hax-v${{ inputs.version }}
+
+      - uses: cargo-bins/cargo-binstall@v1.21.1
+
+      - name: Install the release, from its archive alone
+        env:
+          VERSION: ${{ inputs.version }}
+        run: >
+          cargo binstall --no-confirm --strategies crate-meta-data
+          --targets ${{ matrix.target }} --root "$RUNNER_TEMP/hax"
+          "cargo-hax@$VERSION"
+
+      # Lean is the one backend that runs from the `cargo-hax` binary alone,
+      # so this checks the archive holds a binary this platform can run.
+      - name: Extract to Lean, from that installation
+        working-directory: examples/barrett
+        run: '"$RUNNER_TEMP/hax/bin/cargo-hax" into lean'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,16 @@ concurrency:
 
 jobs:
   # Computes the values every publish job keys on: the tag the release's
-  # artifacts are published under, empty for a ref that is not a release tag,
-  # and the assets published under it already.
+  # artifacts are published under, empty for a ref that is not a release tag;
+  # the assets published under it already; and the platform matrix for
+  # `cargo-hax`.
   tag:
     if: github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       assets: ${{ steps.assets.outputs.assets }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -68,6 +70,13 @@ jobs:
             fi
           fi
           echo "assets=$assets" >> "$GITHUB_OUTPUT"
+
+      # The platforms `cargo-hax` binaries are built for, shared with the
+      # binstall workflow that installs from them.
+      - id: matrix
+        run: |
+          echo "matrix=$(jq -c '{include: .}' .github/cargo-hax-targets.json)" \
+            >> "$GITHUB_OUTPUT"
 
   release-js:
     needs: tag
@@ -149,3 +158,68 @@ jobs:
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           files: hacspec_${{ matrix.os }}.tar.gz
+
+  # The pre-built `cargo-hax` binaries `cargo binstall cargo-hax` installs.
+  #
+  # Default features, on stable, as `cargo install cargo-hax` builds it: this
+  # binary comes without the driver and the engine, so it serves the `lean`
+  # backend, and `legacy-engine` would tie it to the pinned nightly.
+  release-cargo-hax:
+    needs: tag
+    if: needs.tag.outputs.tag != ''
+    strategy:
+      fail-fast: false
+      # Which image is strictest differs by system: on Linux the oldest, glibc
+      # being backward compatible, so a binary built on 22.04 runs on the newer
+      # images too; on macOS the newest, since what refuses a binary there is the
+      # code-signing policy, which Apple only tightens. `macos-15-intel` is
+      # pinned for want of a floating Intel label, not for its version.
+      matrix: ${{ fromJSON(needs.tag.outputs.matrix) }}
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    env:
+      # Outranks `rust-toolchain.toml`, which would otherwise select the pinned
+      # nightly that this binary must not need.
+      RUSTUP_TOOLCHAIN: stable
+      # The oldest macOS the binaries run on, above rustc's own floor for the
+      # Intel target (10.12) so that both are the platform the README documents.
+      MACOSX_DEPLOYMENT_TARGET: '11.0'
+      # Kept in step with the binstall metadata `pkg-url` by a `cargo-hax` test.
+      ARCHIVE: cargo-hax-${{ matrix.target }}.tar.zst
+      # In the delete/re-upload window a `cargo binstall` finds nothing and
+      # silently builds from source. Checked per target, so a release that got
+      # only some of its archives is still completed by a later run.
+      PUBLISHED: ${{ contains(fromJSON(needs.tag.outputs.assets), format('cargo-hax-{0}.tar.zst', matrix.target)) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        if: env.PUBLISHED != 'true'
+      - uses: dtolnay/rust-toolchain@stable
+        if: env.PUBLISHED != 'true'
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build `cargo-hax`
+        if: env.PUBLISHED != 'true'
+        run: cargo build --locked --release -p cargo-hax --target ${{ matrix.target }}
+
+      # Compressed by the `zstd` command, which every image here ships, rather
+      # than by `tar` itself: whether its `--zstd` is available depends on how
+      # the `tar` of the image was built.
+      - name: Package the binary at the archive root
+        if: env.PUBLISHED != 'true'
+        run: |
+          set -o pipefail
+          tar -cf - -C target/${{ matrix.target }}/release cargo-hax \
+            | zstd -9 -T0 -o "$ARCHIVE"
+
+      - name: Release
+        if: env.PUBLISHED != 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.tag.outputs.tag }}
+          files: ${{ env.ARCHIVE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
       assets: ${{ steps.assets.outputs.assets }}
       matrix: ${{ steps.matrix.outputs.matrix }}
     env:
@@ -44,6 +45,7 @@ jobs:
           # is not that tag, such as a dispatch on a branch, is not a release.
           if [ "$GITHUB_REF_NAME" = "cargo-hax-v$version" ]; then
             echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::$GITHUB_REF_NAME is not a release tag"
           fi
@@ -223,3 +225,13 @@ jobs:
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           files: ${{ env.ARCHIVE }}
+
+  # Installs the release the way every user's `cargo binstall` does, once the
+  # archives it fetches are all published.
+  binstall:
+    needs: [tag, release-cargo-hax]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/binstall.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
       assets: ${{ steps.assets.outputs.assets }}
       matrix: ${{ steps.matrix.outputs.matrix }}
     env:
@@ -44,6 +45,7 @@ jobs:
           # is not that tag, such as a dispatch on a branch, is not a release.
           if [ "$GITHUB_REF_NAME" = "cargo-hax-v$version" ]; then
             echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::$GITHUB_REF_NAME is not a release tag"
           fi
@@ -135,3 +137,13 @@ jobs:
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           files: ${{ env.ARCHIVE }}
+
+  # Installs the release the way every user's `cargo binstall` does, once the
+  # archives it fetches are all published.
+  binstall:
+    needs: [tag, release-cargo-hax]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/binstall.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,80 @@
-name: Release binaries for hax-engine
+name: Release binaries
 
+# `cargo release --workspace` pushes every crate's tag in one push, and GitHub
+# raises push events for only some tags of a multi-tag push. When the
+# `cargo-hax-v*` event is among the dropped ones, dispatching this workflow on
+# the tag builds the release's assets.
 on:
   push:
     tags:
-      - '*'
+      - 'cargo-hax-v*'
+  workflow_dispatch:
+
+# A push event and a manual dispatch of the same tag publish the same assets,
+# so runs are grouped by the ref. Runs are never cancelled: cancelling a
+# publish mid-upload can leave the release missing assets. A covered run
+# instead finds every asset published already and skips the work.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  # Computes the values every publish job keys on: the tag the release's
+  # artifacts are published under, empty for a ref that is not a release tag,
+  # and the assets published under it already.
+  tag:
+    if: github.repository == 'cryspen/hax'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      assets: ${{ steps.assets.outputs.assets }}
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: resolve
+        run: |
+          set -o pipefail
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "cargo-hax") | .version')"
+          # `cargo release` tags this crate `cargo-hax-v<version>`; a ref that
+          # is not that tag, such as a dispatch on a branch, is not a release.
+          if [ "$GITHUB_REF_NAME" = "cargo-hax-v$version" ]; then
+            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::$GITHUB_REF_NAME is not a release tag"
+          fi
+
+      # An interrupted upload can leave an asset record that is not
+      # `uploaded`; it does not count as published, so a later run replaces
+      # the remains.
+      - id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          assets='[]'
+          if [ -n "$TAG" ]; then
+            if release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" 2>&1)"; then
+              assets="$(jq -c '[.assets[]
+                | select(.state == "uploaded" and .size > 0) | .name]' <<< "$release")"
+            # Only a missing release means nothing is published; any other
+            # failure must not pass for that and disable the published-assets
+            # guards.
+            elif ! grep -q 'HTTP 404' <<< "$release"; then
+              echo "$release" >&2
+              exit 1
+            fi
+          fi
+          echo "assets=$assets" >> "$GITHUB_OUTPUT"
+
   release-js:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
+    needs: tag
+    # Publishing an asset the release already carries would delete it before
+    # uploading it again, and a download in that window fails. A covered job
+    # is skipped, so a run only publishes what is missing.
+    if: needs.tag.outputs.tag != '' && !contains(fromJSON(needs.tag.outputs.assets), 'hacspec_js.tar.gz')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,10 +90,12 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
+        tag_name: ${{ needs.tag.outputs.tag }}
         files: hacspec_js.tar.gz
 
   release:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
+    needs: tag
+    if: needs.tag.outputs.tag != ''
     strategy:
       fail-fast: false
       matrix:
@@ -34,37 +103,49 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler: [4.14.x]
-        
+
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    env:
+      # Publishing an asset the release already carries would delete it before
+      # uploading it again, and a download in that window fails. Checked per
+      # matrix entry, so a run only publishes what is missing.
+      PUBLISHED: ${{ contains(fromJSON(needs.tag.outputs.assets), format('hacspec_{0}.tar.gz', matrix.os)) }}
     steps:
       - name: Checkout code
+        if: env.PUBLISHED != 'true'
         uses: actions/checkout@v4
 
       - uses: ocaml/setup-ocaml@v2
+        if: env.PUBLISHED != 'true'
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       # `rust-toolchain.toml` selects the toolchain; this only has to put rustup
       # and cargo on PATH.
       - uses: dtolnay/rust-toolchain@stable
+        if: env.PUBLISHED != 'true'
 
-      - run: source .utils/install-rust-binaries.sh && install_rust_binaries
+      - if: env.PUBLISHED != 'true'
+        run: source .utils/install-rust-binaries.sh && install_rust_binaries
 
-      - run: opam install . --deps-only
+      - if: env.PUBLISHED != 'true'
+        run: opam install . --deps-only
         working-directory: engine
-        
-      - run: opam exec -- dune build
+
+      - if: env.PUBLISHED != 'true'
+        run: opam exec -- dune build
         working-directory: engine
 
-      - run: |
+      - if: env.PUBLISHED != 'true'
+        run: |
           cp engine/_build/default/bin/native_driver.exe  hax-engine
           tar -czf hacspec_${{ matrix.os }}.tar.gz hax-engine
-        
+
       - name: Release
+        if: env.PUBLISHED != 'true'
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ needs.tag.outputs.tag }}
           files: hacspec_${{ matrix.os }}.tar.gz
-
-          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,16 @@ concurrency:
 
 jobs:
   # Computes the values every publish job keys on: the tag the release's
-  # artifacts are published under, empty for a ref that is not a release tag,
-  # and the assets published under it already.
+  # artifacts are published under, empty for a ref that is not a release tag;
+  # the assets published under it already; and the platform matrix for
+  # `cargo-hax`.
   tag:
     if: github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       assets: ${{ steps.assets.outputs.assets }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
@@ -69,3 +71,67 @@ jobs:
           fi
           echo "assets=$assets" >> "$GITHUB_OUTPUT"
 
+      # The platforms `cargo-hax` binaries are built for, shared with the
+      # binstall workflow that installs from them.
+      - id: matrix
+        run: |
+          echo "matrix=$(jq -c '{include: .}' .github/cargo-hax-targets.json)" \
+            >> "$GITHUB_OUTPUT"
+
+  release-cargo-hax:
+    needs: tag
+    if: needs.tag.outputs.tag != ''
+    strategy:
+      fail-fast: false
+      # Which image is strictest differs by system: on Linux the oldest, glibc
+      # being backward compatible, so a binary built on 22.04 runs on the newer
+      # images too; on macOS the newest, since what refuses a binary there is
+      # the code-signing policy, which Apple only tightens.
+      matrix: ${{ fromJSON(needs.tag.outputs.matrix) }}
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    env:
+      # Outranks `rust-toolchain.toml`, which would otherwise select the pinned
+      # nightly that this binary must not need.
+      RUSTUP_TOOLCHAIN: stable
+      # The oldest macOS the binary runs on.
+      MACOSX_DEPLOYMENT_TARGET: '11.0'
+      # Kept in step with the binstall metadata `pkg-url` by a `cargo-hax` test.
+      ARCHIVE: cargo-hax-${{ matrix.target }}.tar.zst
+      # In the delete/re-upload window a `cargo binstall` finds nothing and
+      # silently builds from source. Checked per target, so a release that got
+      # only some of its archives is still completed by a later run.
+      PUBLISHED: ${{ contains(fromJSON(needs.tag.outputs.assets), format('cargo-hax-{0}.tar.zst', matrix.target)) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        if: env.PUBLISHED != 'true'
+      - uses: dtolnay/rust-toolchain@stable
+        if: env.PUBLISHED != 'true'
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build `cargo-hax`
+        if: env.PUBLISHED != 'true'
+        run: cargo build --locked --release -p cargo-hax --target ${{ matrix.target }}
+
+      # Compressed by the `zstd` command, which every image here ships, rather
+      # than by `tar` itself: whether its `--zstd` is available depends on how
+      # the `tar` of the image was built.
+      - name: Package the binary at the archive root
+        if: env.PUBLISHED != 'true'
+        run: |
+          set -o pipefail
+          tar -cf - -C target/${{ matrix.target }}/release cargo-hax \
+            | zstd -9 -T0 -o "$ARCHIVE"
+
+      - name: Release
+        if: env.PUBLISHED != 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.tag.outputs.tag }}
+          files: ${{ env.ARCHIVE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release binaries
+
+# `cargo release --workspace` pushes every crate's tag in one push, and GitHub
+# raises push events for only some tags of a multi-tag push. When the
+# `cargo-hax-v*` event is among the dropped ones, dispatching this workflow on
+# the tag builds the release's assets.
+on:
+  push:
+    tags:
+      - 'cargo-hax-v*'
+  workflow_dispatch:
+
+# A push event and a manual dispatch of the same tag publish the same assets,
+# so runs are grouped by the ref. Runs are never cancelled: cancelling a
+# publish mid-upload can leave the release missing assets. A covered run
+# instead finds every asset published already and skips the work.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  # Computes the values every publish job keys on: the tag the release's
+  # artifacts are published under, empty for a ref that is not a release tag,
+  # and the assets published under it already.
+  tag:
+    if: github.repository == 'cryspen/hax'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      assets: ${{ steps.assets.outputs.assets }}
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: resolve
+        run: |
+          set -o pipefail
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "cargo-hax") | .version')"
+          # `cargo release` tags this crate `cargo-hax-v<version>`; a ref that
+          # is not that tag, such as a dispatch on a branch, is not a release.
+          if [ "$GITHUB_REF_NAME" = "cargo-hax-v$version" ]; then
+            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::$GITHUB_REF_NAME is not a release tag"
+          fi
+
+      # An interrupted upload can leave an asset record that is not
+      # `uploaded`; it does not count as published, so a later run replaces
+      # the remains.
+      - id: assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          assets='[]'
+          if [ -n "$TAG" ]; then
+            if release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" 2>&1)"; then
+              assets="$(jq -c '[.assets[]
+                | select(.state == "uploaded" and .size > 0) | .name]' <<< "$release")"
+            # Only a missing release means nothing is published; any other
+            # failure must not pass for that and disable the published-assets
+            # guards.
+            elif ! grep -q 'HTTP 404' <<< "$release"; then
+              echo "$release" >&2
+              exit 1
+            fi
+          fi
+          echo "assets=$assets" >> "$GITHUB_OUTPUT"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changes to cargo-hax:
  - Add `cargo hax tools pin` to write version pins into `hax.toml`, either this release's defaults or a single `<name>@<version>` entry
  - `cargo hax into lean` generates a complete, buildable Lean package by default: project files, a root module, and a `Verification/` folder for handwritten proofs, created only when missing; stale files in `Extraction/` are removed and the root module's imports are checked on every run. Disable with a top-level `project-files = false` in `hax.toml` (#2142)
  - Compile with `cfg(hax)` in the `lean` backend, as the engine-based backends do. Without it `hax-lib` was its dummy implementation, and `loop_invariant!` expanded to code that did not type-check
+ - Publish a pre-built `cargo-hax` binary per supported platform with every release, so that `cargo binstall cargo-hax` installs it without building
  - Make `cargo install cargo-hax` build on any recent toolchain, so that the `lean` backend can be installed on its own and pinned per project with `cargo-run-bin`; the JSON schema exporter the OCaml engine's build consumes moved behind the new `legacy-engine` feature
 
 Changes to hax-lib:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes to cargo-hax:
  - Manage aeneas and charon versions with `cargo hax tools` (`install`, `list`, `show`), pinned via a committed `hax.toml` and installed from pre-built binaries verified against a shipped manifest and cached under `$XDG_CACHE_HOME/hax/tools/`
  - Resolve aeneas and charon from the version manifest instead of `PATH`; use a `path` entry in `hax.toml` to point at a local build
  - Check that the `hax-lib` version in scope matches the `cargo-hax` version before processing
+ - Publish a pre-built `cargo-hax` binary per supported platform with every release, so that `cargo binstall cargo-hax` installs it without building
  - Make `cargo install cargo-hax` build on any recent toolchain, so that the `lean` backend can be installed on its own and pinned per project with `cargo-run-bin`; the JSON schema exporter the OCaml engine's build consumes moved behind the new `legacy-engine` feature
 
 Changes to hax-lib:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ resolver = "2"
 version = "0.3.7"
 authors = ["hax Authors"]
 license = "Apache-2.0"
-homepage = "https://github.com/hacspec/hax"
+homepage = "https://github.com/cryspen/hax"
 edition = "2024"
 rust-version = "1.88"
-repository = "https://github.com/hacspec/hax"
+repository = "https://github.com/cryspen/hax"
 readme = "README.md"
 
 [workspace.dependencies]

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,38 +2,23 @@
 
 ## OCaml
 
-There is only the package `hax-engine`, that includes a binary and a
-number of libraries.
-
-We have no particular release procedure for the engine: we don't plan
-on publishing it to opam.
+The OCaml engine is a single package, `hax-engine`, with a binary and a number of libraries. It is not published to opam and has no release step of its own.
 
 ## Rust
 
-This repository is divided into several crates, some to be published,
-some not. All crates should start with the `hax-` prefix, but
-`cargo-hax` which is the entrypoint to the cargo `hax` subcommand.
+All crates start with the `hax-` prefix, except `cargo-hax` (the entrypoint to the cargo `hax` subcommand) and `test-driver`. The published crates, in dependency order:
 
-Here is the list of the crates in this repository (excluding `tests`
-and `examples`):
-
-### cargo-hax
+**cargo-hax**
 
 1. `hax-frontend-exporter-options` (`frontend/exporter/options`)
 2. `hax-adt-into` (`frontend/exporter/adt-into`)
 3. `hax-frontend-exporter` (`frontend/exporter`)
 4. `hax-types` (`hax-types`)
-5. `cargo-hax` (binaries) (`cli/cargo-hax`)
-   - `cargo-hax`
-   - `hax-export-json-schemas` (only with `--features legacy-engine`)
+5. `cargo-hax` (`cli/cargo-hax`)
+6. `hax-driver` (`cli/driver`)
+7. `test-driver` (`cli/test-driver`)
 
-- `hax-driver` (`cli/driver`)
-- `test-driver` (`cli/test-driver`)
-
-### hax-lib
-
-We publish the following crates that are helper libraries to be used
-for hax code:
+**hax-lib**
 
 1. `hax-lib-macros-types` (`hax-lib/macros/types`)
 2. `hax-lib-macros` (`hax-lib/macros`)
@@ -42,34 +27,22 @@ for hax code:
 
 `cargo-hax` accepts only the `hax-lib` of its own version, so every `cargo-hax` release must publish a matching `hax-lib`, even for changes that only touch the binary.
 
-### The Rust engine
+**Rust engine**
 
 1. `hax-rust-engine-macros` (`rust-engine/macros`)
 2. `hax-rust-engine` (`rust-engine`)
 
-### Crates that are not published
+Crates with `package.metadata.release.release = false` in their `Cargo.toml` are not published: `hax-engine-names` and `hax-engine-names-extract` (used only by the OCaml build of the engine), `hax-lib-protocol` and `hax-lib-protocol-macros`.
 
-- `hax-engine-names` (`engine/names`) and
-  `hax-engine-names-extract` (`engine/names/extract`): used only by
-  the OCaml build of the engine.
-- `hax-lib-protocol` (`hax-lib-protocol`) and
-  `hax-lib-protocol-macros` (`hax-lib-protocol-macros`).
+## Binaries
+
+Pushing the release's `cargo-hax-v*` tag runs the `release` workflow, which attaches a `cargo-hax` binary per supported platform to the GitHub release it creates at that tag. `cargo binstall cargo-hax` downloads those, at the names `package.metadata.binstall` in `cli/cargo-hax/Cargo.toml` declares, so both the archives and the published manifest have to be in place for a version to be binstallable. The `binstall` workflow verifies that pairing at the end of every `release` run; a manual dispatch re-checks a released version at any time.
 
 ## Procedure
- 1. Move the contents of `CHANGELOG.md` under the `[Unreleased]` section to a new section named following the target version. Commit this change.
- 2. Bump the version number with `cargo release LEVEL --workspace --no-publish --no-tag --execute` (`cargo release --help` for more details on `LEVEL`, `cargo install cargo-release` if you don't already have this package). This will bump the version of every Rust crate, but also the version in `engine/dune-project`. This will also regenerate `engine/hax-engine.opam`. Note this will *not* publish the crate.
- 3. Check that the default tool versions in `cli/cargo-hax/defaults.toml` are correct and that `cli/cargo-hax/tools-manifest.toml` lists them with checksums for every supported platform
- 4. PR the change
- 5. when the PR is merged in main, checkout `main` and run `cargo release --workspace --execute`
 
-Note: for now, we are not publishing to Opam. Instead, let's just advertise the following for installation:
-```bash
-opam pin hax-engine https://github.com/hacspec/hax.git#the-release-tag
-opam install hax-engine
-```
-
-## Notes
-`cargo release` reads the `Cargo.toml` of each crates of the workspace.
-Some creates are excluded from releasing: in their `Cargo.toml` manifest, they have `package.metadata.release.release` set to `false`.
-
-Also, `cli/cargo-hax/Cargo.toml` specifies pre-release replacements for the engine: the version of the engine is bumped automatically by `cargo release`.
+1. Move the contents of `CHANGELOG.md` under the `[Unreleased]` section to a new section named after the target version. Commit this change.
+2. Bump the version number with `cargo release LEVEL --workspace --no-publish --no-tag --execute` (`cargo install cargo-release` if needed). This bumps the version of every Rust crate and the version in `engine/dune-project`, and regenerates `engine/hax-engine.opam`. It does not publish anything.
+3. Check that the default tool versions in `cli/cargo-hax/defaults.toml` are correct and that `cli/cargo-hax/tools-manifest.toml` lists them with checksums for every supported platform.
+4. PR the change.
+5. When the PR is merged, checkout `main` and run `cargo release --workspace --execute`.
+6. Check that the `release` workflow went through. It attaches a `cargo-hax` archive per platform to the GitHub release at the `cargo-hax-v*` tag, then installs the released version with `cargo binstall` on every platform. GitHub raises push events for only some tags of a multi-tag push: when no run started, dispatch the workflow with `gh workflow run release.yml --ref cargo-hax-vX.Y.Z` (or the "Run workflow" button under Actions, picking the tag as the ref). The tag must be the ref: a dispatch on any other ref is recognized as not being a release and skipped.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ cargo install --locked cargo-hax
 
 `--locked` uses the dependency versions the release was tested with.
 
+To skip that build, use [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) to download the binary the release published:
+
+```bash
+cargo binstall cargo-hax
+```
+
+The binary is the one `cargo install --locked` would produce, built on stable. It needs glibc 2.35 or newer on Linux, and macOS 11 or newer. `cargo binstall` checks neither: it picks the archive from the platform alone, so an older system installs a binary that fails to start; `cargo install --locked cargo-hax` covers those systems. Releases from before 0.4.0 carry no binary at all, and `cargo binstall` falls back to building from source there: pass `--strategies crate-meta-data` to have it fail instead of compiling.
+
 Aeneas and Charon themselves need no install step: hax downloads pre-built binaries on demand. See [Managing tool versions](https://hax.cryspen.com/manual/tools/) in the manual for how they are managed, pinning versions per project, and using your own binaries.
 
 #### From the repository

--- a/cli/cargo-hax/Cargo.toml
+++ b/cli/cargo-hax/Cargo.toml
@@ -96,6 +96,20 @@ hax-lib-macros-types = { workspace = true, features = ["schemars"], optional = t
 version_check = "0.9"
 toml = "0.8"
 
+# Where `cargo binstall cargo-hax` looks for a pre-built binary. The templates it
+# would try by default assume a `v{version}` tag, which this repository does not
+# use; `{ target }` is a target triple, so the release assets are named after one,
+# and they hold the binary at the archive root. The archives carry `cargo-hax`
+# alone: `hax-export-json-schemas` needs a feature, which makes it optional here.
+#
+# `cargo binstall` reads this from the manifest published to crates.io, so a
+# version is binstallable only if it was published with these keys and its
+# release carries the assets they name.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/cargo-hax-v{ version }/cargo-hax-{ target }.tar.zst"
+pkg-fmt = "tzstd"
+bin-dir = "{ bin }{ binary-ext }"
+
 [package.metadata.release]
 pre-release-hook = [
     "dune",

--- a/cli/cargo-hax/tests/release_metadata.rs
+++ b/cli/cargo-hax/tests/release_metadata.rs
@@ -1,0 +1,161 @@
+//! Checks that the binstall metadata of this crate and the release workflow
+//! describe the same archives.
+//!
+//! `cargo binstall` fetches what `package.metadata.binstall` renders to, and
+//! builds from source when it is not there: an archive the release workflow
+//! names or compresses otherwise leaves a release that is silently not
+//! binstallable, or one that every user's `cargo binstall` fails to unpack.
+//! Since both sides of that agreement are files in this repository, it is
+//! checked here rather than at release time, where the first version to
+//! disagree is already published.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// `package.metadata.binstall` of this crate.
+fn binstall_metadata() -> toml::Value {
+    let manifest =
+        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+            .unwrap()
+            .parse::<toml::Value>()
+            .unwrap();
+    manifest["package"]["metadata"]["binstall"].clone()
+}
+
+/// A workflow of this repository, or `None` outside a checkout: the published
+/// crate carries this test, but not the workflows it reads. Whether this is a
+/// checkout is decided by the directory, so that a workflow that moved or was
+/// renamed fails these tests instead of skipping them.
+fn workflow(name: &str) -> Option<String> {
+    let dir: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.github/workflows");
+    dir.is_dir()
+        .then(|| std::fs::read_to_string(dir.join(name)).expect(name))
+}
+
+/// The `ARCHIVE` the release workflow packages, as a `pkg-url` template: the
+/// name is per target there, and per `{ target }` in the metadata.
+fn archive_template(workflow: &str) -> String {
+    let archive = workflow
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("ARCHIVE:"))
+        .expect("the release workflow names an ARCHIVE")
+        .trim();
+    archive.replace("${{ matrix.target }}", "{ target }")
+}
+
+/// The script of the release workflow step that packages the archive.
+fn packaging_script(workflow: &str) -> String {
+    let lines: Vec<&str> = workflow.lines().collect();
+    let indent = |line: &str| line.len() - line.trim_start().len();
+    let step = lines
+        .iter()
+        .position(|line| line.trim() == "- name: Package the binary at the archive root")
+        .expect("the release workflow has a packaging step");
+    let run = (step..lines.len())
+        .find(|&i| lines[i].trim() == "run: |")
+        .expect("the packaging step has a run block");
+    lines[run + 1..]
+        .iter()
+        .take_while(|line| line.trim().is_empty() || indent(line) > indent(lines[run]))
+        .map(|line| line.trim_start())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn the_release_workflow_names_the_archive_binstall_fetches() {
+    let Some(release) = workflow("release.yml") else {
+        return;
+    };
+    let pkg_url = binstall_metadata()["pkg-url"].as_str().unwrap().to_string();
+    let (_, file) = pkg_url.rsplit_once('/').unwrap();
+    assert_eq!(file, archive_template(&release));
+}
+
+#[test]
+fn the_archive_is_published_under_the_tag_a_release_makes() {
+    let pkg_url = binstall_metadata()["pkg-url"].as_str().unwrap().to_string();
+    // `cargo release --workspace` tags this crate as `cargo-hax-v<version>`,
+    // and the release workflow publishes the archives under that tag.
+    assert!(
+        pkg_url.contains("/releases/download/cargo-hax-v{ version }/"),
+        "{pkg_url}"
+    );
+    let Some(release) = workflow("release.yml") else {
+        return;
+    };
+    assert!(
+        release.contains("\"cargo-hax-v$version\""),
+        "the release workflow publishes under another tag"
+    );
+}
+
+#[test]
+fn the_declared_format_matches_the_archive_name() {
+    let metadata = binstall_metadata();
+    let pkg_url = metadata["pkg-url"].as_str().unwrap();
+    let pkg_fmt = metadata["pkg-fmt"].as_str().unwrap();
+    // `cargo binstall` unpacks by `pkg-fmt`, whatever the name says.
+    assert_eq!(pkg_fmt, "tzstd", "{pkg_url}");
+    assert!(pkg_url.ends_with(".tar.zst"), "{pkg_url}");
+}
+
+/// Runs the workflow's packaging step on a stand-in binary and unpacks the
+/// archive the way `cargo binstall` unpacks `tzstd`: the binary has to sit at
+/// the path `bin-dir` renders to, or every install fails to find it.
+#[test]
+fn the_binary_sits_in_the_archive_where_the_metadata_says() {
+    let Some(release) = workflow("release.yml") else {
+        return;
+    };
+    // The packaging step pipes through the `zstd` command.
+    if Command::new("zstd").arg("--version").output().is_err() {
+        eprintln!("skipped: `zstd` is not on PATH");
+        return;
+    }
+
+    let target = "x86_64-unknown-linux-gnu";
+    let archive = archive_template(&release).replace("{ target }", target);
+    let script = packaging_script(&release).replace("${{ matrix.target }}", target);
+
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("release-archive");
+    let _ = std::fs::remove_dir_all(&dir);
+    let release_dir = dir.join("target").join(target).join("release");
+    std::fs::create_dir_all(&release_dir).unwrap();
+    std::fs::write(release_dir.join("cargo-hax"), "the binary").unwrap();
+
+    let packaging = Command::new("bash")
+        .args(["-ec", &script])
+        .env("ARCHIVE", &archive)
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    assert!(
+        packaging.status.success(),
+        "{}",
+        String::from_utf8_lossy(&packaging.stderr)
+    );
+
+    let entries = Command::new("bash")
+        .args([
+            "-eo",
+            "pipefail",
+            "-c",
+            r#"zstd -dc -- "$ARCHIVE" | tar -tf -"#,
+        ])
+        .env("ARCHIVE", &archive)
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    assert!(
+        entries.status.success(),
+        "{}",
+        String::from_utf8_lossy(&entries.stderr)
+    );
+    let bin = binstall_metadata()["bin-dir"]
+        .as_str()
+        .unwrap()
+        .replace("{ bin }", "cargo-hax")
+        .replace("{ binary-ext }", "");
+    assert_eq!(String::from_utf8_lossy(&entries.stdout).trim(), bin);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,7 @@
             pkgs.pkg-config
             pkgs.rust-analyzer
             pkgs.toml2json
+            pkgs.zstd
             rustfmt
             utils
 


### PR DESCRIPTION
Building on the standalone installation (#2125), every release now ships a pre-built `cargo-hax` binary per supported platform, so `cargo binstall cargo-hax` installs the Lean-backend toolchain without compiling.

## Release workflow

- Triggers on the `cargo-hax-v*` tag only and publishes all assets under that single tag.
- A new job builds `cargo-hax` for `x86_64`/`aarch64` Linux and macOS and attaches one `.tar.zst` archive per target.
- Already-published assets are skipped, so an interrupted publish is completed by re-running.
- Build images set the compatibility floors: glibc 2.35 and macOS 11.0.

## binstall metadata

- `cli/cargo-hax/Cargo.toml` declares `package.metadata.binstall`, pointing `cargo binstall` at the release archives.
- This requires a correct workspace `repository` URL, so it moves from `hacspec/hax` to `cryspen/hax`.

## Verification

- A new test checks the metadata against the release workflow (archive name, tag scheme, format, binary location) by running the workflow's packaging step on a stand-in binary. A mismatch fails CI instead of producing a release that silently isn't binstallable.
- A manual `binstall` workflow installs a published release on every supported platform and extracts to Lean with it, as the last step of the release procedure.

## Docs

- The README documents `cargo binstall cargo-hax`.
- PUBLISHING.md gains the release steps for the binaries.
- The CHANGELOG notes the pre-built binaries.

*Assisted by AI. Reviewed manually.*