### PR TITLE
Update OCaml to 5.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   release-js:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
+    if: github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,19 +22,20 @@ jobs:
         tar --dereference -czf hacspec_js.tar.gz hax-engine.js
 
     - name: Release
+      if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
         files: hacspec_js.tar.gz
 
   release:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'cryspen/hax'
+    if: github.repository == 'cryspen/hax'
     strategy:
       fail-fast: false
       matrix:
         os:
           - macos-latest
           - ubuntu-latest
-        ocaml-compiler: [4.14.x]
+        ocaml-compiler: [5.4.1]
         
     runs-on: ${{ matrix.os }}
     permissions:
@@ -42,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: ocaml/setup-ocaml@v2
+      - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -61,6 +63,7 @@ jobs:
           tar -czf hacspec_${{ matrix.os }}.tar.gz hax-engine
         
       - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: hacspec_${{ matrix.os }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1.70
           
-      - run: cargo install --path cli/driver && cargo install --path cli/cargo-hax
+      - run: cargo install --path cli/driver && cargo install --path cli/cargo-hax && cargo install --path engine/names/extract
 
       - run: opam install . --deps-only
         working-directory: engine

--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -35,7 +35,7 @@ jobs:
     - run: curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
     - if: runner.os == 'macOS'
       run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-    - run: opam init --bare -y && opam switch create -y 5.1.1
+    - run: opam init --bare -y && opam switch create -y 5.4.1
     - name: Run `setup.sh`
       run: |
         export OPAMERRLOGLEN=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Changes to the Lean backend:
 - Lean library for the new Lean/Aeneas backend (cryspen/hax-evit/188, #2080)
 
 Miscellaneous:
+ - Update the required OCaml version to 5.4.1 (#2137)
  - New testing framework for the engine(s) (cryspen/hax-evit/135, cryspen/hax-evit/167)
  - Four examples for the new Aeneas/Lean backend (cryspen/hax-evit/190, cryspen/hax-evit/191,
    cryspen/hax-evit/192, #2058, #2059, #2070, #2061)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ hax is supported on Linux and macOS, on both `x86_64` and `aarch64`. Windows is 
   - [`jq`](https://jqlang.github.io/jq/)
 
 2. Clone this repo: `git clone git@github.com:cryspen/hax.git && cd hax`
-3. Create (or use an existing) opam *switch* by running `opam switch create hax 5.1.1`
+3. Create (or use an existing) opam *switch* by running `opam switch create hax 5.4.1`
 3. Run the [setup.sh](./setup.sh) script: `./setup.sh`.
    This installs hax; aeneas and charon are downloaded on demand when first needed.
 4. Run `cargo-hax --help`

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -1,10 +1,10 @@
 { craneLib, stdenv, makeWrapper, lib, rustc, rustc-docs, gcc, hax-engine
-, doCheck ? true, libz, just, libiconv }:
+, doCheck ? true, zlib, just, libiconv }:
 let
   pname = "hax";
   is-webapp-static-asset = path:
     builtins.match ".*(script[.]js|index[.]html)" path != null;
-  buildInputs = lib.optionals stdenv.isDarwin [ libiconv libz.dev ];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv zlib.dev ];
   binaries = [ hax hax-engine.bin rustc gcc hax_rust_engine ] ++ buildInputs;
   commonArgs = {
     version = "0.0.1";
@@ -90,12 +90,12 @@ in stdenv.mkDerivation {
       ${
         lib.optionalString stdenv.isDarwin ''
           --prefix RUSTFLAGS : "-C link-arg=-L${libiconv}/lib" \
-          --suffix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libz rustc ]}
+          --suffix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ zlib rustc ]}
         ''
       } \
       ${
         lib.optionalString stdenv.isLinux ''
-          --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libz rustc ]}
+          --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ zlib rustc ]}
         ''
       }
   '';

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -32,7 +32,7 @@ hax is supported on Linux and macOS, on both `x86_64` and `aarch64`. Windows is 
 
 1. Make sure to have the following installed on your system:
 
-      - [`opam`](https://opam.ocaml.org/) (`opam switch create 5.1.1`)
+      - [`opam`](https://opam.ocaml.org/) (`opam switch create 5.4.1`)
       - [`rustup`](https://rustup.rs/)
       - [`nodejs`](https://nodejs.org/)
       - [`jq`](https://jqlang.github.io/jq/)

--- a/engine/bin/js_driver.ml
+++ b/engine/bin/js_driver.ml
@@ -95,4 +95,4 @@ let _ =
         output_char stdout '\n';
         flush stdout
     end);
-  Lib.main ()
+  Lib.engine ()

--- a/engine/default.nix
+++ b/engine/default.nix
@@ -15,21 +15,6 @@ let
     minimalOCamlVersion = "4.08";
     doCheck = false;
   };
-  ppx_matches = ocamlPackages.buildDunePackage rec {
-    pname = "ppx_matches";
-    version = "0.1";
-
-    src = fetchzip {
-      url =
-        "https://github.com/wrbs/ppx_matches/archive/refs/tags/${version}.zip";
-      sha256 = "sha256-nAmWF8MgW0odKkRiFcHGsvJyIxNHaZpnOlNPsef89Fo=";
-    };
-
-    buildInputs = [ ocamlPackages.ppxlib ];
-    duneVersion = "3";
-    minimalOCamlVersion = "4.04";
-    doCheck = false;
-  };
   hax-engine = ocamlPackages.buildDunePackage {
     pname = "hax-engine";
     version = "0.0.1";
@@ -55,7 +40,6 @@ let
         pprint
         non_empty_list
         ppx_deriving_yojson
-        ppx_matches
         ppx_let
         ppx_enumerate
         cmdliner

--- a/engine/dune-project
+++ b/engine/dune-project
@@ -38,7 +38,6 @@
         cmdliner
         angstrom
         re
-        ppx_matches
         ppx_string
         logs
         (ocamlgraph (>= "2.2.0"))

--- a/engine/hax-engine.opam
+++ b/engine/hax-engine.opam
@@ -28,7 +28,6 @@ depends: [
   "cmdliner"
   "angstrom"
   "re"
-  "ppx_matches"
   "ppx_string"
   "logs"
   "ocamlgraph" {>= "2.2.0"}

--- a/engine/utils/ppx_matches/dune
+++ b/engine/utils/ppx_matches/dune
@@ -1,0 +1,7 @@
+(library
+ (name ppx_matches)
+ (package hax-engine)
+ (kind ppx_rewriter)
+ (libraries ppxlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/engine/utils/ppx_matches/ppx_matches.ml
+++ b/engine/utils/ppx_matches/ppx_matches.ml
@@ -1,0 +1,28 @@
+(* Translates [%matches? PATTERN] into (fun x -> match x with PATTERN -> true | _ -> false).
+   Vendored from https://github.com/wrbs/ppx_matches (MIT License, Copyright (c) 2021 Will
+   Robson), as the upstream project is unmaintained and incompatible with ppxlib >= 0.36. *)
+
+open Ppxlib
+
+let name = "matches"
+
+let expand ~ctxt pat guard =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let open Ast_builder.Default in
+  let cases =
+    [
+      case ~lhs:pat ~guard ~rhs:[%expr true];
+      case ~lhs:(ppat_any ~loc) ~guard:None ~rhs:[%expr false];
+    ]
+  in
+  [%expr
+    fun __ppx_matches_value ->
+      [%e pexp_match ~loc [%expr __ppx_matches_value] cases]]
+
+let ext =
+  Extension.V3.declare name Extension.Context.expression
+    Ast_pattern.(ppat __ __)
+    expand
+
+let rule = Ppxlib.Context_free.Rule.extension ext
+let () = Ppxlib.Driver.register_transformation ~rules:[ rule ] name

--- a/engine/utils/universe-hash.sh
+++ b/engine/utils/universe-hash.sh
@@ -28,7 +28,7 @@ function error() {
     echo "Error: could not find [$1] in PATH." >&2
     echo "Please make sure that:" >&2
     echo '  - you ran Hax''s `setup.sh` script;' >&2
-    echo "  - you have `~/.cargo/bin` in your PATH ($DIAG)." >&2
+    echo '  - you have `~/.cargo/bin` in your PATH ('"$DIAG"').' >&2
     exit 1
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -103,16 +103,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1761999846,
-        "narHash": "sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo=",
+        "lastModified": 1786535285,
+        "narHash": "sha256-rG5HKMAgAhMgydvKGtco6rqTxRq4EDZQCx9USLvVqYw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3de8f8d73e35724bf9abef41f1bdbedda1e14a31",
+        "rev": "9f78f44a87948854445dae0b6bf82b2e87e4efb5",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -189,7 +189,7 @@
             pkgs.cargo-expand
             pkgs.cargo-release
             pkgs.openssl.dev
-            pkgs.libz.dev
+            pkgs.zlib.dev
             pkgs.pkg-config
             pkgs.rust-analyzer
             pkgs.toml2json
@@ -199,7 +199,7 @@
             pkgs.go-grip
           ];
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-          DYLD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.libz rustc ];
+          DYLD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.zlib rustc ];
         in {
           examples = pkgs.mkShell {
             inherit LIBCLANG_PATH DYLD_LIBRARY_PATH;

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
     crane = { url = "github:ipetkov/crane"; };
     rust-overlay = {
@@ -56,7 +56,9 @@
           fi
         '';
         ocamlPackages = pkgs.ocamlPackages;
-        ocamlformat = ocamlPackages.ocamlformat_0_27_0;
+        # ocamlformat 0.27.0 is marked broken for OCaml 5.4, so build it
+        # from the OCaml 5.3 package set.
+        ocamlformat = pkgs.ocaml-ng.ocamlPackages_5_3.ocamlformat_0_27_0;
         proverif = pkgs.proverif.overrideDerivation
           (_: { patches = [ examples/proverif-psk/pv_div_by_zero_fix.diff ]; });
       in rec {

--- a/setup.sh
+++ b/setup.sh
@@ -122,7 +122,7 @@ install_ocaml_engine() {
 
 warn_if_dirty
 
-REQUIRED_OCAML_VERSION="5.1.1"
+REQUIRED_OCAML_VERSION="5.4.1"
 ensure_ocaml_version() {
     CURRENT_VERSION=$(opam exec -- ocamlc --version 2>/dev/null || echo "none")
     if [ "$CURRENT_VERSION" != "$REQUIRED_OCAML_VERSION" ]; then


### PR DESCRIPTION
Updates OCaml to 5.4.1 and nixpkgs to nixos-26.05, updates setup-ocaml to v3, and makes the release workflow manually runnable for testing without publishing.

Preparatory commits fix issues that the update would otherwise expose, or that already break the release workflow on `main`:

- **Vendor ppx_matches**: the upstream project is unmaintained and incompatible with ppxlib >= 0.36, which is required for OCaml 5.4. The ppx is now an internal dune library.
- **Replace libz by zlib**: nixpkgs' `libz` is an outdated zlib fork that lacks the `ZLIB_1.2.9` symbol version required by newer binutils. As the cargo-hax wrapper puts it on `LD_LIBRARY_PATH`, it broke all C compilations in subprocesses.
- **Install hax-engine-names-extract in release workflow**: the engine build requires this binary, so the release job has been failing since the dependency was introduced in January 2024.
- **Fix entry point of JS driver**: `Lib.main` was renamed to `Lib.engine`, breaking the JS build of the engine, which is only exercised by the release workflow.

*Assisted by AI. Reviewed manually.*