### PR TITLE
ci: create version tags when syncing hax lean lib

### DIFF
--- a/.github/workflows/check_hax_lean_version.yml
+++ b/.github/workflows/check_hax_lean_version.yml
@@ -1,0 +1,108 @@
+name: Check hax-lean version
+
+# The Lean library in `hax-lib/proof-libs/lean` is published as its own
+# repository: `deploy_hax_lean.yml` mirrors it to `cryspen/hax-lean` on
+# every commit that lands on `main`, and tags each snapshot with the
+# library's version.
+#
+# That version lives in two places, and they have to agree:
+#
+#   * `version` in `hax-lib/proof-libs/lean/lakefile.toml` — the library's own
+#     idea of what it is. Lake parses this as a semantic version, so it carries
+#     no `v` prefix.
+#   * `hax-lean-lib` in `cli/cargo-hax/defaults.toml` — the tag of
+#     `cryspen/hax-lean` that extracted code is pinned against. This is a git
+#     tag, spelled with the `v` prefix.
+#
+# This workflow enforces that correspondence, and that the version is bumped
+# whenever the library itself changes: without a bump, a second, different
+# snapshot would land under a tag that is already published.
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-version:
+    name: Check the Lean library version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # The bump check diffs against the base of this change, so the tip
+          # commit alone is not enough.
+          fetch-depth: 0
+
+      - name: Check the version fields against each other and against the base
+        env:
+          # What to compare against: the target branch for a pull request, the
+          # base the queue built on for a merge group.
+          BASE: >-
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha
+            || github.event.merge_group.base_sha }}
+          LEAN_LIB: hax-lib/proof-libs/lean
+        run: |
+          set -euo pipefail
+
+          # The reader takes the file on stdin, so that it can be pointed
+          # either at the worktree or at a blob out of git history.
+          #
+          # `/^\[/q` stops at the first table header: only the package section
+          # of the lakefile declares the package version, and a dependency's
+          # own `version` key must never be picked up instead.
+          lakefile_version() {
+            sed -n '/^\[/q; s/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p'
+          }
+
+          LAKE=$(lakefile_version < "$LEAN_LIB/lakefile.toml")
+          DEFAULTS=$(sed -n 's/^[[:space:]]*hax-lean-lib[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            cli/cargo-hax/defaults.toml)
+
+          if [ -z "$LAKE" ]; then
+            echo "::error file=$LEAN_LIB/lakefile.toml::No version field in the Lean library lakefile."
+            exit 1
+          fi
+          if [ -z "$DEFAULTS" ]; then
+            echo "::error file=cli/cargo-hax/defaults.toml::No hax-lean-lib entry in defaults.toml."
+            exit 1
+          fi
+
+          # The lakefile spells the version bare, defaults.toml spells it as
+          # the git tag it resolves to; they differ by exactly the v prefix.
+          if [ "v$LAKE" != "$DEFAULTS" ]; then
+            echo "::error::Version mismatch: $LEAN_LIB/lakefile.toml says '$LAKE', so defaults.toml must say 'v$LAKE', but it says '$DEFAULTS'."
+            exit 1
+          fi
+          echo "Both files agree on $DEFAULTS."
+
+          # A run with no usable base has nothing to compare against; there is
+          # no bump to check.
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "No base commit available; skipping the bump check."
+            exit 0
+          fi
+
+          if git diff --quiet "$BASE" HEAD -- "$LEAN_LIB"; then
+            echo "The in-tree Lean library is unchanged; no bump required."
+            exit 0
+          fi
+
+          # The base version, read the same way. A base predating the lakefile
+          # version field compares against 0.0.0, so any version passes.
+          BASE_LAKE=$(git show "$BASE:$LEAN_LIB/lakefile.toml" 2>/dev/null | lakefile_version || true)
+          BASE_LAKE="${BASE_LAKE:-0.0.0}"
+
+          # Strictly greater: `sort -V` puts the older version first, so if the
+          # base does not sort first, or the two are equal, the bump is missing.
+          LOWEST=$(printf '%s\n%s\n' "$BASE_LAKE" "$LAKE" | sort -V | head -n 1)
+          if [ "$BASE_LAKE" = "$LAKE" ] || [ "$LOWEST" != "$BASE_LAKE" ]; then
+            echo "::error file=$LEAN_LIB/lakefile.toml::$LEAN_LIB changed, so its version must increase, but it went from '$BASE_LAKE' to '$LAKE'. Bump it here and in cli/cargo-hax/defaults.toml."
+            exit 1
+          fi
+          echo "The Lean library changed and its version went $BASE_LAKE -> $LAKE."

--- a/.github/workflows/deploy_hax_lean.yml
+++ b/.github/workflows/deploy_hax_lean.yml
@@ -1,7 +1,10 @@
 name: Deploy cryspen/hax-lean
 
 # On every commit that lands on `main`, mirror the current state of
-# `hax-lib/proof-libs/lean` into the `cryspen/hax-lean` repository.
+# `hax-lib/proof-libs/lean` into the `cryspen/hax-lean` repository, and tag the
+# resulting snapshot with the library's version.
+#
+# The workflow `check_hax_lean_version.yml` checks that the version is valid and pinned.
 
 on:
   push:
@@ -51,9 +54,11 @@ jobs:
           # Overwrite whatever text sits between them with the note above.
           perl -i -pe 's/⚠️.*⚠️/⚠️ $ENV{NOTE} ⚠️/' README.md
 
-      - name: Commit and push if there are changes
+      - name: Commit, tag and push if there are changes
         working-directory: target
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -67,8 +72,39 @@ jobs:
           SHA=$(git -C ../source rev-parse HEAD)
           AUTHOR=$(git -C ../source log -1 --format='%an <%ae>')
 
+          # The snapshot is tagged with the version that extracted code pins,
+          # so that the hax-lean-lib entry of defaults.toml resolves to exactly
+          # the tree being mirrored.
+          VERSION=$(sed -n 's/^[[:space:]]*hax-lean-lib[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            ../source/cli/cargo-hax/defaults.toml)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read the hax-lean-lib version from defaults.toml."
+            exit 1
+          fi
+
+          # What the mirrored tree itself claims to be.
+          DECLARED=$(sed -n '/^\[/q; s/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            lakefile.toml)
+          
+          # Check that the two correspond:
+          if [ "$VERSION" != "v$DECLARED" ]; then
+            echo "::error::Refusing to publish: defaults.toml pins '$VERSION', but the mirrored lakefile.toml declares '$DECLARED'."
+            exit 1
+          fi
+
+          # Every change to the library must come with a bump, so the tag
+          # should be free. If it is not, two different snapshots claim the
+          # same version: refuse rather than silently move a published tag.
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists in cryspen/hax-lean, but this commit changes the library. Bump the version instead of reusing it."
+            exit 1
+          fi
+
           git commit \
             --author="$AUTHOR" \
             -m "$MSG" \
             -m "Snapshot of cryspen/hax@${SHA}"
-          git push
+          git tag -a "$VERSION" -m "hax-lean $VERSION (cryspen/hax@${SHA})"
+
+          # Branch and tag land together, or neither does.
+          git push --atomic origin HEAD "refs/tags/$VERSION"

--- a/cli/cargo-hax/defaults.toml
+++ b/cli/cargo-hax/defaults.toml
@@ -16,5 +16,7 @@ charon = "nightly-2026.07.24"
 # Declared-only versions: known to hax, but not installed by it.
 # The Lean toolchain, written verbatim into generated `lean-toolchain` files.
 lean = "leanprover/lean4:v4.31.0"
-# The Lean library that extracted code builds against.
-hax-lean-lib = "v0.2.0"
+# The Lean library that extracted code builds against. This is a tag in
+# `cryspen/hax-lean`, pushed by `.github/workflows/deploy_hax_lean.yml`; it
+# must match `version` in `hax-lib/proof-libs/lean/lakefile.toml`.
+hax-lean-lib = "v0.3.0"

--- a/cli/cargo-hax/src/tools/defaults.rs
+++ b/cli/cargo-hax/src/tools/defaults.rs
@@ -56,4 +56,34 @@ mod tests {
             assert!(super::super::DECLARED_VERSION_KEYS.contains(&key.as_str()));
         }
     }
+
+    /// The version of `hax-lean-lib` in `defaults.toml` must be the same as the version
+    /// declared in `hax-lib/proof-libs/lean/lakefile.toml`.
+    #[test]
+    fn hax_lean_lib_pin_matches_declared_version() {
+        let lean_lib =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../hax-lib/proof-libs/lean");
+        // Nix builds this crate from a filtered source tree that drops
+        // `proof-libs`. In such a situation, we need to skip this test:
+        if !lean_lib.is_dir() {
+            return;
+        }
+        let path = lean_lib.join("lakefile.toml");
+        let contents = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+        let lakefile: toml::Value = toml::from_str(&contents)
+            .unwrap_or_else(|e| panic!("{} is malformed: {e}", path.display()));
+        let declared = lakefile
+            .get("version")
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("{} declares no `version`", path.display()));
+
+        let pinned = &defaults().versions["hax-lean-lib"];
+        assert_eq!(
+            pinned,
+            &format!("v{declared}"),
+            "`hax-lean-lib` in defaults.toml must pin the version declared in {}",
+            path.display()
+        );
+    }
 }

--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,4 +1,5 @@
 name = "hax"
+version = "0.3.0"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
Fixes #2083 

This PR solves the issue of version synchronization between the `defaults.toml` file in this repo and the version numbers on the `hax-lean` repo. The solution is:
- A CI job forces us to keep the version numbers in `defaults.toml` and `lakefile.toml` in sync, and bump them with every change.
- The CI job that copies changes into the `hax-lean` repo also adds a GitHub tag carrying the version number to inform Reservoir about the new version.

Assisted-By: Claude Opus 4.8

[skip changelog]