### PR TITLE
feat(cli): add `cargo hax tools remove` and `cargo hax tools clean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Changes to cargo-hax:
  - Manage aeneas and charon versions with `cargo hax tools` (`install`, `list`, `show`), pinned via a committed `hax.toml` and installed from pre-built binaries verified against a shipped manifest and cached under `$XDG_CACHE_HOME/hax/tools/`
  - Resolve aeneas and charon from the version manifest instead of `PATH`; use a `path` entry in `hax.toml` to point at a local build
  - Check that the `hax-lib` version in scope matches the `cargo-hax` version before processing
- - Add `cargo hax tools remove <tool>@<version>` to delete a cached tool version
+ - Add `cargo hax tools remove <tool>@<version>` and `cargo hax tools clean` to delete a cached tool version or the whole tool cache
 
 Changes to hax-lib:
  - Basis of core model testing infrastructure (cryspen/hax-evit/160, cryspen/hax-evit/164)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes to cargo-hax:
  - Manage aeneas and charon versions with `cargo hax tools` (`install`, `list`, `show`), pinned via a committed `hax.toml` and installed from pre-built binaries verified against a shipped manifest and cached under `$XDG_CACHE_HOME/hax/tools/`
  - Resolve aeneas and charon from the version manifest instead of `PATH`; use a `path` entry in `hax.toml` to point at a local build
  - Check that the `hax-lib` version in scope matches the `cargo-hax` version before processing
+ - Add `cargo hax tools remove <tool>@<version>` to delete a cached tool version
 
 Changes to hax-lib:
  - Basis of core model testing infrastructure (cryspen/hax-evit/160, cryspen/hax-evit/164)

--- a/cli/cargo-hax/src/tools.rs
+++ b/cli/cargo-hax/src/tools.rs
@@ -188,5 +188,6 @@ pub fn run(command: &ToolsCommand, message_format: MessageFormat) -> i32 {
             installed,
             all,
         } => subcommands::list(tool.as_deref(), *installed, *all, message_format),
+        ToolsCommand::Remove { spec } => subcommands::remove(spec, message_format),
     }
 }

--- a/cli/cargo-hax/src/tools.rs
+++ b/cli/cargo-hax/src/tools.rs
@@ -189,5 +189,6 @@ pub fn run(command: &ToolsCommand, message_format: MessageFormat) -> i32 {
             all,
         } => subcommands::list(tool.as_deref(), *installed, *all, message_format),
         ToolsCommand::Remove { spec } => subcommands::remove(spec, message_format),
+        ToolsCommand::Clean => subcommands::clean(message_format),
     }
 }

--- a/cli/cargo-hax/src/tools/cache.rs
+++ b/cli/cargo-hax/src/tools/cache.rs
@@ -170,6 +170,48 @@ pub fn remove_version(tool: &str, version: &str) -> Result<Removal<bool>, String
     })
 }
 
+/// Delete the entire tool cache. Returns how many tool versions it held,
+/// including versions of tools this binary does not manage. The `tools`
+/// directory is renamed into a temporary sibling before deletion, so a
+/// concurrent reader observes an empty cache rather than a shrinking one.
+pub fn clean() -> Result<Removal<usize>, String> {
+    let root = cache_root()?;
+    sweep_staging(&root, ".clean-");
+    let dir = root.join("tools");
+    if !dir.is_dir() {
+        return Ok(Removal::done(0));
+    }
+    let subdirectories = |dir: &Path| -> Vec<PathBuf> {
+        std::fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let name = entry.file_name().into_string().ok()?;
+                (entry.file_type().ok()?.is_dir() && !name.starts_with('.')).then(|| entry.path())
+            })
+            .collect()
+    };
+    let removed = subdirectories(&dir)
+        .iter()
+        .map(|tool| subdirectories(tool).len())
+        .sum();
+    let staging = tempfile::Builder::new()
+        .prefix(".clean-")
+        .tempdir_in(&root)
+        .map_err(|e| format!("could not create a temporary directory: {e}"))?;
+    match std::fs::rename(&dir, staging.path().join("contents")) {
+        Ok(()) => {}
+        // A concurrent clean won the race.
+        Err(_) if !dir.exists() => return Ok(Removal::done(0)),
+        Err(e) => return Err(format!("could not move aside {}: {e}", dir.display())),
+    }
+    Ok(Removal {
+        result: removed,
+        leftover: delete_staging(staging),
+    })
+}
+
 /// Read a version directory's metadata. A missing file is `None` (the
 /// `bin/` convention applies); an unreadable one is an error, since the
 /// executables' locations may depend on it.

--- a/cli/cargo-hax/src/tools/cache.rs
+++ b/cli/cargo-hax/src/tools/cache.rs
@@ -97,6 +97,79 @@ pub fn installed_versions(tool: &str) -> Vec<String> {
     versions
 }
 
+/// Outcome of a removal that has taken effect.
+pub struct Removal<T> {
+    pub result: T,
+    /// Warning about a staging directory that could not be deleted. It
+    /// holds no live data: removing it manually is safe, and a later
+    /// removal sweeping the same location reaps it.
+    pub leftover: Option<String>,
+}
+
+impl<T> Removal<T> {
+    fn done(result: T) -> Self {
+        Self {
+            result,
+            leftover: None,
+        }
+    }
+}
+
+/// Delete a staging directory whose contents are already logically
+/// removed. Failure is a warning, not an error: the removal has taken
+/// effect, only disk space is still held.
+fn delete_staging(staging: tempfile::TempDir) -> Option<String> {
+    let path = staging.keep();
+    match std::fs::remove_dir_all(&path) {
+        Ok(()) => None,
+        Err(e) => Some(format!(
+            "could not delete {}: {e}; delete it manually to reclaim the space",
+            path.display()
+        )),
+    }
+}
+
+/// Best-effort removal of staging directories a previous run left behind.
+/// Errors are ignored: a directory may belong to a concurrent removal, and
+/// whatever blocked the original deletion may still hold. The sweep can
+/// delete a concurrent removal's staging directory before its rename,
+/// failing that removal with a spurious "could not move aside" error; the
+/// window is a few syscalls wide and retrying recovers.
+fn sweep_staging(dir: &Path, prefix: &str) {
+    for entry in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+        if entry.file_name().to_string_lossy().starts_with(prefix) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// Remove an installed tool version. Returns whether the version was
+/// present. The directory is renamed into a temporary sibling before
+/// deletion, so a concurrent reader never observes a partially deleted
+/// version directory.
+pub fn remove_version(tool: &str, version: &str) -> Result<Removal<bool>, String> {
+    let dir = version_dir(tool, version)?;
+    if !dir.is_dir() {
+        return Ok(Removal::done(false));
+    }
+    let parent = tool_dir(tool)?;
+    sweep_staging(&parent, ".remove-");
+    let staging = tempfile::Builder::new()
+        .prefix(".remove-")
+        .tempdir_in(&parent)
+        .map_err(|e| format!("could not create a temporary directory: {e}"))?;
+    match std::fs::rename(&dir, staging.path().join("contents")) {
+        Ok(()) => {}
+        // A concurrent removal won the race.
+        Err(_) if !dir.exists() => return Ok(Removal::done(false)),
+        Err(e) => return Err(format!("could not move aside {}: {e}", dir.display())),
+    }
+    Ok(Removal {
+        result: true,
+        leftover: delete_staging(staging),
+    })
+}
+
 /// Read a version directory's metadata. A missing file is `None` (the
 /// `bin/` convention applies); an unreadable one is an error, since the
 /// executables' locations may depend on it.
@@ -172,6 +245,18 @@ mod tests {
         assert!(cache_root_of(None, None).is_err());
         assert!(cache_root_of(Some(""), Some("")).is_err());
         assert!(cache_root_of(Some(".cache"), Some("home")).is_err());
+    }
+
+    #[test]
+    fn sweep_staging_removes_only_matching_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".remove-old/contents")).unwrap();
+        std::fs::create_dir(dir.path().join("1.2.3")).unwrap();
+        std::fs::create_dir(dir.path().join(".clean-x")).unwrap();
+        sweep_staging(dir.path(), ".remove-");
+        assert!(!dir.path().join(".remove-old").exists());
+        assert!(dir.path().join("1.2.3").is_dir());
+        assert!(dir.path().join(".clean-x").is_dir());
     }
 
     #[test]

--- a/cli/cargo-hax/src/tools/subcommands.rs
+++ b/cli/cargo-hax/src/tools/subcommands.rs
@@ -38,27 +38,10 @@ fn reported(name: &str, resolution: &Resolution) -> ToolResolution {
 /// across all workspace crates: pins, member overrides, and defaults.
 pub fn install(spec: Option<&str>, force: bool, message_format: MessageFormat) -> i32 {
     let requests: Vec<(String, String)> = match spec {
-        Some(spec) => {
-            let Some((tool, version)) = spec.split_once('@') else {
-                return error(
-                    format!("`{spec}` is not a `<tool>@<version>` specification"),
-                    message_format,
-                );
-            };
-            if !MANAGED_TOOLS.contains(&tool) {
-                return error(
-                    format!(
-                        "`{tool}` is not a managed tool (managed tools: {})",
-                        MANAGED_TOOLS.join(", ")
-                    ),
-                    message_format,
-                );
-            }
-            if version.is_empty() {
-                return error(format!("`{spec}` lacks a version"), message_format);
-            }
-            vec![(tool.to_string(), version.to_string())]
-        }
+        Some(spec) => match parse_spec(spec) {
+            Ok(request) => vec![request],
+            Err(message) => return error(message, message_format),
+        },
         None => {
             let ctx = match ProjectContext::load(message_format) {
                 Ok(ctx) => ctx,
@@ -130,6 +113,55 @@ pub fn install(spec: Option<&str>, force: bool, message_format: MessageFormat) -
     }
     HaxMessage::ToolsInstalled { installed }.report(message_format, None);
     if failed { 1 } else { 0 }
+}
+
+/// Parse a `<tool>@<version>` specification naming a managed tool.
+fn parse_spec(spec: &str) -> Result<(String, String), String> {
+    let Some((tool, version)) = spec.split_once('@') else {
+        return Err(format!(
+            "`{spec}` is not a `<tool>@<version>` specification"
+        ));
+    };
+    if !MANAGED_TOOLS.contains(&tool) {
+        return Err(format!(
+            "`{tool}` is not a managed tool (managed tools: {})",
+            MANAGED_TOOLS.join(", ")
+        ));
+    }
+    if version.is_empty() {
+        return Err(format!("`{spec}` lacks a version"));
+    }
+    Ok((tool.to_string(), version.to_string()))
+}
+
+/// `cargo hax tools remove`: delete a version from the machine-wide
+/// cache. Removal is safe at any time: a later run that needs the version
+/// re-downloads it.
+pub fn remove(spec: &str, message_format: MessageFormat) -> i32 {
+    let (tool, version) = match parse_spec(spec) {
+        Ok(request) => request,
+        Err(message) => return error(message, message_format),
+    };
+    match cache::remove_version(&tool, &version) {
+        Ok(cache::Removal {
+            result: true,
+            leftover,
+        }) => {
+            if let Some(message) = leftover {
+                HaxMessage::GenericWarning { message }.report(message_format, None);
+            }
+            HaxMessage::ToolRemoved { tool, version }.report(message_format, None);
+            0
+        }
+        Ok(cache::Removal { result: false, .. }) => error(
+            format!("{tool} {version} is not in the cache; nothing to remove"),
+            message_format,
+        ),
+        Err(message) => error(
+            format!("could not remove {tool} {version}: {message}"),
+            message_format,
+        ),
+    }
 }
 
 /// How many versions per tool `list` shows without `--all`.

--- a/cli/cargo-hax/src/tools/subcommands.rs
+++ b/cli/cargo-hax/src/tools/subcommands.rs
@@ -164,6 +164,27 @@ pub fn remove(spec: &str, message_format: MessageFormat) -> i32 {
     }
 }
 
+/// `cargo hax tools clean`: delete the entire tool cache. Idempotent:
+/// cleaning an empty or absent cache succeeds and reports zero removals.
+pub fn clean(message_format: MessageFormat) -> i32 {
+    match cache::clean() {
+        Ok(cache::Removal {
+            result: removed,
+            leftover,
+        }) => {
+            if let Some(message) = leftover {
+                HaxMessage::GenericWarning { message }.report(message_format, None);
+            }
+            HaxMessage::ToolsCleaned { removed }.report(message_format, None);
+            0
+        }
+        Err(message) => error(
+            format!("could not clean the tool cache: {message}"),
+            message_format,
+        ),
+    }
+}
+
 /// How many versions per tool `list` shows without `--all`.
 const LIST_RECENT: usize = 10;
 

--- a/cli/cargo-hax/tests/tools_install.rs
+++ b/cli/cargo-hax/tests/tools_install.rs
@@ -186,6 +186,51 @@ entry_points = {{ charon = "charon", charon-driver = "charon-driver" }}
 }
 
 #[test]
+fn clean_deletes_the_whole_cache() {
+    let charon = make_archive(&[("charon", ""), ("charon-driver", "")]);
+    let aeneas = make_archive(&[("bin/aeneas", "")]);
+    let server = serve(HashMap::from([
+        ("/charon-v1.tar.gz".to_string(), charon.clone()),
+        ("/aeneas-v1.tar.gz".to_string(), aeneas.clone()),
+    ]));
+    let env = Env::new(&format!(
+        r#"[tools.charon."v1".{platform}]
+url = "{base}/charon-v1.tar.gz"
+sha256 = "{sha_c}"
+entry_points = {{ charon = "charon", charon-driver = "charon-driver" }}
+
+[tools.aeneas."v1".{platform}]
+url = "{base}/aeneas-v1.tar.gz"
+sha256 = "{sha_a}"
+"#,
+        platform = platform(),
+        base = server.base_url,
+        sha_c = sha256_hex(&charon),
+        sha_a = sha256_hex(&aeneas),
+    ));
+
+    let (output, success) = env.run(&["tools", "install", "charon@v1"]);
+    assert!(success, "{output}");
+    let (output, success) = env.run(&["tools", "install", "aeneas@v1"]);
+    assert!(success, "{output}");
+
+    let (output, success) = env.run(&["tools", "clean"]);
+    assert!(success, "{output}");
+    assert!(output.contains("Removed 2 tool versions"), "{output}");
+    assert!(!env.cache().join("hax/tools").exists());
+    // No temporary directories survive next to the removed cache.
+    let leftovers: Vec<_> = std::fs::read_dir(env.cache().join("hax"))
+        .map(|entries| entries.flatten().collect())
+        .unwrap_or_default();
+    assert!(leftovers.is_empty(), "{leftovers:?}");
+
+    // Cleaning an already empty cache is not an error.
+    let (output, success) = env.run(&["tools", "clean"]);
+    assert!(success, "{output}");
+    assert!(output.contains("Removed 0 tool versions"), "{output}");
+}
+
+#[test]
 fn checksum_mismatch_aborts_without_caching() {
     let archive = make_archive(&[("charon", ""), ("charon-driver", "")]);
     let server = serve(HashMap::from([("/charon-v1.tar.gz".to_string(), archive)]));

--- a/cli/cargo-hax/tests/tools_install.rs
+++ b/cli/cargo-hax/tests/tools_install.rs
@@ -135,6 +135,57 @@ entry_points = {{ charon = "charon", charon-driver = "charon-driver" }}
 }
 
 #[test]
+fn remove_deletes_a_cached_version() {
+    let archive = make_archive(&[("charon", ""), ("charon-driver", "")]);
+    let sha = sha256_hex(&archive);
+    let server = serve(HashMap::from([("/charon-v1.tar.gz".to_string(), archive)]));
+    let env = Env::new(&format!(
+        r#"[tools.charon."v1".{platform}]
+url = "{base}/charon-v1.tar.gz"
+sha256 = "{sha}"
+entry_points = {{ charon = "charon", charon-driver = "charon-driver" }}
+"#,
+        platform = platform(),
+        base = server.base_url,
+    ));
+
+    let (output, success) = env.run(&["tools", "install", "charon@v1"]);
+    assert!(success, "{output}");
+    assert!(env.version_dir("charon", "v1").is_dir());
+
+    let (output, success) = env.run(&["tools", "remove", "charon@v1"]);
+    assert!(success, "{output}");
+    assert!(output.contains("Removed charon v1"), "{output}");
+    assert!(!env.version_dir("charon", "v1").exists());
+    // No temporary directories survive, and `list` no longer marks the
+    // version as installed.
+    let leftovers: Vec<_> = std::fs::read_dir(env.cache().join("hax/tools/charon"))
+        .map(|entries| entries.flatten().collect())
+        .unwrap_or_default();
+    assert!(leftovers.is_empty(), "{leftovers:?}");
+    let (output, _) = env.run(&["tools", "list", "charon"]);
+    assert!(!output.contains("installed"), "{output}");
+
+    // Removing a version that is not cached is an error, as are the same
+    // malformed specifications `install` rejects.
+    let (output, success) = env.run(&["tools", "remove", "charon@v1"]);
+    assert!(!success);
+    assert!(output.contains("not in the cache"), "{output}");
+    let (output, success) = env.run(&["tools", "remove", "charon"]);
+    assert!(!success);
+    assert!(output.contains("<tool>@<version>"), "{output}");
+    let (output, success) = env.run(&["tools", "remove", "unknown@v1"]);
+    assert!(!success);
+    assert!(output.contains("not a managed tool"), "{output}");
+    let (output, success) = env.run(&["tools", "remove", "charon@../escape"]);
+    assert!(!success);
+    assert!(
+        output.contains("not a valid version identifier"),
+        "{output}"
+    );
+}
+
+#[test]
 fn checksum_mismatch_aborts_without_caching() {
     let archive = make_archive(&[("charon", ""), ("charon-driver", "")]);
     let server = serve(HashMap::from([("/charon-v1.tar.gz".to_string(), archive)]));

--- a/docs/manual/tools.md
+++ b/docs/manual/tools.md
@@ -24,7 +24,7 @@ Every release of hax ships with a built-in default for each of these, tested tog
 
 You do not have to install anything up front. The first time a `cargo hax into lean` run needs `aeneas` or `charon`, hax downloads the resolved version, verifies its SHA-256 checksum against the shipped manifest, and stores it in a cache. Subsequent runs reuse the cached binary.
 
-The cache lives under `$XDG_CACHE_HOME/hax/tools/` (falling back to `~/.cache/hax/tools/` when `XDG_CACHE_HOME` is unset, empty, or not an absolute path), with one directory per tool and version. Downloads are verified before they are moved into place, so an interrupted download never leaves a half-installed version behind. They use the proxy and the certificate store the environment configures. The cache only grows; drop versions you no longer need with [`tools remove`](#tools-remove).
+The cache lives under `$XDG_CACHE_HOME/hax/tools/` (falling back to `~/.cache/hax/tools/` when `XDG_CACHE_HOME` is unset, empty, or not an absolute path), with one directory per tool and version. Downloads are verified before they are moved into place, so an interrupted download never leaves a half-installed version behind. They use the proxy and the certificate store the environment configures. The cache only grows; drop versions you no longer need with [`tools remove`](#tools-remove), or all of them with [`tools clean`](#tools-clean).
 
 Pre-built binaries are available for the platforms hax supports: Linux and macOS, on both `x86_64` and `aarch64`. On any other platform there is nothing to download, and hax reports so, naming the version it wanted; build `aeneas` and `charon` yourself and point hax at them as described under [Using a local build](#using-a-local-build).
 
@@ -89,6 +89,14 @@ cargo hax tools remove charon@nightly-2026.07.01
 ```
 
 Removal is always safe: a later run that needs the version downloads it again. Deleting version directories, or the whole cache, by hand is equally safe.
+
+### `tools clean`
+
+`cargo hax tools clean` deletes the entire tool cache: every cached version of every tool. It works from any directory and reports how many versions it removed.
+
+```bash
+cargo hax tools clean
+```
 
 ## Pinning versions with `hax.toml`
 

--- a/docs/manual/tools.md
+++ b/docs/manual/tools.md
@@ -24,7 +24,7 @@ Every release of hax ships with a built-in default for each of these, tested tog
 
 You do not have to install anything up front. The first time a `cargo hax into lean` run needs `aeneas` or `charon`, hax downloads the resolved version, verifies its SHA-256 checksum against the shipped manifest, and stores it in a cache. Subsequent runs reuse the cached binary.
 
-The cache lives under `$XDG_CACHE_HOME/hax/tools/` (falling back to `~/.cache/hax/tools/` when `XDG_CACHE_HOME` is unset, empty, or not an absolute path), with one directory per tool and version. Downloads are verified before they are moved into place, so an interrupted download never leaves a half-installed version behind. They use the proxy and the certificate store the environment configures.
+The cache lives under `$XDG_CACHE_HOME/hax/tools/` (falling back to `~/.cache/hax/tools/` when `XDG_CACHE_HOME` is unset, empty, or not an absolute path), with one directory per tool and version. Downloads are verified before they are moved into place, so an interrupted download never leaves a half-installed version behind. They use the proxy and the certificate store the environment configures. The cache only grows; drop versions you no longer need with [`tools remove`](#tools-remove).
 
 Pre-built binaries are available for the platforms hax supports: Linux and macOS, on both `x86_64` and `aarch64`. On any other platform there is nothing to download, and hax reports so, naming the version it wanted; build `aeneas` and `charon` yourself and point hax at them as described under [Using a local build](#using-a-local-build).
 
@@ -79,6 +79,16 @@ Cached versions are always listed, even ones absent from this release's manifest
 - `installed`: present in the local cache.
 - `unverified`: the cached copy was installed without checksum verification (through the fallback path); once a release ships a checksum for it, reinstall with `--force` to verify it.
 - `not in manifest`: the version is not in this release's manifest, so it can only be reinstalled through the unverified fallback path.
+
+### `tools remove`
+
+`cargo hax tools remove` deletes one version from the machine-wide cache. Like `install <tool>@<version>`, it works from any directory.
+
+```bash
+cargo hax tools remove charon@nightly-2026.07.01
+```
+
+Removal is always safe: a later run that needs the version downloads it again. Deleting version directories, or the whole cache, by hand is equally safe.
 
 ## Pinning versions with `hax.toml`
 

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -550,6 +550,9 @@ pub enum ToolsCommand {
         /// `charon@nightly-2026.07.01`) to remove from the cache.
         spec: String,
     },
+    /// Delete the entire tool cache. Later runs download what they need
+    /// again.
+    Clean,
 }
 
 impl<E: Extension> Command<E> {

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -504,9 +504,7 @@ pub enum Command<E: Extension> {
         backend: Option<BackendName>,
     },
 
-    /// Manage the external tools hax depends on (e.g. charon and
-    /// aeneas): show the versions the current project resolves to,
-    /// list installable versions, and install them.
+    /// Manage the external tools hax depends on (e.g. charon and aeneas).
     #[command(subcommand)]
     Tools(ToolsCommand),
 
@@ -546,6 +544,12 @@ pub enum ToolsCommand {
     /// Show which tool versions are active in the current project,
     /// and where each one comes from.
     Show,
+    /// Remove a tool version from the machine-wide cache.
+    Remove {
+        /// The `<tool>@<version>` specification (e.g.
+        /// `charon@nightly-2026.07.01`) to remove from the cache.
+        spec: String,
+    },
 }
 
 impl<E: Extension> Command<E> {

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -240,6 +240,12 @@ pub enum HaxMessage {
         found: String,
         expected: String,
     } = 24,
+    /// The result of `cargo hax tools remove`: the version deleted from
+    /// the cache.
+    ToolRemoved {
+        tool: String,
+        version: String,
+    } = 25,
 }
 
 impl HaxMessage {
@@ -555,6 +561,10 @@ impl HaxMessage {
                 installed_only,
             } => render_tools_list(&tools, installed_only),
             Self::ToolsInstalled { installed } => render_tools_installed(&installed),
+            Self::ToolRemoved { tool, version } => {
+                use colored::Colorize;
+                format!("{:>12} {tool} {version}", "Removed".bold().green())
+            }
         }
     }
 }

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -246,6 +246,11 @@ pub enum HaxMessage {
         tool: String,
         version: String,
     } = 25,
+    /// The result of `cargo hax tools clean`: how many cached tool
+    /// versions the deleted cache held.
+    ToolsCleaned {
+        removed: usize,
+    } = 26,
 }
 
 impl HaxMessage {
@@ -564,6 +569,15 @@ impl HaxMessage {
             Self::ToolRemoved { tool, version } => {
                 use colored::Colorize;
                 format!("{:>12} {tool} {version}", "Removed".bold().green())
+            }
+            Self::ToolsCleaned { removed } => {
+                use colored::Colorize;
+                let noun = if removed == 1 {
+                    "tool version"
+                } else {
+                    "tool versions"
+                };
+                format!("{:>12} {removed} {noun}", "Removed".bold().green())
             }
         }
     }


### PR DESCRIPTION
Adds two subcommands for cleaning up the machine-wide tool cache, which so far only grows and requires manual deletion:

- `cargo hax tools remove <tool>@<version>` deletes one cached tool version. The specification is parsed with the same rules as `tools install`, and removing a version that is not cached is an error.
- `cargo hax tools clean` deletes the entire tool cache and reports how many versions it held. Cleaning an empty or absent cache succeeds and reports zero removals.

*Assisted by AI. Reviewed and tested manually.*