### PR TITLE
feat(core-models): model indexing by `RangeInclusive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Changes to hax-lib:
  - Support `requires`, and `ensures` written behind a `cfg_attr` in
    an `impl` block or a trait annotated with `#[hax_lib::attributes]`, keeping
    the `cfg_attr` predicate (#1496)
+ - Model indexing by `RangeInclusive<usize>`: `SliceIndex<[T]>` for slices and, for the F* backend, `Index` for arrays. Both were missing, so any `Index` constraint on an inclusive range was unsolvable
 
 Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)

--- a/cli/cargo-hax/defaults.toml
+++ b/cli/cargo-hax/defaults.toml
@@ -19,4 +19,4 @@ lean = "leanprover/lean4:v4.31.0"
 # The Lean library that extracted code builds against. This is a tag in
 # `cryspen/hax-lean`, pushed by `.github/workflows/deploy_hax_lean.yml`; it
 # must match `version` in `hax-lib/proof-libs/lean/lakefile.toml`.
-hax-lean-lib = "v0.3.3"
+hax-lean-lib = "v0.3.4"

--- a/hax-lib/core-models/core-models/src/core/array.rs
+++ b/hax-lib/core-models/core-models/src/core/array.rs
@@ -71,7 +71,7 @@ impl<T, const N: usize> crate::iter::traits::collect::IntoIterator for [T; N] {
 
 use crate::ops::{
     index::Index,
-    range::{Range, RangeFrom, RangeFull, RangeTo},
+    range::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo},
 };
 
 #[cfg(not(hax_backend_fstar))]
@@ -125,6 +125,18 @@ impl<T, const N: usize> Index<RangeFrom<usize>> for [T; N] {
     #[hax_lib::requires(i.start <= N)]
     fn index(&self, i: RangeFrom<usize>) -> &[T] {
         array_slice(self, i.start, N)
+    }
+}
+/// `i.end` is the last included index, hence the `i.end < N` bound. Like the
+/// slice impl, the precondition rules out the empty inclusive range.
+#[cfg(hax_backend_fstar)]
+#[hax_lib::attributes]
+#[cfg_attr(hax_backend_legacy_lean, hax_lib::exclude)]
+impl<T, const N: usize> Index<RangeInclusive<usize>> for [T; N] {
+    type Output = [T];
+    #[hax_lib::requires(i.start <= i.end && i.end < N)]
+    fn index(&self, i: RangeInclusive<usize>) -> &[T] {
+        array_slice(self, i.start, i.end + 1)
     }
 }
 #[cfg(hax_backend_fstar)]

--- a/hax-lib/core-models/core-models/src/core/slice.rs
+++ b/hax-lib/core-models/core-models/src/core/slice.rs
@@ -591,6 +591,43 @@ pub mod index {
         }
     }
 
+    /// `end` is the last included index, hence the `end < len` bound. The
+    /// precondition is stronger than std's: the empty inclusive range
+    /// (`start == end + 1`) is rejected instead of denoting an empty slice.
+    #[hax_lib::attributes]
+    #[cfg_attr(hax_backend_legacy_lean, hax_lib::exclude)]
+    impl<T> SliceIndex<[T]> for crate::ops::range::RangeInclusive<usize> {
+        type Output = [T];
+        fn get(self, slice: &[T]) -> Option<&[T]> {
+            if self.start <= self.end && self.end < slice_length(slice) {
+                Option::Some(slice_slice(slice, self.start, self.end + 1))
+            } else {
+                Option::None
+            }
+        }
+        #[hax_lib::requires(self.start <= self.end && self.end < slice_length(slice))]
+        fn index(self, slice: &[T]) -> &[T] {
+            slice_slice(slice, self.start, self.end + 1)
+        }
+        #[hax_lib::requires(self.start <= self.end && self.end < slice_length(slice))]
+        fn get_unchecked(self, slice: &[T]) -> &[T] {
+            slice_slice(slice, self.start, self.end + 1)
+        }
+        #[cfg(not(hax_backend_fstar))]
+        fn get_mut(self, slice: &mut [T]) -> Option<&mut [T]> {
+            if self.start <= self.end && self.end < slice_length(slice) {
+                Option::Some(slice_slice_mut(slice, self.start, self.end + 1))
+            } else {
+                Option::None
+            }
+        }
+        #[cfg(not(hax_backend_fstar))]
+        #[hax_lib::requires(self.start <= self.end && self.end < slice_length(slice))]
+        fn get_unchecked_mut(self, slice: &mut [T]) -> &mut [T] {
+            slice_slice_mut(slice, self.start, self.end + 1)
+        }
+    }
+
     /// Generic `Index<I>` for `[T]`, matching std's
     /// `impl<T, I: SliceIndex<[T]>> Index<I> for [T]`
     /// in `core/src/slice/index.rs`. Body delegates to

--- a/hax-lib/proof-libs/fstar/core/Core_models.Array.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Array.fst
@@ -26,3 +26,5 @@ include Core_models.Bundle {impl_27 as impl_27}
 include Core_models.Bundle {impl_28 as impl_28}
 
 include Core_models.Bundle {impl_29 as impl_29}
+
+include Core_models.Bundle {impl_30 as impl_30}

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -2441,7 +2441,7 @@ let impl_26 (#v_T: Type0) (v_N: usize)
 type t_RangeFull = | RangeFull : t_RangeFull
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_29 (#v_T: Type0) (v_N: usize) : Core_models.Ops.Index.t_Index (t_Array v_T v_N) t_RangeFull =
+let impl_30 (#v_T: Type0) (v_N: usize) : Core_models.Ops.Index.t_Index (t_Array v_T v_N) t_RangeFull =
   {
     f_Output = t_Slice v_T;
     f_index_pre = (fun (self: t_Array v_T v_N) (i: t_RangeFull) -> true);
@@ -2457,6 +2457,26 @@ type t_RangeInclusive (v_T: Type0) = {
   f_start:v_T;
   f_end:v_T
 }
+
+/// `i.end` is the last included index, hence the `i.end < N` bound. Like the
+/// slice impl, the precondition rules out the empty inclusive range.
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_29 (#v_T: Type0) (v_N: usize)
+    : Core_models.Ops.Index.t_Index (t_Array v_T v_N) (t_RangeInclusive usize) =
+  {
+    f_Output = t_Slice v_T;
+    f_index_pre
+    =
+    (fun (self_: t_Array v_T v_N) (i: t_RangeInclusive usize) ->
+        i.f_start <=. i.f_end && i.f_end <. v_N);
+    f_index_post
+    =
+    (fun (self: t_Array v_T v_N) (i: t_RangeInclusive usize) (out: t_Slice v_T) -> true);
+    f_index
+    =
+    fun (self: t_Array v_T v_N) (i: t_RangeInclusive usize) ->
+      Rust_primitives.Slice.array_slice #v_T v_N self i.f_start (i.f_end +! mk_usize 1 <: usize)
+  }
 
 /// See [`std::option::Option`]
 type t_Option (v_T: Type0) =
@@ -4248,7 +4268,7 @@ let impl_2 (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: t_Partia
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_30: t_PartialOrd u8 u8 =
+let impl_30__from__cmp: t_PartialOrd u8 u8 =
   {
     _super_i0 = FStar.Tactics.Typeclasses.solve;
     f_partial_cmp_pre = (fun (self: u8) (other: u8) -> true);

--- a/hax-lib/proof-libs/fstar/core/Core_models.Cmp.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Cmp.fst
@@ -99,7 +99,7 @@ include Core_models.Bundle {impl_4 as impl_4}
 
 include Core_models.Bundle {impl_5__from__cmp as impl_5}
 
-include Core_models.Bundle {impl_30 as impl_30}
+include Core_models.Bundle {impl_30__from__cmp as impl_30}
 
 include Core_models.Bundle {impl_31__from__cmp as impl_Ord_for_u8}
 

--- a/hax-lib/proof-libs/fstar/core/Core_models.Slice.Index.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Slice.Index.fst
@@ -275,6 +275,84 @@ let impl_4 (#v_T: Type0) : t_SliceIndex (Core_models.Ops.Range.t_Range usize) (t
         self.Core_models.Ops.Range.f_end
   }
 
+/// `end` is the last included index, hence the `end < len` bound. The
+/// precondition is stronger than std\'s: the empty inclusive range
+/// (`start == end + 1`) is rejected instead of denoting an empty slice.
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_5 (#v_T: Type0) : t_SliceIndex (Core_models.Ops.Range.t_RangeInclusive usize) (t_Slice v_T) =
+  {
+    f_Output = t_Slice v_T;
+    f_get_pre
+    =
+    (fun (self: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) -> true);
+    f_get_post
+    =
+    (fun
+        (self: Core_models.Ops.Range.t_RangeInclusive usize)
+        (slice: t_Slice v_T)
+        (out: Core_models.Option.t_Option (t_Slice v_T))
+        ->
+        true);
+    f_get
+    =
+    (fun (self: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) ->
+        if
+          self.Core_models.Ops.Range.f_start <=. self.Core_models.Ops.Range.f_end &&
+          self.Core_models.Ops.Range.f_end <.
+          (Rust_primitives.Slice.slice_length #v_T slice <: usize)
+        then
+          Core_models.Option.Option_Some
+          (Rust_primitives.Slice.slice_slice #v_T
+              slice
+              self.Core_models.Ops.Range.f_start
+              (self.Core_models.Ops.Range.f_end +! mk_usize 1 <: usize))
+          <:
+          Core_models.Option.t_Option (t_Slice v_T)
+        else Core_models.Option.Option_None <: Core_models.Option.t_Option (t_Slice v_T));
+    f_index_pre
+    =
+    (fun (self_: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) ->
+        self_.Core_models.Ops.Range.f_start <=. self_.Core_models.Ops.Range.f_end &&
+        self_.Core_models.Ops.Range.f_end <.
+        (Rust_primitives.Slice.slice_length #v_T slice <: usize));
+    f_index_post
+    =
+    (fun
+        (self: Core_models.Ops.Range.t_RangeInclusive usize)
+        (slice: t_Slice v_T)
+        (out: t_Slice v_T)
+        ->
+        true);
+    f_index
+    =
+    (fun (self: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) ->
+        Rust_primitives.Slice.slice_slice #v_T
+          slice
+          self.Core_models.Ops.Range.f_start
+          (self.Core_models.Ops.Range.f_end +! mk_usize 1 <: usize));
+    f_get_unchecked_pre
+    =
+    (fun (self_: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) ->
+        self_.Core_models.Ops.Range.f_start <=. self_.Core_models.Ops.Range.f_end &&
+        self_.Core_models.Ops.Range.f_end <.
+        (Rust_primitives.Slice.slice_length #v_T slice <: usize));
+    f_get_unchecked_post
+    =
+    (fun
+        (self: Core_models.Ops.Range.t_RangeInclusive usize)
+        (slice: t_Slice v_T)
+        (out: t_Slice v_T)
+        ->
+        true);
+    f_get_unchecked
+    =
+    fun (self: Core_models.Ops.Range.t_RangeInclusive usize) (slice: t_Slice v_T) ->
+      Rust_primitives.Slice.slice_slice #v_T
+        slice
+        self.Core_models.Ops.Range.f_start
+        (self.Core_models.Ops.Range.f_end +! mk_usize 1 <: usize)
+  }
+
 /// Generic `Index<I>` for `[T]`, matching std\'s
 /// `impl<T, I: SliceIndex<[T]>> Index<I> for [T]`
 /// in `core/src/slice/index.rs`. Body delegates to
@@ -282,7 +360,7 @@ let impl_4 (#v_T: Type0) : t_SliceIndex (Core_models.Ops.Range.t_Range usize) (t
 /// from the trait to avoid modeling raw pointers; std would call
 /// `index.index(self)` instead).
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_5
+let impl_6
       (#v_T #v_I: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: t_SliceIndex v_I (t_Slice v_T))
     : Core_models.Ops.Index.t_Index (t_Slice v_T) v_I =

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -149,7 +149,7 @@ def Array.Insts.CoreOpsIndexIndex {T : Type} {I : Type} {Clause0_Output
 }
 
 /-- [core_models::array::{impl core_models::clone::Clone for [T; N]}::clone]:
-    Source: 'core-models/src/core/array.rs', lines 142:4-144:5
+    Source: 'core-models/src/core/array.rs', lines 154:4-156:5
     Visibility: public -/
 def Array.Insts.CoreCloneClone.clone
   {T : Type} {N : Std.Usize} (cloneCloneInst : clone.Clone T)
@@ -159,7 +159,7 @@ def Array.Insts.CoreCloneClone.clone
   ok self
 
 /-- Trait implementation: [core_models::array::{impl core_models::clone::Clone for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 141:0-145:1 -/
+    Source: 'core-models/src/core/array.rs', lines 153:0-157:1 -/
 @[reducible]
 def Array.Insts.CoreCloneClone {T : Type} (N : Std.Usize)
   (cloneCloneInst : clone.Clone T) : clone.Clone (Array T N) := {
@@ -167,7 +167,7 @@ def Array.Insts.CoreCloneClone {T : Type} (N : Std.Usize)
 }
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]: loop body 0:
-    Source: 'core-models/src/core/array.rs', lines 154:12-161:9
+    Source: 'core-models/src/core/array.rs', lines 166:12-173:9
     Visibility: public -/
 @[rust_loop_body]
 def Array.Insts.CoreCmpPartialEqArray.eq_loop.body
@@ -187,7 +187,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq_loop.body
   else ok (done true)
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]: loop 0:
-    Source: 'core-models/src/core/array.rs', lines 154:12-161:9
+    Source: 'core-models/src/core/array.rs', lines 166:12-173:9
     Visibility: public -/
 @[rust_loop]
 def Array.Insts.CoreCmpPartialEqArray.eq_loop
@@ -201,7 +201,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq_loop
     i
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]:
-    Source: 'core-models/src/core/array.rs', lines 152:8-161:9
+    Source: 'core-models/src/core/array.rs', lines 164:8-173:9
     Visibility: public -/
 @[reducible]
 def Array.Insts.CoreCmpPartialEqArray.eq
@@ -213,7 +213,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq
     0#usize
 
 /-- Trait implementation: [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 151:4-162:5 -/
+    Source: 'core-models/src/core/array.rs', lines 163:4-174:5 -/
 @[reducible]
 def Array.Insts.CoreCmpPartialEqArray {T : Type} {U : Type} (N :
   Std.Usize) (cmpPartialEqInst : cmp.PartialEq T U) : cmp.PartialEq (Array T N)
@@ -222,7 +222,7 @@ def Array.Insts.CoreCmpPartialEqArray {T : Type} {U : Type} (N :
 }
 
 /-- [core_models::array::iter::{impl core_models::iter::traits::iterator::Iterator<T> for core_models::array::iter::IntoIter<T, N>}::next]:
-    Source: 'core-models/src/core/array.rs', lines 172:8-179:9
+    Source: 'core-models/src/core/array.rs', lines 184:8-191:9
     Visibility: public -/
 def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
   {T : Type} {N : Std.Usize} (self : array.iter.IntoIter T N) :
@@ -236,7 +236,7 @@ def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
     ok (option.Option.Some res, s)
 
 /-- Trait implementation: [core_models::array::iter::{impl core_models::iter::traits::iterator::Iterator<T> for core_models::array::iter::IntoIter<T, N>}]
-    Source: 'core-models/src/core/array.rs', lines 170:4-180:5 -/
+    Source: 'core-models/src/core/array.rs', lines 182:4-192:5 -/
 @[reducible]
 def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator (T : Type)
   (N : Std.Usize) : iter.traits.iterator.Iterator (array.iter.IntoIter T N) T
@@ -424,7 +424,7 @@ def Isize.Insts.CoreCloneClone : clone.Clone Std.Isize := {
 }
 
 /-- [core_models::cmp::PartialOrd::lt]:
-    Source: 'core-models/src/core/cmp.rs', lines 44:4-46:5
+    Source: 'core-models/src/core/cmp.rs', lines 42:4-44:5
     Visibility: public -/
 @[trait_default]
 def cmp.PartialOrd.lt.default
@@ -442,7 +442,7 @@ def cmp.PartialOrd.lt.default
   | option.Option.None => ok false
 
 /-- [core_models::cmp::PartialOrd::le]:
-    Source: 'core-models/src/core/cmp.rs', lines 49:4-54:5
+    Source: 'core-models/src/core/cmp.rs', lines 47:4-52:5
     Visibility: public -/
 @[trait_default]
 def cmp.PartialOrd.le.default
@@ -460,7 +460,7 @@ def cmp.PartialOrd.le.default
   | option.Option.None => ok false
 
 /-- [core_models::cmp::PartialOrd::gt]:
-    Source: 'core-models/src/core/cmp.rs', lines 57:4-59:5
+    Source: 'core-models/src/core/cmp.rs', lines 55:4-57:5
     Visibility: public -/
 @[trait_default]
 def cmp.PartialOrd.gt.default
@@ -478,7 +478,7 @@ def cmp.PartialOrd.gt.default
   | option.Option.None => ok false
 
 /-- [core_models::cmp::PartialOrd::ge]:
-    Source: 'core-models/src/core/cmp.rs', lines 62:4-67:5
+    Source: 'core-models/src/core/cmp.rs', lines 60:4-65:5
     Visibility: public -/
 @[trait_default]
 def cmp.PartialOrd.ge.default
@@ -496,7 +496,7 @@ def cmp.PartialOrd.ge.default
   | option.Option.None => ok false
 
 /-- [core_models::cmp::{impl core_models::cmp::Neq<T> for T}::neq]:
-    Source: 'core-models/src/core/cmp.rs', lines 78:4-81:5 -/
+    Source: 'core-models/src/core/cmp.rs', lines 75:4-78:5 -/
 def cmp.Neq.Blanket.neq
   {T : Type} (PartialEqInst : cmp.PartialEq T T) (self : T) (y : T) :
   Result Bool
@@ -505,7 +505,7 @@ def cmp.Neq.Blanket.neq
   ok (b = false)
 
 /-- Trait implementation: [core_models::cmp::{impl core_models::cmp::Neq<T> for T}]
-    Source: 'core-models/src/core/cmp.rs', lines 77:0-82:1 -/
+    Source: 'core-models/src/core/cmp.rs', lines 74:0-79:1 -/
 @[reducible]
 def cmp.Neq.Blanket {T : Type} (PartialEqInst : cmp.PartialEq T T) : cmp.Neq T
   T := {
@@ -513,7 +513,7 @@ def cmp.Neq.Blanket {T : Type} (PartialEqInst : cmp.PartialEq T T) : cmp.Neq T
 }
 
 /-- [core_models::cmp::max]:
-    Source: 'core-models/src/core/cmp.rs', lines 152:0-157:1
+    Source: 'core-models/src/core/cmp.rs', lines 147:0-152:1
     Visibility: public -/
 def cmp.max {T : Type} (OrdInst : cmp.Ord T) (v1 : T) (v2 : T) : Result T := do
   let o ← OrdInst.cmp v1 v2
@@ -523,7 +523,7 @@ def cmp.max {T : Type} (OrdInst : cmp.Ord T) (v1 : T) (v2 : T) : Result T := do
   | cmp.Ordering.Greater => ok v1
 
 /-- [core_models::cmp::min]:
-    Source: 'core-models/src/core/cmp.rs', lines 160:0-165:1
+    Source: 'core-models/src/core/cmp.rs', lines 155:0-160:1
     Visibility: public -/
 def cmp.min {T : Type} (OrdInst : cmp.Ord T) (v1 : T) (v2 : T) : Result T := do
   let o ← OrdInst.cmp v1 v2
@@ -533,7 +533,7 @@ def cmp.min {T : Type} (OrdInst : cmp.Ord T) (v1 : T) (v2 : T) : Result T := do
   | cmp.Ordering.Greater => ok v2
 
 /-- [core_models::cmp::{impl core_models::cmp::PartialEq<core_models::cmp::Reverse<T>> for core_models::cmp::Reverse<T>}::eq]:
-    Source: 'core-models/src/core/cmp.rs', lines 177:4-179:5
+    Source: 'core-models/src/core/cmp.rs', lines 172:4-174:5
     Visibility: public -/
 def cmp.Reverse.Insts.CoreCmpPartialEqReverse.eq
   {T : Type} (PartialEqInst : cmp.PartialEq T T) (self : cmp.Reverse T)
@@ -543,7 +543,7 @@ def cmp.Reverse.Insts.CoreCmpPartialEqReverse.eq
   PartialEqInst.eq other self
 
 /-- Trait implementation: [core_models::cmp::{impl core_models::cmp::PartialEq<core_models::cmp::Reverse<T>> for core_models::cmp::Reverse<T>}]
-    Source: 'core-models/src/core/cmp.rs', lines 176:0-180:1 -/
+    Source: 'core-models/src/core/cmp.rs', lines 171:0-175:1 -/
 @[reducible]
 def cmp.Reverse.Insts.CoreCmpPartialEqReverse {T : Type} (PartialEqInst
   : cmp.PartialEq T T) : cmp.PartialEq (cmp.Reverse T) (cmp.Reverse T) := {
@@ -551,7 +551,7 @@ def cmp.Reverse.Insts.CoreCmpPartialEqReverse {T : Type} (PartialEqInst
 }
 
 /-- [core_models::cmp::{impl core_models::cmp::PartialOrd<core_models::cmp::Reverse<T>> for core_models::cmp::Reverse<T>}::partial_cmp]:
-    Source: 'core-models/src/core/cmp.rs', lines 171:4-173:5
+    Source: 'core-models/src/core/cmp.rs', lines 166:4-168:5
     Visibility: public -/
 def cmp.Reverse.Insts.CoreCmpPartialOrdReverse.partial_cmp
   {T : Type} (PartialOrdInst : cmp.PartialOrd T T) (self : cmp.Reverse T)
@@ -561,7 +561,7 @@ def cmp.Reverse.Insts.CoreCmpPartialOrdReverse.partial_cmp
   PartialOrdInst.partial_cmp other self
 
 /-- Trait implementation: [core_models::cmp::{impl core_models::cmp::PartialOrd<core_models::cmp::Reverse<T>> for core_models::cmp::Reverse<T>}]
-    Source: 'core-models/src/core/cmp.rs', lines 170:0-174:1 -/
+    Source: 'core-models/src/core/cmp.rs', lines 165:0-169:1 -/
 @[reducible]
 impl_def cmp.Reverse.Insts.CoreCmpPartialOrdReverse {T : Type}
   (PartialOrdInst : cmp.PartialOrd T T) : cmp.PartialOrd (cmp.Reverse T)
@@ -581,7 +581,7 @@ impl_def cmp.Reverse.Insts.CoreCmpPartialOrdReverse {T : Type}
 }
 
 /-- Trait implementation: [core_models::cmp::{impl core_models::cmp::Eq for core_models::cmp::Reverse<T>}]
-    Source: 'core-models/src/core/cmp.rs', lines 182:0-182:32 -/
+    Source: 'core-models/src/core/cmp.rs', lines 177:0-177:32 -/
 @[reducible]
 def cmp.Reverse.Insts.CoreCmpEq {T : Type} (EqInst : cmp.Eq T) : cmp.Eq
   (cmp.Reverse T) := {
@@ -590,7 +590,7 @@ def cmp.Reverse.Insts.CoreCmpEq {T : Type} (EqInst : cmp.Eq T) : cmp.Eq
 }
 
 /-- [core_models::cmp::{impl core_models::cmp::Ord for core_models::cmp::Reverse<T>}::cmp]:
-    Source: 'core-models/src/core/cmp.rs', lines 185:4-187:5
+    Source: 'core-models/src/core/cmp.rs', lines 180:4-182:5
     Visibility: public -/
 def cmp.Reverse.Insts.CoreCmpOrd.cmp
   {T : Type} (OrdInst : cmp.Ord T) (self : cmp.Reverse T)
@@ -600,7 +600,7 @@ def cmp.Reverse.Insts.CoreCmpOrd.cmp
   OrdInst.cmp other self
 
 /-- Trait implementation: [core_models::cmp::{impl core_models::cmp::Ord for core_models::cmp::Reverse<T>}]
-    Source: 'core-models/src/core/cmp.rs', lines 184:0-188:1 -/
+    Source: 'core-models/src/core/cmp.rs', lines 179:0-183:1 -/
 @[reducible]
 def cmp.Reverse.Insts.CoreCmpOrd {T : Type} (OrdInst : cmp.Ord T) :
   cmp.Ord (cmp.Reverse T) := {
@@ -611,7 +611,7 @@ def cmp.Reverse.Insts.CoreCmpOrd {T : Type} (OrdInst : cmp.Ord T) :
 }
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_eq]:
-    Source: 'core-models/src/core/cmp.rs', lines 245:4-247:5
+    Source: 'core-models/src/core/cmp.rs', lines 240:4-242:5
     Visibility: public -/
 def cmp.Ordering.is_eq (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -620,7 +620,7 @@ def cmp.Ordering.is_eq (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok false
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_ne]:
-    Source: 'core-models/src/core/cmp.rs', lines 249:4-251:5
+    Source: 'core-models/src/core/cmp.rs', lines 244:4-246:5
     Visibility: public -/
 def cmp.Ordering.is_ne (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -629,7 +629,7 @@ def cmp.Ordering.is_ne (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok true
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_lt]:
-    Source: 'core-models/src/core/cmp.rs', lines 253:4-255:5
+    Source: 'core-models/src/core/cmp.rs', lines 248:4-250:5
     Visibility: public -/
 def cmp.Ordering.is_lt (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -638,7 +638,7 @@ def cmp.Ordering.is_lt (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok false
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_gt]:
-    Source: 'core-models/src/core/cmp.rs', lines 257:4-259:5
+    Source: 'core-models/src/core/cmp.rs', lines 252:4-254:5
     Visibility: public -/
 def cmp.Ordering.is_gt (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -647,7 +647,7 @@ def cmp.Ordering.is_gt (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok true
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_le]:
-    Source: 'core-models/src/core/cmp.rs', lines 261:4-263:5
+    Source: 'core-models/src/core/cmp.rs', lines 256:4-258:5
     Visibility: public -/
 def cmp.Ordering.is_le (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -656,7 +656,7 @@ def cmp.Ordering.is_le (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok false
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::is_ge]:
-    Source: 'core-models/src/core/cmp.rs', lines 265:4-267:5
+    Source: 'core-models/src/core/cmp.rs', lines 260:4-262:5
     Visibility: public -/
 def cmp.Ordering.is_ge (self : cmp.Ordering) : Result Bool := do
   match self with
@@ -665,7 +665,7 @@ def cmp.Ordering.is_ge (self : cmp.Ordering) : Result Bool := do
   | cmp.Ordering.Greater => ok true
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::reverse]:
-    Source: 'core-models/src/core/cmp.rs', lines 269:4-275:5
+    Source: 'core-models/src/core/cmp.rs', lines 264:4-270:5
     Visibility: public -/
 def cmp.Ordering.reverse (self : cmp.Ordering) : Result cmp.Ordering := do
   match self with
@@ -674,7 +674,7 @@ def cmp.Ordering.reverse (self : cmp.Ordering) : Result cmp.Ordering := do
   | cmp.Ordering.Greater => ok cmp.Ordering.Less
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::then]:
-    Source: 'core-models/src/core/cmp.rs', lines 277:4-282:5
+    Source: 'core-models/src/core/cmp.rs', lines 272:4-277:5
     Visibility: public -/
 def cmp.Ordering.then
   (self : cmp.Ordering) (other : cmp.Ordering) : Result cmp.Ordering := do
@@ -684,7 +684,7 @@ def cmp.Ordering.then
   | cmp.Ordering.Greater => ok cmp.Ordering.Greater
 
 /-- [core_models::cmp::{core_models::cmp::Ordering}::then_with]:
-    Source: 'core-models/src/core/cmp.rs', lines 284:4-289:5
+    Source: 'core-models/src/core/cmp.rs', lines 279:4-284:5
     Visibility: public -/
 def cmp.Ordering.then_with
   {F : Type} (coreopsfunctionFnOnceFTupleOrderingInst :
@@ -705,7 +705,7 @@ def panicking.internal.panic (T : Type) : Result T := do
   fail Error.panic
 
 /-- [core_models::cmp::clamp]:
-    Source: 'core-models/src/core/cmp.rs', lines 294:0-306:1
+    Source: 'core-models/src/core/cmp.rs', lines 289:0-301:1
     Visibility: public -/
 def cmp.clamp
   {T : Type} (OrdInst : cmp.Ord T) (value : T) (min : T) (max : T) :
@@ -12213,8 +12213,107 @@ def ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice (T :
     ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_unchecked_mut
 }
 
+/-- [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}::get_unchecked_mut]:
+    Source: 'core-models/src/core/slice.rs', lines 626:8-628:9
+    Visibility: public -/
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_unchecked_mut
+  {T : Type} (self : ops.range.RangeInclusive Std.Usize) (slice : Slice T) :
+  Result ((Slice T) × (Slice T → Slice T))
+  := do
+  let i ← self.«end» + 1#usize
+  rust_primitives.slice.slice_slice_mut slice self.start i
+
+/-- [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}::get_mut]:
+    Source: 'core-models/src/core/slice.rs', lines 617:8-623:9
+    Visibility: public -/
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_mut
+  {T : Type} (self : ops.range.RangeInclusive Std.Usize) (slice : Slice T) :
+  Result ((option.Option (Slice T)) × (option.Option (Slice T) → Slice T))
+  := do
+  if self.start <= self.«end»
+  then
+    let i ← rust_primitives.slice.slice_length slice
+    if self.«end» < i
+    then
+      let i1 ← self.«end» + 1#usize
+      let (s, slice_slice_mut_back) ←
+        rust_primitives.slice.slice_slice_mut slice self.start i1
+      let back :=
+        fun o =>
+          let s1 := match o with
+                    | option.Option.Some s2 => s2
+                    | _ => s
+          slice_slice_mut_back s1
+      ok (option.Option.Some s, back)
+    else let back := fun o => slice
+         ok (option.Option.None, back)
+  else let back := fun o => slice
+       ok (option.Option.None, back)
+
+/-- [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}::get_unchecked]:
+    Source: 'core-models/src/core/slice.rs', lines 613:8-615:9
+    Visibility: public -/
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_unchecked
+  {T : Type} (self : ops.range.RangeInclusive Std.Usize) (slice : Slice T) :
+  Result (Slice T)
+  := do
+  let i ← self.«end» + 1#usize
+  rust_primitives.slice.slice_slice slice self.start i
+
+/-- [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}::index]:
+    Source: 'core-models/src/core/slice.rs', lines 609:8-611:9
+    Visibility: public -/
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.index
+  {T : Type} (self : ops.range.RangeInclusive Std.Usize) (slice : Slice T) :
+  Result (Slice T)
+  := do
+  let i ← self.«end» + 1#usize
+  rust_primitives.slice.slice_slice slice self.start i
+
+/-- [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}::get]:
+    Source: 'core-models/src/core/slice.rs', lines 601:8-607:9
+    Visibility: public -/
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get
+  {T : Type} (self : ops.range.RangeInclusive Std.Usize) (slice : Slice T) :
+  Result (option.Option (Slice T))
+  := do
+  if self.start <= self.«end»
+  then
+    let i ← rust_primitives.slice.slice_length slice
+    if self.«end» < i
+    then
+      let i1 ← self.«end» + 1#usize
+      let s ← rust_primitives.slice.slice_slice slice self.start i1
+      ok (option.Option.Some s)
+    else ok option.Option.None
+  else ok option.Option.None
+
+/-- Trait implementation: [core_models::slice::index::{impl core_models::slice::index::SliceIndex<[T], [T]> for core_models::ops::range::RangeInclusive<usize>}]
+    Source: 'core-models/src/core/slice.rs', lines 599:4-629:5 -/
+@[reducible]
+def
+  ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
+  (T : Type) : slice.index.SliceIndex (ops.range.RangeInclusive Std.Usize)
+  (Slice T) (Slice T) := {
+  get :=
+    ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get
+  index :=
+    ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.index
+  get_unchecked :=
+    ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_unchecked
+  get_mut :=
+    ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_mut
+  get_unchecked_mut :=
+    ops.range.RangeInclusiveUsize.Insts.CoreSliceIndexSliceIndexSliceSlice.get_unchecked_mut
+}
+
 /-- [core_models::slice::index::{impl core_models::ops::index::Index<I, Clause0_Output> for [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 608:8-613:9
+    Source: 'core-models/src/core/slice.rs', lines 645:8-650:9
     Visibility: public -/
 def Slice.Insts.CoreOpsIndexIndex.index
   {T : Type} {I : Type} {Clause0_Output : Type}
@@ -12228,7 +12327,7 @@ def Slice.Insts.CoreOpsIndexIndex.index
   | option.Option.None => panicking.internal.panic Clause0_Output
 
 /-- Trait implementation: [core_models::slice::index::{impl core_models::ops::index::Index<I, Clause0_Output> for [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 602:4-614:5 -/
+    Source: 'core-models/src/core/slice.rs', lines 639:4-651:5 -/
 @[reducible]
 def Slice.Insts.CoreOpsIndexIndex {T : Type} {I : Type} {Clause0_Output
   : Type} (SliceIndexISliceClause0_OutputInst : slice.index.SliceIndex I (Slice
@@ -12238,7 +12337,7 @@ def Slice.Insts.CoreOpsIndexIndex {T : Type} {I : Type} {Clause0_Output
 }
 
 /-- [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::Range<usize>, [T]> for &'_0 [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 629:4-631:5
+    Source: 'core-models/src/core/slice.rs', lines 666:4-668:5
     Visibility: public -/
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeUsizeSlice.index
   {T : Type} (self : Slice T) (i : ops.range.Range Std.Usize) :
@@ -12247,7 +12346,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeUsizeSlice.index
   rust_primitives.slice.slice_slice self i.start i.«end»
 
 /-- Trait implementation: [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::Range<usize>, [T]> for &'_0 [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 626:0-632:1 -/
+    Source: 'core-models/src/core/slice.rs', lines 663:0-669:1 -/
 @[reducible]
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeUsizeSlice (T : Type) :
   ops.index.Index (Slice T) (ops.range.Range Std.Usize) (Slice T) := {
@@ -12255,7 +12354,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeUsizeSlice (T : Type) :
 }
 
 /-- [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeTo<usize>, [T]> for &'_0 [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 638:4-640:5
+    Source: 'core-models/src/core/slice.rs', lines 675:4-677:5
     Visibility: public -/
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeToUsizeSlice.index
   {T : Type} (self : Slice T) (i : ops.range.RangeTo Std.Usize) :
@@ -12264,7 +12363,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeToUsizeSlice.index
   rust_primitives.slice.slice_slice self 0#usize i.«end»
 
 /-- Trait implementation: [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeTo<usize>, [T]> for &'_0 [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 635:0-641:1 -/
+    Source: 'core-models/src/core/slice.rs', lines 672:0-678:1 -/
 @[reducible]
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeToUsizeSlice (T : Type) :
   ops.index.Index (Slice T) (ops.range.RangeTo Std.Usize) (Slice T) := {
@@ -12272,7 +12371,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeToUsizeSlice (T : Type) :
 }
 
 /-- [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeFrom<usize>, [T]> for &'_0 [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 647:4-649:5
+    Source: 'core-models/src/core/slice.rs', lines 684:4-686:5
     Visibility: public -/
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeFromUsizeSlice.index
   {T : Type} (self : Slice T) (i : ops.range.RangeFrom Std.Usize) :
@@ -12282,7 +12381,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeFromUsizeSlice.index
   rust_primitives.slice.slice_slice self i.start i1
 
 /-- Trait implementation: [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeFrom<usize>, [T]> for &'_0 [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 644:0-650:1 -/
+    Source: 'core-models/src/core/slice.rs', lines 681:0-687:1 -/
 @[reducible]
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeFromUsizeSlice (T : Type) :
   ops.index.Index (Slice T) (ops.range.RangeFrom Std.Usize) (Slice T) := {
@@ -12290,7 +12389,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeFromUsizeSlice (T : Type) :
 }
 
 /-- [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeFull, [T]> for &'_0 [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 655:4-657:5
+    Source: 'core-models/src/core/slice.rs', lines 692:4-694:5
     Visibility: public -/
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeFullSlice.index
   {T : Type} (self : Slice T) (i : ops.range.RangeFull) :
@@ -12300,7 +12399,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeFullSlice.index
   rust_primitives.slice.slice_slice self 0#usize i1
 
 /-- Trait implementation: [core_models::slice::{impl core_models::ops::index::Index<core_models::ops::range::RangeFull, [T]> for &'_0 [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 653:0-658:1 -/
+    Source: 'core-models/src/core/slice.rs', lines 690:0-695:1 -/
 @[reducible]
 def Shared0Slice.Insts.CoreOpsIndexIndexRangeFullSlice (T : Type) :
   ops.index.Index (Slice T) ops.range.RangeFull (Slice T) := {
@@ -12308,14 +12407,14 @@ def Shared0Slice.Insts.CoreOpsIndexIndexRangeFullSlice (T : Type) :
 }
 
 /-- [core_models::slice::{impl core_models::ops::index::Index<usize, T> for &'_0 [T]}::index]:
-    Source: 'core-models/src/core/slice.rs', lines 665:4-667:5
+    Source: 'core-models/src/core/slice.rs', lines 702:4-704:5
     Visibility: public -/
 def Shared0Slice.Insts.CoreOpsIndexIndexUsizeT.index
   {T : Type} (self : Slice T) (i : Std.Usize) : Result T := do
   rust_primitives.slice.slice_index self i
 
 /-- Trait implementation: [core_models::slice::{impl core_models::ops::index::Index<usize, T> for &'_0 [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 662:0-668:1 -/
+    Source: 'core-models/src/core/slice.rs', lines 699:0-705:1 -/
 @[reducible]
 def Shared0Slice.Insts.CoreOpsIndexIndexUsizeT (T : Type) :
   ops.index.Index (Slice T) Std.Usize T := {
@@ -12323,7 +12422,7 @@ def Shared0Slice.Insts.CoreOpsIndexIndexUsizeT (T : Type) :
 }
 
 /-- [core_models::slice::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T]}::eq]: loop body 0:
-    Source: 'core-models/src/core/slice.rs', lines 683:16-688:17
+    Source: 'core-models/src/core/slice.rs', lines 720:16-725:17
     Visibility: public -/
 @[rust_loop_body]
 def Slice.Insts.CoreCmpPartialEqArray.eq_loop.body
@@ -12349,7 +12448,7 @@ def Slice.Insts.CoreCmpPartialEqArray.eq_loop.body
     else ok (cont (iter1, false))
 
 /-- [core_models::slice::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T]}::eq]: loop 0:
-    Source: 'core-models/src/core/slice.rs', lines 683:16-688:17
+    Source: 'core-models/src/core/slice.rs', lines 720:16-725:17
     Visibility: public -/
 @[rust_loop]
 def Slice.Insts.CoreCmpPartialEqArray.eq_loop
@@ -12364,7 +12463,7 @@ def Slice.Insts.CoreCmpPartialEqArray.eq_loop
     (iter_, res)
 
 /-- [core_models::slice::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T]}::eq]:
-    Source: 'core-models/src/core/slice.rs', lines 678:8-691:9
+    Source: 'core-models/src/core/slice.rs', lines 715:8-728:9
     Visibility: public -/
 def Slice.Insts.CoreCmpPartialEqArray.eq
   {T : Type} {U : Type} {N : Std.Usize} (cmpPartialEqInst : cmp.PartialEq T U)
@@ -12379,7 +12478,7 @@ def Slice.Insts.CoreCmpPartialEqArray.eq
       { start := 0#usize, «end» := N } self other true
 
 /-- Trait implementation: [core_models::slice::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T]}]
-    Source: 'core-models/src/core/slice.rs', lines 677:4-692:5 -/
+    Source: 'core-models/src/core/slice.rs', lines 714:4-729:5 -/
 @[reducible]
 def Slice.Insts.CoreCmpPartialEqArray {T : Type} {U : Type} (N :
   Std.Usize) (cmpPartialEqInst : cmp.PartialEq T U) : cmp.PartialEq (Slice T)

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -45,7 +45,7 @@ structure iter.traits.collect.IntoIterator (Self : Type) (Self_Item : Type)
   into_iter : Self → Result Self_IntoIter
 
 /-- [core_models::array::iter::IntoIter]
-    Source: 'core-models/src/core/array.rs', lines 168:4-168:55
+    Source: 'core-models/src/core/array.rs', lines 180:4-180:55
     Visibility: public -/
 @[reducible]
 def array.iter.IntoIter (T : Type) (N : Std.Usize) :=
@@ -108,7 +108,7 @@ inductive cmp.Ordering where
 -/
 
 /-- Trait declaration: [core_models::cmp::PartialOrd]
-    Source: 'core-models/src/core/cmp.rs', lines 30:0-68:1
+    Source: 'core-models/src/core/cmp.rs', lines 30:0-66:1
     Visibility: public -/
 structure cmp.PartialOrd (Self : Type) (Rhs : Type) where
   PartialEqInst : cmp.PartialEq Self Rhs
@@ -119,12 +119,12 @@ structure cmp.PartialOrd (Self : Type) (Rhs : Type) where
   ge : Self → Rhs → Result Bool
 
 /-- Trait declaration: [core_models::cmp::Neq]
-    Source: 'core-models/src/core/cmp.rs', lines 72:0-75:1 -/
+    Source: 'core-models/src/core/cmp.rs', lines 69:0-72:1 -/
 structure cmp.Neq (Self : Type) (Rhs : Type) where
   neq : Self → Rhs → Result Bool
 
 /-- Trait declaration: [core_models::cmp::Ord]
-    Source: 'core-models/src/core/cmp.rs', lines 145:0-149:1
+    Source: 'core-models/src/core/cmp.rs', lines 140:0-144:1
     Visibility: public -/
 structure cmp.Ord (Self : Type) where
   EqInst : cmp.Eq Self
@@ -132,7 +132,7 @@ structure cmp.Ord (Self : Type) where
   cmp : Self → Self → Result cmp.Ordering
 
 /-- [core_models::cmp::Reverse]
-    Source: 'core-models/src/core/cmp.rs', lines 168:0-168:29
+    Source: 'core-models/src/core/cmp.rs', lines 163:0-163:29
     Visibility: public -/
 @[reducible]
 def cmp.Reverse (T : Type) := T

--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "hax"
-version = "0.3.3"
+version = "0.3.4"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
The `extract-mlkem` job fails on `Libcrux_ml_kem.Vector.Avx2.Sampling.fst` with an unsolvable `t_Index (t_Slice i16) (t_RangeInclusive usize)` constraint, even though no inclusive range appears in the Rust source. It comes from a `hax_lib::fstar!` block that builds a range by field name:

```
assume (Core_models.Ops.Index.f_index_pre output ({
            Core_models.Ops.Range.f_start = ...;
            Core_models.Ops.Range.f_end   = ... }))
```

`t_Range` and `t_RangeInclusive` share `f_start`/`f_end`, and `Core_models.Ops.Range` re-includes `t_RangeInclusive` last, so F* resolves the unascribed literal to `t_RangeInclusive` — for which no `Index` instance existed. std has `impl SliceIndex<[T]> for RangeInclusive<usize>`, so this is a real gap in the model.

This adds that impl plus the array `Index` counterpart on the F* backend path, and regenerates the F* and Lean proof-libs.

The precondition is `start <= end && end < len`, deliberately stronger than std's: the empty inclusive range (`start == end + 1`) is rejected. Admitting it needs `end + 1` inside a precondition, which cannot be discharged without guard ordering that F*'s `&&` does not provide.

## Note for reviewers: three generated instances are renumbered

- `Core_models.Slice.Index.impl_5` (blanket `Index<I> for [T]`) → `impl_6`
- `Core_models.Bundle.impl_29` (array `Index<RangeFull>`) → `impl_30`
- `Core_models.Bundle.impl_30` (`PartialOrd u8`) → `impl_30__from__cmp`

Downstream proofs naming any of these explicitly need updating.

## Follow-ups, not in this PR

- **libcrux should ascribe that literal** (`<: Core_models.Ops.Range.t_Range usize`). The code it guards indexes with an exclusive `Range`, so the assumption is about the wrong type and discharges nothing for the real obligation. This PR makes the file typecheck; it does not make the assumption meaningful — and under `prove --admit` that is invisible.
- `s[a..=b]` remains unextractable: `..=` desugars to `RangeInclusive::new`, which the model lacks. Fixed here is typeclass resolution for F*-level range values, which is what broke.
- The shadowing is unchanged, so a future unascribed literal resolves to `t_RangeInclusive` again — now typechecking silently rather than erroring loudly.

Fixes #2054 (see [extract-mlkem](https://github.com/cryspen/hax/actions/runs/32368163175/job/96422290366))

*Assisted by AI. Tested manually.*