### PR TITLE
[hax-lib] Re-architecture so that rustdoc picks the doc comments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Changes to hax-lib:
    `len' <= len` (#2157)
  - Add specs for Lean rust primitives (#2146)
  - Restore the documentation of the proc-macros, which was missing on docs.rs and in builds without `--cfg hax` (#1759)
+ - Fix the docs.rs build of `hax-lib`: its `docs.rs` metadata table was misspelled, and `--cfg hax` has to reach rustc too so that the `cfg(hax)` dependencies resolve (#2087)
 
 Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Changes to hax-lib:
    `impl<T: Clone>` block and relaxed `Vec::remove`'s postcondition to
    `len' <= len` (#2157)
  - Add specs for Lean rust primitives (#2146)
+ - Restore the documentation of the proc-macros, which was missing on docs.rs and in builds without `--cfg hax` (#1759)
 
 Changes to the Lean backend:
 - Hoist methods to allow (mutual) recursion between methods and associated items of the same impl (cryspen/hax-evit/163)

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -28,4 +28,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)'] }
 # `--cfg hax` also has to reach rustc: otherwise Cargo does not see the `hax`
 # cfg and leaves the `[target.'cfg(hax)'.dependencies]` unresolved.
 rustc-args = ["--cfg", "hax"]
-rustdoc-args = ["--cfg", "doc_cfg", "--cfg", "hax"]
+rustdoc-args = ["--cfg", "hax"]

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -24,5 +24,8 @@ macros = ["dep:hax-lib-macros"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)'] }
 
-[package.metadata."docs.rs"]
+[package.metadata.docs.rs]
+# `--cfg hax` also has to reach rustc: otherwise Cargo does not see the `hax`
+# cfg and leaves the `[target.'cfg(hax)'.dependencies]` unresolved.
+rustc-args = ["--cfg", "hax"]
 rustdoc-args = ["--cfg", "doc_cfg", "--cfg", "hax"]

--- a/hax-lib/macros/src/dummy.rs
+++ b/hax-lib/macros/src/dummy.rs
@@ -1,125 +1,34 @@
-mod hax_paths;
+//! Fallbacks used when hax is not running: the proc-macros of this crate should
+//! then be transparent. Only the macros that cannot simply forward their input
+//! need an implementation here.
 
-use hax_paths::*;
+use crate::hax_paths::*;
 use proc_macro::{TokenStream, TokenTree};
 use quote::quote;
 use syn::{visit_mut::VisitMut, *};
 
-macro_rules! identity_proc_macro_attribute {
-    ($($name:ident),*$(,)?) => {
-        $(
-            #[proc_macro_attribute]
-            pub fn $name(_attr: TokenStream, item: TokenStream) -> TokenStream {
-                item
-            }
-        )*
-    }
-}
-
-identity_proc_macro_attribute!(
-    fstar_options,
-    fstar_verification_status,
-    include,
-    exclude,
-    requires,
-    ensures,
-    decreases,
-    pv_handwritten,
-    pv_constructor,
-    protocol_messages,
-    process_init,
-    process_write,
-    process_read,
-    opaque,
-    opaque_type,
-    transparent,
-    refinement_type,
-    fstar_replace,
-    coq_replace,
-    legacy_lean_replace,
-    proverif_replace,
-    fstar_replace_body,
-    coq_replace_body,
-    legacy_lean_replace_body,
-    proverif_replace_body,
-    fstar_before,
-    coq_before,
-    legacy_lean_before,
-    proverif_before,
-    fstar_after,
-    coq_after,
-    legacy_lean_after,
-    proverif_after,
-    fstar_smt_pat,
-    fstar_postprocess_with,
-    legacy_lean_proof,
-    legacy_lean_pure_requires_proof,
-    legacy_lean_pure_ensures_proof,
-    legacy_lean_proof_method_grind,
-    legacy_lean_proof_method_bv_decide,
-);
-
-#[proc_macro]
-pub fn fstar_expr(_payload: TokenStream) -> TokenStream {
-    quote! { () }.into()
-}
-#[proc_macro]
-pub fn coq_expr(_payload: TokenStream) -> TokenStream {
-    quote! { () }.into()
-}
-#[proc_macro]
-pub fn legacy_lean_expr(_payload: TokenStream) -> TokenStream {
-    quote! { () }.into()
-}
-#[proc_macro]
-pub fn proverif_expr(_payload: TokenStream) -> TokenStream {
+/// Expansion of a `<BACKEND>_expr!` macro.
+pub fn unit_expr() -> TokenStream {
     quote! { () }.into()
 }
 
-#[proc_macro_attribute]
-pub fn lemma(_attr: TokenStream, _item: TokenStream) -> TokenStream {
-    quote! {}.into()
+/// Expansion of a `<BACKEND>_prop_expr!` macro.
+pub fn prop_expr() -> TokenStream {
+    quote! {::hax_lib::Prop::from_bool(true)}.into()
 }
 
-fn unsafe_expr() -> TokenStream {
-    // `*_unsafe_expr("<code>")` are macro generating a Rust expression of any type, that will be replaced by `<code>` in the backends.
-    // This should be used solely in hax-only contextes.
-    // If this macro is used, that means the user broke this rule.
+/// Expansion of a `<BACKEND>_unsafe_expr!` macro. Such a macro generates a Rust
+/// expression of any type, that gets replaced by verbatim backend code at
+/// extraction: it is meaningful only in hax-only contexts, so reaching this
+/// point means the user broke that rule.
+pub fn unsafe_expr() -> TokenStream {
     quote! { ::std::compile_error!("`hax_lib::unsafe_expr` has no meaning outside of hax extraction, please use it solely on hax-only places.") }.into()
 }
 
-#[proc_macro]
-pub fn fstar_unsafe_expr(_payload: TokenStream) -> TokenStream {
-    unsafe_expr()
-}
-#[proc_macro]
-pub fn coq_unsafe_expr(_payload: TokenStream) -> TokenStream {
-    unsafe_expr()
-}
-#[proc_macro]
-pub fn legacy_lean_unsafe_expr(_payload: TokenStream) -> TokenStream {
-    unsafe_expr()
-}
-#[proc_macro]
-pub fn proverif_unsafe_expr(_payload: TokenStream) -> TokenStream {
-    unsafe_expr()
-}
-
-#[proc_macro]
-pub fn fstar_prop_expr(_payload: TokenStream) -> TokenStream {
-    quote! {::hax_lib::Prop::from_bool(true)}.into()
-}
-#[proc_macro]
-pub fn coq_prop_expr(_payload: TokenStream) -> TokenStream {
-    quote! {::hax_lib::Prop::from_bool(true)}.into()
-}
-#[proc_macro]
-pub fn legacy_lean_prop_expr(_payload: TokenStream) -> TokenStream {
-    quote! {::hax_lib::Prop::from_bool(true)}.into()
-}
-#[proc_macro]
-pub fn proverif_prop_expr(_payload: TokenStream) -> TokenStream {
-    quote! {::hax_lib::Prop::from_bool(true)}.into()
+/// Expansion of an internal macro that was used directly.
+pub fn internal_macro_misuse(name: &str) -> TokenStream {
+    let message = format!("`{name}` is an internal macro and should never be used directly.");
+    quote! { ::std::compile_error!(#message) }.into()
 }
 
 fn not_hax_attribute(attr: &syn::Attribute) -> bool {
@@ -139,8 +48,8 @@ fn not_field_attribute(attr: &syn::Attribute) -> bool {
     }
 }
 
-#[proc_macro_attribute]
-pub fn attributes(_attr: TokenStream, item: TokenStream) -> TokenStream {
+/// Strips the hax attributes enabled by `#[attributes]`.
+pub fn attributes(item: TokenStream) -> TokenStream {
     let item: Item = parse_macro_input!(item);
 
     struct AttrVisitor;
@@ -184,7 +93,7 @@ pub fn attributes(_attr: TokenStream, item: TokenStream) -> TokenStream {
     quote! { #item }.into()
 }
 
-#[proc_macro]
+/// Expansion of `int!`.
 pub fn int(payload: TokenStream) -> TokenStream {
     let mut tokens = payload.into_iter().peekable();
     let negative = matches!(tokens.peek(), Some(TokenTree::Punct(p)) if p.as_char() == '-');
@@ -196,24 +105,4 @@ pub fn int(payload: TokenStream) -> TokenStream {
     };
     let lit: proc_macro2::TokenStream = TokenStream::from(lit.clone()).into();
     quote! {::hax_lib::int::Int(#lit)}.into()
-}
-
-#[proc_macro_attribute]
-pub fn impl_fn_decoration(_attr: TokenStream, _item: TokenStream) -> TokenStream {
-    quote! { ::std::compile_error!("`impl_fn_decoration` is an internal macro and should never be used directly.") }.into()
-}
-
-#[proc_macro_attribute]
-pub fn trait_fn_decoration(_attr: TokenStream, _item: TokenStream) -> TokenStream {
-    quote! { ::std::compile_error!("`trait_fn_decoration` is an internal macro and should never be used directly.") }.into()
-}
-
-#[proc_macro]
-pub fn loop_invariant(_predicate: TokenStream) -> TokenStream {
-    quote! {}.into()
-}
-
-#[proc_macro]
-pub fn loop_decreases(_predicate: TokenStream) -> TokenStream {
-    quote! {}.into()
 }

--- a/hax-lib/macros/src/impl_fn_decoration.rs
+++ b/hax-lib/macros/src/impl_fn_decoration.rs
@@ -55,8 +55,11 @@ impl parse::Parse for ImplFnDecoration {
                     });
                 }
                 _ => unreachable!(),
-            }
-            None => Err(Error::new(path_span, "Expected `::hax_lib::<KIND>`, `hax_lib::<KIND>` or `<KIND>` with `KIND` in {DECORATION_KINDS:?}"))?,
+            },
+            None => Err(Error::new(
+                path_span,
+                "Expected `::hax_lib::<KIND>`, `hax_lib::<KIND>` or `<KIND>` with `KIND` in {DECORATION_KINDS:?}",
+            ))?,
         };
 
         let (generics, self_ty, self_trait) = parse_next()?;

--- a/hax-lib/macros/src/impl_fn_decoration.rs
+++ b/hax-lib/macros/src/impl_fn_decoration.rs
@@ -58,7 +58,9 @@ impl parse::Parse for ImplFnDecoration {
             },
             None => Err(Error::new(
                 path_span,
-                "Expected `::hax_lib::<KIND>`, `hax_lib::<KIND>` or `<KIND>` with `KIND` in {DECORATION_KINDS:?}",
+                format!(
+                    "Expected `::hax_lib::<KIND>`, `hax_lib::<KIND>` or `<KIND>` with `KIND` in {DECORATION_KINDS:?}"
+                ),
             ))?,
         };
 

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -990,7 +990,10 @@ pub fn legacy_lean_pure_requires_proof(
 /// This macro inserts a verbatim Lean proof showing that the `ensures`-condition is panic-free.
 /// The proof is inserted into the `pureEnsures` field of the Lean spec.
 #[proc_macro_attribute]
-pub fn legacy_lean_pure_ensures_proof(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+pub fn legacy_lean_pure_ensures_proof(
+    payload: pm::TokenStream,
+    item: pm::TokenStream,
+) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let payload = parse_macro_input!(payload as LitStr).value();
     let attr = AttrPayload::PureEnsuresProof(payload);
@@ -999,7 +1002,10 @@ pub fn legacy_lean_pure_ensures_proof(payload: pm::TokenStream, item: pm::TokenS
 
 /// Use the proof method `grind`. This influences the tactic and spec set used by Lean.
 #[proc_macro_attribute]
-pub fn legacy_lean_proof_method_grind(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+pub fn legacy_lean_proof_method_grind(
+    _attr: pm::TokenStream,
+    item: pm::TokenStream,
+) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::ProofMethod(hax_lib_macros_types::ProofMethod::Grind);
     quote! {#attr #item}.into()

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -1,29 +1,10 @@
-mod hax_paths;
-mod impl_fn_decoration;
-mod quote;
-mod rewrite_self;
-mod syn_ext;
-mod utils;
+//! The actual implementation of the proc-macros of this crate. The
+//! `#[proc_macro*]` entry points live in `lib.rs` and merely dispatch here.
 
-mod prelude {
-    pub use crate::hax_paths::*;
-    pub use crate::syn_ext::*;
-    pub use proc_macro as pm;
-    pub use proc_macro2::*;
-    pub use quote::*;
-    pub use std::collections::HashSet;
-    pub use syn::spanned::Spanned;
-    pub use syn::{visit_mut::VisitMut, *};
-
-    pub use AttrPayload::Language as AttrHaxLang;
-    pub use hax_lib_macros_types::*;
-    pub type FnLike = syn::ImplItemFn;
-}
-
-use impl_fn_decoration::*;
-use prelude::*;
-use rewrite_self::SelfProjection;
-use utils::*;
+use crate::impl_fn_decoration::*;
+use crate::prelude::*;
+use crate::rewrite_self::SelfProjection;
+use crate::utils::*;
 
 /// Reports a compile error at `$span` and returns from the enclosing
 /// proc-macro function. The message is either a single value or a `format!`
@@ -56,9 +37,6 @@ macro_rules! abort_call_site {
     };
 }
 
-/// When extracting to F*, wrap this item in `#push-options "..."` and
-/// `#pop-options`.
-#[proc_macro_attribute]
 pub fn fstar_options(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
     let lit_str = parse_macro_input!(attr as LitStr);
@@ -72,26 +50,6 @@ pub fn fstar_options(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenS
     .into()
 }
 
-/// Add an invariant to a loop which deals with an index. The
-/// invariant cannot refer to any variable introduced within the
-/// loop. An invariant is a closure that takes one argument, the
-/// index, and returns a proposition.
-///
-/// Note that loop invariants are unstable (this will be handled in a
-/// better way in the future, see
-/// https://github.com/hacspec/hax/issues/858) and only supported on
-/// specific `for` loops with specific iterators:
-///
-///  - `for i in start..end {...}`
-///  - `for i in (start..end).step_by(n) {...}`
-///  - `for i in slice.enumerate() {...}`
-///  - `for i in slice.chunks_exact(n).enumerate() {...}`
-///
-/// This function must be called on the first line of a loop body to
-/// be effective. Note that in the invariant expression, `forall`,
-/// `exists`, and `BACKEND!` (`BACKEND` can be `fstar`, `proverif`,
-/// `coq`...) are in scope.
-#[proc_macro]
 pub fn loop_invariant(predicate: pm::TokenStream) -> pm::TokenStream {
     let predicate2: TokenStream = predicate.clone().into();
     let predicate_expr: syn::Expr = parse_macro_input!(predicate);
@@ -116,12 +74,6 @@ pub fn loop_invariant(predicate: pm::TokenStream) -> pm::TokenStream {
     ts
 }
 
-/// Must be used to prove termination of while loops. This takes an
-/// expression that should be a usize that decreases at every iteration
-///
-/// This function must be called just after `loop_invariant`, or at the first
-/// line of the loop if there is no invariant.
-#[proc_macro]
 pub fn loop_decreases(predicate: pm::TokenStream) -> pm::TokenStream {
     let predicate: TokenStream = predicate.into();
     let ts: pm::TokenStream = quote! {
@@ -138,10 +90,6 @@ pub fn loop_decreases(predicate: pm::TokenStream) -> pm::TokenStream {
     ts
 }
 
-/// When extracting to F*, inform about what is the current
-/// verification status for an item. It can either be `lax` or
-/// `panic_free`.
-#[proc_macro_attribute]
 pub fn fstar_verification_status(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let action = format!("{}", parse_macro_input!(attr as Ident));
     match action.as_str() {
@@ -185,10 +133,6 @@ pub fn fstar_verification_status(attr: pm::TokenStream, item: pm::TokenStream) -
     .into()
 }
 
-/// Postprocess an item with a given tactic. This macro takes the tactic in
-/// parameter: this may be a Rust identifier or a raw snippet of F* code as a
-/// string literal.
-#[proc_macro_attribute]
 pub fn fstar_postprocess_with(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
     let payload: String = if let Ok(s) = syn::parse::<LitStr>(attr.clone()) {
@@ -209,8 +153,6 @@ fn charon_attr(name: TokenStream) -> Option<TokenStream> {
     cfg!(charon).then(|| quote! {#[charon::#name]})
 }
 
-/// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
-#[proc_macro_attribute]
 pub fn include(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
     let _ = parse_macro_input!(attr as parse::Nothing);
@@ -218,8 +160,6 @@ pub fn include(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream 
     quote! {#attr #item}.into()
 }
 
-/// Exclude this item from the Hax translation.
-#[proc_macro_attribute]
 pub fn exclude(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: TokenStream = item.into();
     let _ = parse_macro_input!(attr as parse::Nothing);
@@ -256,29 +196,6 @@ pub fn modeled_by(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStre
 }
 */
 
-/// Mark a `Proof<{STATEMENT}>`-returning function as a lemma, where
-/// `STATEMENT` is a `Prop` expression capturing any input
-/// variable.
-/// In the backends, this will generate a lemma with an empty proof.
-///
-/// # Example
-///
-/// ```
-/// use hax_lib_macros::*;
-// #[decreases((m, n))] (TODO: see #297)
-/// pub fn ackermann(m: u64, n: u64) -> u64 {
-///     match (m, n) {
-///         (0, _) => n + 1,
-///         (_, 0) => ackermann(m - 1, 1),
-///         _ => ackermann(m - 1, ackermann(m, n - 1)),
-///     }
-/// }
-///
-/// #[lemma]
-/// /// $`\forall n \in \mathbb{N}, \textrm{ackermann}(2, n) = 2 (n + 3) - 3`$
-/// pub fn ackermann_property_m1(n: u64) -> Proof<{ ackermann(2, n) == 2 * (n + 3) - 3 }> {}
-/// ```
-#[proc_macro_attribute]
 pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let mut item: syn::ItemFn = parse_macro_input!(item as ItemFn);
     use syn::{GenericArgument, PathArguments, ReturnType, spanned::Spanned};
@@ -337,25 +254,6 @@ pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     )
 }
 
-/// Provide a measure for a function: this measure will be used once
-/// extracted in a backend for checking termination. The expression
-/// that decreases can be of any type. (TODO: this is probably as it
-/// is true only for F*, see #297)
-///
-/// # Example
-///
-/// ```
-/// use hax_lib_macros::*;
-/// #[decreases((m, n))]
-/// pub fn ackermann(m: u64, n: u64) -> u64 {
-///     match (m, n) {
-///         (0, _) => n + 1,
-///         (_, 0) => ackermann(m - 1, 1),
-///         _ => ackermann(m - 1, ackermann(m, n - 1)),
-///     }
-/// }
-/// ```
-#[proc_macro_attribute]
 pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let phi: syn::Expr = parse_macro_input!(attr);
     let item: FnLike = parse_macro_input!(item);
@@ -370,9 +268,6 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
     quote! {#requires #attr #item}.into()
 }
 
-/// Allows to add SMT patterns to a lemma.
-/// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
-#[proc_macro_attribute]
 pub fn fstar_smt_pat(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let phi: syn::Expr = parse_macro_input!(attr);
     let item: FnLike = parse_macro_input!(item);
@@ -387,31 +282,6 @@ pub fn fstar_smt_pat(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenS
     quote! {#requires #attr #item}.into()
 }
 
-/// Add a logical precondition to a function.
-// Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
-/// In the case of a function that has one or more `&mut` inputs, in
-/// the `ensures` clause, you can refer to such an `&mut` input `x` as
-/// `x` for its "past" value and `future(x)` for its "future" value.
-///
-/// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
-/// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
-/// the precondition, e.g. `fstar!("true")`.
-///
-/// # Example
-///
-/// ```
-/// use hax_lib_macros::*;
-/// #[requires(x.len() == y.len())]
-// #[requires(x.len() == y.len() && forall(|i: usize| i >= x.len() || y[i] > 0))] (TODO: commented out for now, see #297)
-/// pub fn div_pairwise(x: Vec<u64>, y: Vec<u64>) -> Vec<u64> {
-///     x.iter()
-///         .copied()
-///         .zip(y.iter().copied())
-///         .map(|(x, y)| x / y)
-///         .collect()
-/// }
-/// ```
-#[proc_macro_attribute]
 pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let phi: syn::Expr = parse_macro_input!(attr);
     let item: FnLike = parse_macro_input!(item);
@@ -438,23 +308,6 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
     .into()
 }
 
-/// Add a logical postcondition to a function. Note you can use the
-/// `forall` and `exists` operators.
-///
-/// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
-/// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
-/// the postcondition, e.g. `fstar!("true")`.
-///
-/// # Example
-///
-/// ```
-/// use hax_lib_macros::*;
-/// #[ensures(|result| result == x * 2)]
-/// pub fn twice(x: u64) -> u64 {
-///     x + x
-/// }
-/// ```
-#[proc_macro_attribute]
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let ExprClosure1 {
         arg: ret_binder,
@@ -494,14 +347,6 @@ mod kw {
     syn::custom_keyword!(refine);
 }
 
-/// Internal macro for dealing with function decorations
-/// (`#[decreases(...)]`, `#[ensures(...)]`, `#[requires(...)]`) on
-/// `fn` items within an `impl` block. There is special handling since
-/// such functions might have a `self` argument: in such cases, we
-/// rewrite function decorations as `#[impl_fn_decoration(<KIND>,
-/// <GENERICS>, <WHERE CLAUSE>, <SELF TYPE> [as <TRAIT>], <BODY>)]`, where
-/// `<TRAIT>` is the trait implemented by the enclosing `impl` block.
-#[proc_macro_attribute]
 pub fn impl_fn_decoration(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let ImplFnDecoration {
         kind,
@@ -528,7 +373,6 @@ pub fn impl_fn_decoration(attr: pm::TokenStream, item: pm::TokenStream) -> pm::T
     quote! {#attr #item}.into()
 }
 
-#[proc_macro_attribute]
 pub fn trait_fn_decoration(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let ImplFnDecoration {
         kind,
@@ -560,57 +404,6 @@ pub fn trait_fn_decoration(attr: pm::TokenStream, item: pm::TokenStream) -> pm::
     quote! {#attr #item}.into()
 }
 
-/// Enable the following attrubutes in the annotated item and sub-items.
-///
-/// ### `refine` (on a field in a struct)
-/// Refine a type with a logical formula.
-///
-/// ### `order` (on a field in a struct or an enum)
-/// Reorders a field in the extracted code.
-///
-/// Rust fields order matters for bit-level representation. Similarly, in some
-/// situations, fields order matters in the backends: for instance in F*, one
-/// may refine a field with a formula referring to a later field.
-///
-/// Those two orders may conflict. Adding `#[hax_lib::order(n)]` on a field with
-/// override its order at extraction time.
-///
-/// By default, the order of a field is its index, e.g. the first field has
-/// order 0, the i-th field has order i+1.
-///
-/// ### `decreases`, `ensures` and `requires` (on a `fn` in an `impl`)
-/// `decreases`, `ensures`, `requires`: behave exactly as documented above on
-/// the proc attributes of the same name.
-///
-/// Those may also be written behind a `cfg_attr`, e.g.
-/// `#[cfg_attr(hax, requires(..))]`: the predicate is preserved, so the
-/// specification appears exactly when the predicate holds. This makes
-/// `hax-lib` usable as a `cfg(hax)`-gated dependency.
-///
-/// # Example
-///
-/// ```
-/// #[hax_lib_macros::attributes]
-/// mod foo {
-///     pub struct Hello {
-///         pub x: u32,
-///         #[refine(y > 3)]
-///         pub y: u32,
-///         #[refine(y + x + z > 3)]
-///         pub z: u32,
-///     }
-///     impl Hello {
-///         fn sum(&self) -> u32 {
-///             self.x + self.y + self.z
-///         }
-///         #[ensures(|result| result - n == self.sum())]
-///         fn plus(self, n: u32) -> u32 {
-///             self.sum() + n
-///         }
-///     }
-/// }
-/// ```
-#[proc_macro_attribute]
 pub fn attributes(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: Item = parse_macro_input!(item);
 
@@ -871,17 +664,10 @@ pub fn attributes(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStr
     quote! { #item #(#extra_items)* }.into()
 }
 
-/// Mark an item opaque: the extraction will assume the
-/// type without revealing its definition.
-#[proc_macro_attribute]
-#[deprecated(note = "Please use 'opaque' instead")]
 pub fn opaque_type(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     opaque(attr, item)
 }
 
-/// Mark an item opaque: the extraction will assume the
-/// type without revealing its definition.
-#[proc_macro_attribute]
 pub fn opaque(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: Item = parse_macro_input!(item);
     let attr = AttrPayload::Erased;
@@ -889,72 +675,48 @@ pub fn opaque(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream 
     quote! {#attr #charon #item}.into()
 }
 
-/// Mark an item transparent: the extraction will not
-/// make it opaque regardless of the `-i` flag default.
-#[proc_macro_attribute]
 pub fn transparent(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: Item = parse_macro_input!(item);
     let attr = AttrPayload::NeverErased;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating a `fn` as a ProVerif process read.
-#[proc_macro_attribute]
 pub fn process_read(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::ProcessRead;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating a `fn` as a ProVerif process write.
-#[proc_macro_attribute]
 pub fn process_write(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::ProcessWrite;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating a `fn` as a ProVerif process initialization.
-#[proc_macro_attribute]
 pub fn process_init(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::ProcessInit;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating an `enum` as describing the protocol messages.
-#[proc_macro_attribute]
 pub fn protocol_messages(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemEnum = parse_macro_input!(item);
     let attr = AttrPayload::ProtocolMessages;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating a `fn` should be automatically translated to a ProVerif constructor.
-#[proc_macro_attribute]
 pub fn pv_constructor(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::PVConstructor;
     quote! {#attr #item}.into()
 }
 
-/// A marker indicating a `fn` requires manual modelling in ProVerif.
-#[proc_macro_attribute]
 pub fn pv_handwritten(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let attr = AttrPayload::PVHandwritten;
     quote! {#attr #item}.into()
 }
 
-/// Create a mathematical integer. This macro expects a Rust integer
-/// literal without suffix.
-///
-/// ## Examples:
-/// - `int!(0x101010)`
-/// - `int!(42)`
-/// - `int!(0o52)`
-/// - `int!(0h2A)`
-#[proc_macro]
 pub fn int(payload: pm::TokenStream) -> pm::TokenStream {
     let n: LitInt = parse_macro_input!(payload);
     let suffix = n.suffix();
@@ -965,8 +727,6 @@ pub fn int(payload: pm::TokenStream) -> pm::TokenStream {
     quote! {::hax_lib::int::Int::_unsafe_from_str(#digits)}.into()
 }
 
-/// This macro inserts a verbatim Lean proof into the extracted code.
-#[proc_macro_attribute]
 pub fn legacy_lean_proof(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let item: ItemFn = parse_macro_input!(item);
     let payload = parse_macro_input!(payload as LitStr).value();
@@ -974,9 +734,6 @@ pub fn legacy_lean_proof(payload: pm::TokenStream, item: pm::TokenStream) -> pm:
     quote! {#attr #item}.into()
 }
 
-/// This macro inserts a verbatim Lean proof showing that the `requires`-condition is panic-free.
-/// The proof is inserted into the `pureRequires` field of the Lean spec.
-#[proc_macro_attribute]
 pub fn legacy_lean_pure_requires_proof(
     payload: pm::TokenStream,
     item: pm::TokenStream,
@@ -987,9 +744,6 @@ pub fn legacy_lean_pure_requires_proof(
     quote! {#attr #item}.into()
 }
 
-/// This macro inserts a verbatim Lean proof showing that the `ensures`-condition is panic-free.
-/// The proof is inserted into the `pureEnsures` field of the Lean spec.
-#[proc_macro_attribute]
 pub fn legacy_lean_pure_ensures_proof(
     payload: pm::TokenStream,
     item: pm::TokenStream,
@@ -1000,8 +754,6 @@ pub fn legacy_lean_pure_ensures_proof(
     quote! {#attr #item}.into()
 }
 
-/// Use the proof method `grind`. This influences the tactic and spec set used by Lean.
-#[proc_macro_attribute]
 pub fn legacy_lean_proof_method_grind(
     _attr: pm::TokenStream,
     item: pm::TokenStream,
@@ -1011,8 +763,6 @@ pub fn legacy_lean_proof_method_grind(
     quote! {#attr #item}.into()
 }
 
-/// Use the proof method `bv_decide`. This influences the tactic and spec set used by Lean.
-#[proc_macro_attribute]
 pub fn legacy_lean_proof_method_bv_decide(
     _attr: pm::TokenStream,
     item: pm::TokenStream,
@@ -1024,23 +774,12 @@ pub fn legacy_lean_proof_method_bv_decide(
 
 macro_rules! make_quoting_item_proc_macro {
     ($backend:ident, $macro_name:ident, $short_name:ident, $position:expr, $cfg_name:ident) => {
-        #[doc = concat!("This macro inlines verbatim ", stringify!($backend)," code before a Rust item.")]
-        ///
-        /// This macro takes a string literal containing backend
-        /// code. Just as backend expression macros, this literal can
-        /// contains dollar-prefixed Rust names.
-        ///
-        /// Note: when targetting F*, you can prepend a first
-        /// comma-separated argument: `interface`, `impl` or
-        /// `both`. This controls where the code will apprear: in the
-        /// `fst` or `fsti` files or both.
-        #[proc_macro_attribute]
         pub fn $macro_name(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
             // On an inherent `impl` block, re-target the annotation onto one of its items.
             {
                 let raw_payload: TokenStream = payload.clone().into();
                 let attr = quote! {#[::hax_lib::$backend::$short_name(#raw_payload)]};
-                if let Some(ts) = quote::retarget_on_inherent_impl(&item, $position, attr) {
+                if let Some(ts) = crate::quote::retarget_on_inherent_impl(&item, $position, attr) {
                     return ts.into();
                 }
             }
@@ -1055,10 +794,7 @@ macro_rules! make_quoting_item_proc_macro {
                         r#impl: ident_str == "impl" || ident_str == "both",
                     });
                     if !matches!(ident_str.as_str(), "impl" | "both" | "interface") {
-                        abort!(
-                            ident.span(),
-                            "Expected `impl`, `both` or `interface`"
-                        );
+                        abort!(ident.span(), "Expected `impl`, `both` or `interface`");
                     }
                     // Consume the ident
                     let _ = tokens.next();
@@ -1069,7 +805,7 @@ macro_rules! make_quoting_item_proc_macro {
                 pm::TokenStream::from_iter(tokens)
             };
 
-            let ts: TokenStream = quote::item(
+            let ts: TokenStream = crate::quote::item(
                 ItemQuote {
                     position: $position,
                     fstar_options,
@@ -1086,40 +822,8 @@ macro_rules! make_quoting_item_proc_macro {
 
 macro_rules! make_quoting_proc_macro {
     ($backend:ident) => {
-        #[doc = concat!("Embed ", stringify!($backend), " expression inside a Rust expression. This macro takes only one argument: some raw ", stringify!($backend), " code as a string literal.")]
-        ///
-
-        /// While it is possible to directly write raw backend code,
-        /// sometimes it can be inconvenient. For example, referencing
-        /// Rust names can be a bit cumbersome: for example, the name
-        /// `my_crate::my_module::CONSTANT` might be translated
-        /// differently in a backend (e.g. in the F* backend, it will
-        /// probably be `My_crate.My_module.v_CONSTANT`).
-        ///
-
-        /// To facilitate this, you can write Rust names directly,
-        /// using the prefix `$`: `f $my_crate::my_module__CONSTANT + 3`
-        /// will be replaced with `f My_crate.My_module.v_CONSTANT + 3`
-        /// in the F* backend for instance.
-
-        /// If you want to refer to the Rust constructor
-        /// `Enum::Variant`, you should write `$$Enum::Variant` (note
-        /// the double dollar).
-
-        /// If the name refers to something polymorphic, you need to
-        /// signal it by adding _any_ type informations,
-        /// e.g. `${my_module::function<()>}`. The curly braces are
-        /// needed for such more complex expressions.
-
-        /// You can also write Rust patterns with the `$?{SYNTAX}`
-        /// syntax, where `SYNTAX` is a Rust pattern. The syntax
-        /// `${EXPR}` also allows any Rust expressions
-        /// `EXPR` to be embedded.
-
-        /// Types can be refered to with the syntax `$:{TYPE}`.
-        #[proc_macro]
         pub fn ${concat($backend, _expr)}(payload: pm::TokenStream) -> pm::TokenStream {
-            let ts: TokenStream = quote::expression(quote::InlineExprType::Unit, payload).into();
+            let ts: TokenStream = crate::quote::expression(crate::quote::InlineExprType::Unit, payload).into();
             quote!{{
                 #[cfg(${concat(hax_backend_, $backend)})]
                 {
@@ -1128,10 +832,8 @@ macro_rules! make_quoting_proc_macro {
             }}.into()
         }
 
-        #[doc = concat!("The `Prop` version of `", stringify!($backend), "_expr`.")]
-        #[proc_macro]
         pub fn ${concat($backend, _prop_expr)}(payload: pm::TokenStream) -> pm::TokenStream {
-            let ts: TokenStream = quote::expression(quote::InlineExprType::Prop, payload).into();
+            let ts: TokenStream = crate::quote::expression(crate::quote::InlineExprType::Prop, payload).into();
             quote!{{
                 #[cfg(${concat(hax_backend_, $backend)})]
                 {
@@ -1144,11 +846,8 @@ macro_rules! make_quoting_proc_macro {
             }}.into()
         }
 
-        #[doc = concat!("The unsafe (because polymorphic: even computationally relevant code can be inlined!) version of `", stringify!($backend), "_expr`.")]
-        #[proc_macro]
-        #[doc(hidden)]
         pub fn ${concat($backend, _unsafe_expr)}(payload: pm::TokenStream) -> pm::TokenStream {
-            let ts: TokenStream = quote::expression(quote::InlineExprType::Anything, payload).into();
+            let ts: TokenStream = crate::quote::expression(crate::quote::InlineExprType::Anything, payload).into();
             quote!{{
                 #[cfg(${concat(hax_backend_, $backend)})]
                 {
@@ -1160,8 +859,6 @@ macro_rules! make_quoting_proc_macro {
         make_quoting_item_proc_macro!($backend, ${concat($backend, _before)}, before, ItemQuotePosition::Before, ${concat(hax_backend_, $backend)});
         make_quoting_item_proc_macro!($backend, ${concat($backend, _after)}, after, ItemQuotePosition::After, ${concat(hax_backend_, $backend)});
 
-        #[doc = concat!("Replaces a Rust item with some verbatim ", stringify!($backend)," code.")]
-        #[proc_macro_attribute]
         pub fn ${concat($backend, _replace)}(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
             if let Ok(item_impl) = syn::parse::<ItemImpl>(item.clone()) {
                 if item_impl.trait_.is_none() {
@@ -1186,8 +883,6 @@ macro_rules! make_quoting_proc_macro {
             .into()
         }
 
-        #[doc = concat!("Replaces the body of a Rust function with some verbatim ", stringify!($backend)," code.")]
-        #[proc_macro_attribute]
         pub fn ${concat($backend, _replace_body)}(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
             let payload: TokenStream = payload.into();
             let item: ItemFn = parse_macro_input!(item);
@@ -1213,37 +908,6 @@ macro_rules! make_quoting_proc_macro {
 
 make_quoting_proc_macro!(fstar coq proverif legacy_lean);
 
-/// Marks a newtype `struct RefinedT(T);` as a refinement type. The
-/// struct should have exactly one unnamed private field.
-///
-/// This macro takes one argument: a `Prop` proposition that refines
-/// values of type `SomeType`.
-///
-/// For example, the following type defines bounded `u64` integers.
-///
-/// ```
-/// #[hax_lib::refinement_type(|x| x >= MIN && x <= MAX)]
-/// pub struct BoundedU64<const MIN: u64, const MAX: u64>(u64);
-/// ```
-///
-/// This macro will generate an implementation of the [`Deref`] trait
-/// and of the [`hax_lib::Refinement`] type. Those two traits are
-/// the only interface to this newtype: one is allowed only to
-/// construct or destruct refined type via those smart constructors
-/// and destructors, ensuring the abstraction.
-///
-/// A refinement of a type `T` with a formula `f` can be seen as a box
-/// that contains a value of type `T` and a proof that this value
-/// satisfies the formula `f`.
-///
-/// In debug mode, the refinement will be checked at run-time. This
-/// requires the base type `T` to implement `Clone`. Pass a first
-/// parameter `no_debug_runtime_check` to disable this behavior.
-///
-/// When extracted via hax, this is interpreted in the backend as a
-/// refinement type: the use of such a type yields static proof
-/// obligations.
-#[proc_macro_attribute]
 pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let mut item = parse_macro_input!(item as syn::ItemStruct);
 

--- a/hax-lib/macros/src/implementation.rs
+++ b/hax-lib/macros/src/implementation.rs
@@ -1,5 +1,5 @@
-//! The actual implementation of the proc-macros of this crate. The
-//! `#[proc_macro*]` entry points live in `lib.rs` and merely dispatch here.
+//! Implementations of the proc-macros that are too big to sit next to their
+//! documentation in `lib.rs`, and the machinery they share.
 
 use crate::impl_fn_decoration::*;
 use crate::prelude::*;
@@ -35,19 +35,6 @@ macro_rules! abort_call_site {
             .to_compile_error()
             .into()
     };
-}
-
-pub fn fstar_options(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: TokenStream = item.into();
-    let lit_str = parse_macro_input!(attr as LitStr);
-    let payload = format!(r#"#push-options "{}""#, lit_str.value());
-    let payload = LitStr::new(&payload, lit_str.span());
-    quote! {
-        #[::hax_lib::fstar::before(#payload)]
-        #[::hax_lib::fstar::after(r#"#pop-options"#)]
-        #item
-    }
-    .into()
 }
 
 pub fn loop_invariant(predicate: pm::TokenStream) -> pm::TokenStream {
@@ -131,41 +118,6 @@ pub fn fstar_verification_status(attr: pm::TokenStream, item: pm::TokenStream) -
         _ => abort_call_site!("Expected `lax` or `panic_free`"),
     }
     .into()
-}
-
-pub fn fstar_postprocess_with(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: TokenStream = item.into();
-    let payload: String = if let Ok(s) = syn::parse::<LitStr>(attr.clone()) {
-        s.value()
-    } else {
-        let e = parse_macro_input!(attr as Expr);
-        format!(" ${{ {} }} ", e.to_token_stream())
-    };
-    let payload = format!("[@@FStar.Tactics.postprocess_with ({payload})]");
-    let payload: Lit = Lit::Str(syn::LitStr::new(&payload, Span::call_site()));
-    quote! {#[::hax_lib::fstar::before(#payload)] #item}.into()
-}
-
-/// Emit one of charon's native `charon::*` markers. The lean backend drives charon
-/// directly, bypassing the engine, so it is the only one to set `cfg(charon)` on this
-/// crate's build; every other backend gets nothing.
-fn charon_attr(name: TokenStream) -> Option<TokenStream> {
-    cfg!(charon).then(|| quote! {#[charon::#name]})
-}
-
-pub fn include(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: TokenStream = item.into();
-    let _ = parse_macro_input!(attr as parse::Nothing);
-    let attr = AttrPayload::ItemStatus(ItemStatus::Included { late_skip: false });
-    quote! {#attr #item}.into()
-}
-
-pub fn exclude(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: TokenStream = item.into();
-    let _ = parse_macro_input!(attr as parse::Nothing);
-    let attr = AttrPayload::ItemStatus(ItemStatus::Excluded { modeled_by: None });
-    let charon = charon_attr(quote! {exclude});
-    quote! {#attr #charon #item}.into()
 }
 
 /*
@@ -252,60 +204,6 @@ pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
         item.sig.output.span(),
         "A lemma is expected to return a `Proof<{STATEMENT}>`, where {STATEMENT} is a `Prop` expression."
     )
-}
-
-pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let phi: syn::Expr = parse_macro_input!(attr);
-    let item: FnLike = parse_macro_input!(item);
-    let (requires, attr) = make_fn_decoration(
-        phi,
-        item.sig.clone(),
-        FnDecorationKind::Decreases,
-        None,
-        None,
-        SelfProjection::Unknown,
-    );
-    quote! {#requires #attr #item}.into()
-}
-
-pub fn fstar_smt_pat(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let phi: syn::Expr = parse_macro_input!(attr);
-    let item: FnLike = parse_macro_input!(item);
-    let (requires, attr) = make_fn_decoration(
-        phi,
-        item.sig.clone(),
-        FnDecorationKind::SMTPat,
-        None,
-        None,
-        SelfProjection::Unknown,
-    );
-    quote! {#requires #attr #item}.into()
-}
-
-pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let phi: syn::Expr = parse_macro_input!(attr);
-    let item: FnLike = parse_macro_input!(item);
-    let (requires, attr) = make_fn_decoration(
-        phi.clone(),
-        item.sig.clone(),
-        FnDecorationKind::Requires,
-        None,
-        None,
-        SelfProjection::Unknown,
-    );
-    let mut item_with_debug = item.clone();
-    item_with_debug
-        .block
-        .stmts
-        .insert(0, parse_quote! {debug_assert!(#phi);});
-    quote! {
-        #requires #attr
-        // TODO: disable `assert!`s for now (see #297)
-        #item
-        // #[cfg(    all(not(#HaxCfgOptionName),     debug_assertions )) ] #item_with_debug
-        // #[cfg(not(all(not(#HaxCfgOptionName),     debug_assertions )))] #item
-    }
-    .into()
 }
 
 pub fn ensures(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
@@ -675,48 +573,6 @@ pub fn opaque(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream 
     quote! {#attr #charon #item}.into()
 }
 
-pub fn transparent(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: Item = parse_macro_input!(item);
-    let attr = AttrPayload::NeverErased;
-    quote! {#attr #item}.into()
-}
-
-pub fn process_read(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::ProcessRead;
-    quote! {#attr #item}.into()
-}
-
-pub fn process_write(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::ProcessWrite;
-    quote! {#attr #item}.into()
-}
-
-pub fn process_init(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::ProcessInit;
-    quote! {#attr #item}.into()
-}
-
-pub fn protocol_messages(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemEnum = parse_macro_input!(item);
-    let attr = AttrPayload::ProtocolMessages;
-    quote! {#attr #item}.into()
-}
-
-pub fn pv_constructor(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::PVConstructor;
-    quote! {#attr #item}.into()
-}
-
-pub fn pv_handwritten(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::PVHandwritten;
-    quote! {#attr #item}.into()
-}
-
 pub fn int(payload: pm::TokenStream) -> pm::TokenStream {
     let n: LitInt = parse_macro_input!(payload);
     let suffix = n.suffix();
@@ -725,51 +581,6 @@ pub fn int(payload: pm::TokenStream) -> pm::TokenStream {
     }
     let digits = n.base10_digits();
     quote! {::hax_lib::int::Int::_unsafe_from_str(#digits)}.into()
-}
-
-pub fn legacy_lean_proof(payload: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let payload = parse_macro_input!(payload as LitStr).value();
-    let attr = AttrPayload::Proof(payload);
-    quote! {#attr #item}.into()
-}
-
-pub fn legacy_lean_pure_requires_proof(
-    payload: pm::TokenStream,
-    item: pm::TokenStream,
-) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let payload = parse_macro_input!(payload as LitStr).value();
-    let attr = AttrPayload::PureRequiresProof(payload);
-    quote! {#attr #item}.into()
-}
-
-pub fn legacy_lean_pure_ensures_proof(
-    payload: pm::TokenStream,
-    item: pm::TokenStream,
-) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let payload = parse_macro_input!(payload as LitStr).value();
-    let attr = AttrPayload::PureEnsuresProof(payload);
-    quote! {#attr #item}.into()
-}
-
-pub fn legacy_lean_proof_method_grind(
-    _attr: pm::TokenStream,
-    item: pm::TokenStream,
-) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::ProofMethod(hax_lib_macros_types::ProofMethod::Grind);
-    quote! {#attr #item}.into()
-}
-
-pub fn legacy_lean_proof_method_bv_decide(
-    _attr: pm::TokenStream,
-    item: pm::TokenStream,
-) -> pm::TokenStream {
-    let item: ItemFn = parse_macro_input!(item);
-    let attr = AttrPayload::ProofMethod(hax_lib_macros_types::ProofMethod::BvDecide);
-    quote! {#attr #item}.into()
 }
 
 macro_rules! make_quoting_item_proc_macro {

--- a/hax-lib/macros/src/lib.rs
+++ b/hax-lib/macros/src/lib.rs
@@ -1,10 +1,583 @@
-// Proc-macros must "reside in the root of the crate": whence the use
-// of `std::include!` instead of proper module declaration.
+//! Proc-macros for hax.
+//!
+//! Proc-macros must reside in the root of the crate: this module defines all of
+//! them, in every configuration, so that their documentation is always
+//! available. Each one is a thin shim that dispatches either to `implementation`
+//! (under `--cfg hax`) or to a no-op (otherwise). The real implementations are
+//! gated because they pull in `hax-lib-macros-types`, a dependency normal builds
+//! should not pay for.
 
 #![cfg_attr(hax, feature(macro_metavar_expr_concat))]
 
+mod hax_paths;
+
 #[cfg(hax)]
-std::include!("implementation.rs");
+mod impl_fn_decoration;
+#[cfg(hax)]
+mod implementation;
+#[cfg(hax)]
+mod quote;
+#[cfg(hax)]
+mod rewrite_self;
+#[cfg(hax)]
+mod syn_ext;
+#[cfg(hax)]
+mod utils;
+
+#[cfg(hax)]
+mod prelude {
+    pub use crate::hax_paths::*;
+    pub use crate::syn_ext::*;
+    pub use proc_macro as pm;
+    pub use proc_macro2::*;
+    pub use quote::*;
+    pub use std::collections::HashSet;
+    pub use syn::spanned::Spanned;
+    pub use syn::{visit_mut::VisitMut, *};
+
+    pub use AttrPayload::Language as AttrHaxLang;
+    pub use hax_lib_macros_types::*;
+    pub type FnLike = syn::ImplItemFn;
+}
 
 #[cfg(not(hax))]
-std::include!("dummy.rs");
+mod dummy;
+
+use proc_macro::TokenStream;
+
+/// Defines attribute proc-macros that forward to `implementation` under
+/// `--cfg hax`, and are the identity otherwise.
+macro_rules! passthrough_attributes {
+    ($($(#[$meta:meta])* $name:ident;)*) => {
+        $(
+            $(#[$meta])*
+            #[proc_macro_attribute]
+            pub fn $name(attr: TokenStream, item: TokenStream) -> TokenStream {
+                #[cfg(hax)]
+                { implementation::$name(attr, item) }
+                #[cfg(not(hax))]
+                { let _ = attr; item }
+            }
+        )*
+    };
+}
+
+passthrough_attributes! {
+    /// When extracting to F*, wrap this item in `#push-options "..."` and
+    /// `#pop-options`.
+    fstar_options;
+
+    /// When extracting to F*, inform about what is the current
+    /// verification status for an item. It can either be `lax` or
+    /// `panic_free`.
+    fstar_verification_status;
+
+    /// Postprocess an item with a given tactic. This macro takes the tactic in
+    /// parameter: this may be a Rust identifier or a raw snippet of F* code as a
+    /// string literal.
+    fstar_postprocess_with;
+
+    /// Allows to add SMT patterns to a lemma.
+    /// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
+    fstar_smt_pat;
+
+    /// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
+    include;
+
+    /// Exclude this item from the Hax translation.
+    exclude;
+
+    /// Provide a measure for a function: this measure will be used once
+    /// extracted in a backend for checking termination. The expression
+    /// that decreases can be of any type. (TODO: this is probably as it
+    /// is true only for F*, see #297)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hax_lib_macros::*;
+    /// #[decreases((m, n))]
+    /// pub fn ackermann(m: u64, n: u64) -> u64 {
+    ///     match (m, n) {
+    ///         (0, _) => n + 1,
+    ///         (_, 0) => ackermann(m - 1, 1),
+    ///         _ => ackermann(m - 1, ackermann(m, n - 1)),
+    ///     }
+    /// }
+    /// ```
+    decreases;
+
+    /// Add a logical precondition to a function.
+    // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
+    /// In the case of a function that has one or more `&mut` inputs, in
+    /// the `ensures` clause, you can refer to such an `&mut` input `x` as
+    /// `x` for its "past" value and `future(x)` for its "future" value.
+    ///
+    /// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
+    /// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
+    /// the precondition, e.g. `fstar!("true")`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hax_lib_macros::*;
+    /// #[requires(x.len() == y.len())]
+    // #[requires(x.len() == y.len() && forall(|i: usize| i >= x.len() || y[i] > 0))] (TODO: commented out for now, see #297)
+    /// pub fn div_pairwise(x: Vec<u64>, y: Vec<u64>) -> Vec<u64> {
+    ///     x.iter()
+    ///         .copied()
+    ///         .zip(y.iter().copied())
+    ///         .map(|(x, y)| x / y)
+    ///         .collect()
+    /// }
+    /// ```
+    requires;
+
+    /// Add a logical postcondition to a function. Note you can use the
+    /// `forall` and `exists` operators.
+    ///
+    /// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
+    /// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
+    /// the postcondition, e.g. `fstar!("true")`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hax_lib_macros::*;
+    /// #[ensures(|result| result == x * 2)]
+    /// pub fn twice(x: u64) -> u64 {
+    ///     x + x
+    /// }
+    /// ```
+    ensures;
+
+    /// Mark an item opaque: the extraction will assume the
+    /// type without revealing its definition.
+    #[deprecated(note = "Please use 'opaque' instead")]
+    opaque_type;
+
+    /// Mark an item opaque: the extraction will assume the
+    /// type without revealing its definition.
+    opaque;
+
+    /// Mark an item transparent: the extraction will not
+    /// make it opaque regardless of the `-i` flag default.
+    transparent;
+
+    /// A marker indicating a `fn` as a ProVerif process read.
+    process_read;
+
+    /// A marker indicating a `fn` as a ProVerif process write.
+    process_write;
+
+    /// A marker indicating a `fn` as a ProVerif process initialization.
+    process_init;
+
+    /// A marker indicating an `enum` as describing the protocol messages.
+    protocol_messages;
+
+    /// A marker indicating a `fn` should be automatically translated to a ProVerif constructor.
+    pv_constructor;
+
+    /// A marker indicating a `fn` requires manual modelling in ProVerif.
+    pv_handwritten;
+
+    /// This macro inserts a verbatim Lean proof into the extracted code.
+    legacy_lean_proof;
+
+    /// This macro inserts a verbatim Lean proof showing that the `requires`-condition is panic-free.
+    /// The proof is inserted into the `pureRequires` field of the Lean spec.
+    legacy_lean_pure_requires_proof;
+
+    /// This macro inserts a verbatim Lean proof showing that the `ensures`-condition is panic-free.
+    /// The proof is inserted into the `pureEnsures` field of the Lean spec.
+    legacy_lean_pure_ensures_proof;
+
+    /// Use the proof method `grind`. This influences the tactic and spec set used by Lean.
+    legacy_lean_proof_method_grind;
+
+    /// Use the proof method `bv_decide`. This influences the tactic and spec set used by Lean.
+    legacy_lean_proof_method_bv_decide;
+
+    /// Marks a newtype `struct RefinedT(T);` as a refinement type. The
+    /// struct should have exactly one unnamed private field.
+    ///
+    /// This macro takes one argument: a `Prop` proposition that refines
+    /// values of type `SomeType`.
+    ///
+    /// For example, the following type defines bounded `u64` integers.
+    ///
+    /// ```
+    /// #[hax_lib::refinement_type(|x| x >= MIN && x <= MAX)]
+    /// pub struct BoundedU64<const MIN: u64, const MAX: u64>(u64);
+    /// ```
+    ///
+    /// This macro will generate an implementation of the [`Deref`] trait
+    /// and of the [`hax_lib::Refinement`] type. Those two traits are
+    /// the only interface to this newtype: one is allowed only to
+    /// construct or destruct refined type via those smart constructors
+    /// and destructors, ensuring the abstraction.
+    ///
+    /// A refinement of a type `T` with a formula `f` can be seen as a box
+    /// that contains a value of type `T` and a proof that this value
+    /// satisfies the formula `f`.
+    ///
+    /// In debug mode, the refinement will be checked at run-time. This
+    /// requires the base type `T` to implement `Clone`. Pass a first
+    /// parameter `no_debug_runtime_check` to disable this behavior.
+    ///
+    /// When extracted via hax, this is interpreted in the backend as a
+    /// refinement type: the use of such a type yields static proof
+    /// obligations.
+    refinement_type;
+}
+
+/// Mark a `Proof<{STATEMENT}>`-returning function as a lemma, where
+/// `STATEMENT` is a `Prop` expression capturing any input
+/// variable.
+/// In the backends, this will generate a lemma with an empty proof.
+///
+/// # Example
+///
+/// ```
+/// use hax_lib_macros::*;
+// #[decreases((m, n))] (TODO: see #297)
+/// pub fn ackermann(m: u64, n: u64) -> u64 {
+///     match (m, n) {
+///         (0, _) => n + 1,
+///         (_, 0) => ackermann(m - 1, 1),
+///         _ => ackermann(m - 1, ackermann(m, n - 1)),
+///     }
+/// }
+///
+/// #[lemma]
+/// /// $`\forall n \in \mathbb{N}, \textrm{ackermann}(2, n) = 2 (n + 3) - 3`$
+/// pub fn ackermann_property_m1(n: u64) -> Proof<{ ackermann(2, n) == 2 * (n + 3) - 3 }> {}
+/// ```
+#[proc_macro_attribute]
+pub fn lemma(attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::lemma(attr, item)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = (attr, item);
+        TokenStream::new()
+    }
+}
+
+/// Enable the following attrubutes in the annotated item and sub-items.
+///
+/// ### `refine` (on a field in a struct)
+/// Refine a type with a logical formula.
+///
+/// ### `order` (on a field in a struct or an enum)
+/// Reorders a field in the extracted code.
+///
+/// Rust fields order matters for bit-level representation. Similarly, in some
+/// situations, fields order matters in the backends: for instance in F*, one
+/// may refine a field with a formula referring to a later field.
+///
+/// Those two orders may conflict. Adding `#[hax_lib::order(n)]` on a field with
+/// override its order at extraction time.
+///
+/// By default, the order of a field is its index, e.g. the first field has
+/// order 0, the i-th field has order i+1.
+///
+/// ### `decreases`, `ensures` and `requires` (on a `fn` in an `impl`)
+/// `decreases`, `ensures`, `requires`: behave exactly as documented above on
+/// the proc attributes of the same name.
+///
+/// Those may also be written behind a `cfg_attr`, e.g.
+/// `#[cfg_attr(hax, requires(..))]`: the predicate is preserved, so the
+/// specification appears exactly when the predicate holds. This makes
+/// `hax-lib` usable as a `cfg(hax)`-gated dependency.
+///
+/// # Example
+///
+/// ```
+/// #[hax_lib_macros::attributes]
+/// mod foo {
+///     pub struct Hello {
+///         pub x: u32,
+///         #[refine(y > 3)]
+///         pub y: u32,
+///         #[refine(y + x + z > 3)]
+///         pub z: u32,
+///     }
+///     impl Hello {
+///         fn sum(&self) -> u32 {
+///             self.x + self.y + self.z
+///         }
+///         #[ensures(|result| result - n == self.sum())]
+///         fn plus(self, n: u32) -> u32 {
+///             self.sum() + n
+///         }
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn attributes(attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::attributes(attr, item)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = attr;
+        dummy::attributes(item)
+    }
+}
+
+/// Create a mathematical integer. This macro expects a Rust integer
+/// literal without suffix.
+///
+/// ## Examples:
+/// - `int!(0x101010)`
+/// - `int!(42)`
+/// - `int!(0o52)`
+/// - `int!(0h2A)`
+#[proc_macro]
+pub fn int(payload: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::int(payload)
+    }
+    #[cfg(not(hax))]
+    {
+        dummy::int(payload)
+    }
+}
+
+/// Add an invariant to a loop which deals with an index. The
+/// invariant cannot refer to any variable introduced within the
+/// loop. An invariant is a closure that takes one argument, the
+/// index, and returns a proposition.
+///
+/// Note that loop invariants are unstable (this will be handled in a
+/// better way in the future, see
+/// https://github.com/hacspec/hax/issues/858) and only supported on
+/// specific `for` loops with specific iterators:
+///
+///  - `for i in start..end {...}`
+///  - `for i in (start..end).step_by(n) {...}`
+///  - `for i in slice.enumerate() {...}`
+///  - `for i in slice.chunks_exact(n).enumerate() {...}`
+///
+/// This function must be called on the first line of a loop body to
+/// be effective. Note that in the invariant expression, `forall`,
+/// `exists`, and `BACKEND!` (`BACKEND` can be `fstar`, `proverif`,
+/// `coq`...) are in scope.
+#[proc_macro]
+pub fn loop_invariant(predicate: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::loop_invariant(predicate)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = predicate;
+        TokenStream::new()
+    }
+}
+
+/// Must be used to prove termination of while loops. This takes an
+/// expression that should be a usize that decreases at every iteration
+///
+/// This function must be called just after `loop_invariant`, or at the first
+/// line of the loop if there is no invariant.
+#[proc_macro]
+pub fn loop_decreases(predicate: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::loop_decreases(predicate)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = predicate;
+        TokenStream::new()
+    }
+}
+
+/// Internal macro for dealing with function decorations
+/// (`#[decreases(...)]`, `#[ensures(...)]`, `#[requires(...)]`) on
+/// `fn` items within an `impl` block. There is special handling since
+/// such functions might have a `self` argument: in such cases, we
+/// rewrite function decorations as `#[impl_fn_decoration(<KIND>,
+/// <GENERICS>, <WHERE CLAUSE>, <SELF TYPE> [as <TRAIT>], <BODY>)]`, where
+/// `<TRAIT>` is the trait implemented by the enclosing `impl` block.
+#[proc_macro_attribute]
+pub fn impl_fn_decoration(attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::impl_fn_decoration(attr, item)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = (attr, item);
+        dummy::internal_macro_misuse("impl_fn_decoration")
+    }
+}
+
+/// Internal macro for dealing with function decorations on `fn` items within a
+/// `trait`. See [`macro@impl_fn_decoration`].
+#[proc_macro_attribute]
+pub fn trait_fn_decoration(attr: TokenStream, item: TokenStream) -> TokenStream {
+    #[cfg(hax)]
+    {
+        implementation::trait_fn_decoration(attr, item)
+    }
+    #[cfg(not(hax))]
+    {
+        let _ = (attr, item);
+        dummy::internal_macro_misuse("trait_fn_decoration")
+    }
+}
+
+/// Defines the item-level quoting attributes of a backend: `<BACKEND>_before`
+/// and `<BACKEND>_after`.
+macro_rules! item_quoting_proc_macros {
+    ($backend:ident, $($name:ident),*) => {$(
+        #[doc = concat!("This macro inlines verbatim ", stringify!($backend)," code before a Rust item.")]
+        ///
+        /// This macro takes a string literal containing backend
+        /// code. Just as backend expression macros, this literal can
+        /// contains dollar-prefixed Rust names.
+        ///
+        /// Note: when targetting F*, you can prepend a first
+        /// comma-separated argument: `interface`, `impl` or
+        /// `both`. This controls where the code will apprear: in the
+        /// `fst` or `fsti` files or both.
+        #[proc_macro_attribute]
+        pub fn $name(payload: TokenStream, item: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$name(payload, item) }
+            #[cfg(not(hax))]
+            { let _ = payload; item }
+        }
+    )*};
+}
+
+/// Defines every proc-macro attached to a given backend.
+macro_rules! quoting_proc_macros {
+    ($backend:ident, $expr:ident, $prop_expr:ident, $unsafe_expr:ident,
+     $before:ident, $after:ident, $replace:ident, $replace_body:ident) => {
+        #[doc = concat!("Embed ", stringify!($backend), " expression inside a Rust expression. This macro takes only one argument: some raw ", stringify!($backend), " code as a string literal.")]
+        ///
+        /// While it is possible to directly write raw backend code,
+        /// sometimes it can be inconvenient. For example, referencing
+        /// Rust names can be a bit cumbersome: for example, the name
+        /// `my_crate::my_module::CONSTANT` might be translated
+        /// differently in a backend (e.g. in the F* backend, it will
+        /// probably be `My_crate.My_module.v_CONSTANT`).
+        ///
+        /// To facilitate this, you can write Rust names directly,
+        /// using the prefix `$`: `f $my_crate::my_module__CONSTANT + 3`
+        /// will be replaced with `f My_crate.My_module.v_CONSTANT + 3`
+        /// in the F* backend for instance.
+        ///
+        /// If you want to refer to the Rust constructor
+        /// `Enum::Variant`, you should write `$$Enum::Variant` (note
+        /// the double dollar).
+        ///
+        /// If the name refers to something polymorphic, you need to
+        /// signal it by adding _any_ type informations,
+        /// e.g. `${my_module::function<()>}`. The curly braces are
+        /// needed for such more complex expressions.
+        ///
+        /// You can also write Rust patterns with the `$?{SYNTAX}`
+        /// syntax, where `SYNTAX` is a Rust pattern. The syntax
+        /// `${EXPR}` also allows any Rust expressions
+        /// `EXPR` to be embedded.
+        ///
+        /// Types can be refered to with the syntax `$:{TYPE}`.
+        #[proc_macro]
+        pub fn $expr(payload: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$expr(payload) }
+            #[cfg(not(hax))]
+            { let _ = payload; dummy::unit_expr() }
+        }
+
+        #[doc = concat!("The `Prop` version of `", stringify!($backend), "_expr`.")]
+        #[proc_macro]
+        pub fn $prop_expr(payload: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$prop_expr(payload) }
+            #[cfg(not(hax))]
+            { let _ = payload; dummy::prop_expr() }
+        }
+
+        #[doc = concat!("The unsafe (because polymorphic: even computationally relevant code can be inlined!) version of `", stringify!($backend), "_expr`.")]
+        #[proc_macro]
+        #[doc(hidden)]
+        pub fn $unsafe_expr(payload: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$unsafe_expr(payload) }
+            #[cfg(not(hax))]
+            { let _ = payload; dummy::unsafe_expr() }
+        }
+
+        item_quoting_proc_macros!($backend, $before, $after);
+
+        #[doc = concat!("Replaces a Rust item with some verbatim ", stringify!($backend)," code.")]
+        #[proc_macro_attribute]
+        pub fn $replace(payload: TokenStream, item: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$replace(payload, item) }
+            #[cfg(not(hax))]
+            { let _ = payload; item }
+        }
+
+        #[doc = concat!("Replaces the body of a Rust function with some verbatim ", stringify!($backend)," code.")]
+        #[proc_macro_attribute]
+        pub fn $replace_body(payload: TokenStream, item: TokenStream) -> TokenStream {
+            #[cfg(hax)]
+            { implementation::$replace_body(payload, item) }
+            #[cfg(not(hax))]
+            { let _ = payload; item }
+        }
+    };
+}
+
+quoting_proc_macros!(
+    fstar,
+    fstar_expr,
+    fstar_prop_expr,
+    fstar_unsafe_expr,
+    fstar_before,
+    fstar_after,
+    fstar_replace,
+    fstar_replace_body
+);
+quoting_proc_macros!(
+    coq,
+    coq_expr,
+    coq_prop_expr,
+    coq_unsafe_expr,
+    coq_before,
+    coq_after,
+    coq_replace,
+    coq_replace_body
+);
+quoting_proc_macros!(
+    proverif,
+    proverif_expr,
+    proverif_prop_expr,
+    proverif_unsafe_expr,
+    proverif_before,
+    proverif_after,
+    proverif_replace,
+    proverif_replace_body
+);
+quoting_proc_macros!(
+    legacy_lean,
+    legacy_lean_expr,
+    legacy_lean_prop_expr,
+    legacy_lean_unsafe_expr,
+    legacy_lean_before,
+    legacy_lean_after,
+    legacy_lean_replace,
+    legacy_lean_replace_body
+);

--- a/hax-lib/macros/src/lib.rs
+++ b/hax-lib/macros/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! Proc-macros must reside in the root of the crate: this module defines all of
 //! them, in every configuration, so that their documentation is always
-//! available. Each one is a thin shim that dispatches either to `implementation`
-//! (under `--cfg hax`) or to a no-op (otherwise). The real implementations are
-//! gated because they pull in `hax-lib-macros-types`, a dependency normal builds
-//! should not pay for.
+//! available. Small ones carry their implementation here, right under their
+//! documentation; bigger ones dispatch to `implementation`. Either way the
+//! implementation is gated on `--cfg hax`, since it needs
+//! `hax-lib-macros-types`, which is a `cfg(hax)`-only dependency.
 
 #![cfg_attr(hax, feature(macro_metavar_expr_concat))]
 
@@ -62,76 +62,35 @@ macro_rules! passthrough_attributes {
     };
 }
 
-passthrough_attributes! {
-    /// When extracting to F*, wrap this item in `#push-options "..."` and
-    /// `#pop-options`.
-    fstar_options;
+/// Defines attribute proc-macros whose implementation is inlined below, next to
+/// their documentation. The body is compiled only under `--cfg hax`; otherwise
+/// the macro is the identity.
+macro_rules! attribute_macros {
+    ($($(#[$meta:meta])* fn $name:ident($attr:ident, $item:ident) $body:block)*) => {
+        $(
+            $(#[$meta])*
+            #[proc_macro_attribute]
+            pub fn $name($attr: TokenStream, $item: TokenStream) -> TokenStream {
+                #[cfg(hax)]
+                {
+                    #[allow(unused_imports)]
+                    use crate::{
+                        impl_fn_decoration::*, prelude::*, rewrite_self::SelfProjection, utils::*,
+                    };
+                    $body
+                }
+                #[cfg(not(hax))]
+                { let _ = $attr; $item }
+            }
+        )*
+    };
+}
 
+passthrough_attributes! {
     /// When extracting to F*, inform about what is the current
     /// verification status for an item. It can either be `lax` or
     /// `panic_free`.
     fstar_verification_status;
-
-    /// Postprocess an item with a given tactic. This macro takes the tactic in
-    /// parameter: this may be a Rust identifier or a raw snippet of F* code as a
-    /// string literal.
-    fstar_postprocess_with;
-
-    /// Allows to add SMT patterns to a lemma.
-    /// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
-    fstar_smt_pat;
-
-    /// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
-    include;
-
-    /// Exclude this item from the Hax translation.
-    exclude;
-
-    /// Provide a measure for a function: this measure will be used once
-    /// extracted in a backend for checking termination. The expression
-    /// that decreases can be of any type. (TODO: this is probably as it
-    /// is true only for F*, see #297)
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use hax_lib_macros::*;
-    /// #[decreases((m, n))]
-    /// pub fn ackermann(m: u64, n: u64) -> u64 {
-    ///     match (m, n) {
-    ///         (0, _) => n + 1,
-    ///         (_, 0) => ackermann(m - 1, 1),
-    ///         _ => ackermann(m - 1, ackermann(m, n - 1)),
-    ///     }
-    /// }
-    /// ```
-    decreases;
-
-    /// Add a logical precondition to a function.
-    // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
-    /// In the case of a function that has one or more `&mut` inputs, in
-    /// the `ensures` clause, you can refer to such an `&mut` input `x` as
-    /// `x` for its "past" value and `future(x)` for its "future" value.
-    ///
-    /// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
-    /// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
-    /// the precondition, e.g. `fstar!("true")`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use hax_lib_macros::*;
-    /// #[requires(x.len() == y.len())]
-    // #[requires(x.len() == y.len() && forall(|i: usize| i >= x.len() || y[i] > 0))] (TODO: commented out for now, see #297)
-    /// pub fn div_pairwise(x: Vec<u64>, y: Vec<u64>) -> Vec<u64> {
-    ///     x.iter()
-    ///         .copied()
-    ///         .zip(y.iter().copied())
-    ///         .map(|(x, y)| x / y)
-    ///         .collect()
-    /// }
-    /// ```
-    requires;
 
     /// Add a logical postcondition to a function. Note you can use the
     /// `forall` and `exists` operators.
@@ -159,45 +118,6 @@ passthrough_attributes! {
     /// Mark an item opaque: the extraction will assume the
     /// type without revealing its definition.
     opaque;
-
-    /// Mark an item transparent: the extraction will not
-    /// make it opaque regardless of the `-i` flag default.
-    transparent;
-
-    /// A marker indicating a `fn` as a ProVerif process read.
-    process_read;
-
-    /// A marker indicating a `fn` as a ProVerif process write.
-    process_write;
-
-    /// A marker indicating a `fn` as a ProVerif process initialization.
-    process_init;
-
-    /// A marker indicating an `enum` as describing the protocol messages.
-    protocol_messages;
-
-    /// A marker indicating a `fn` should be automatically translated to a ProVerif constructor.
-    pv_constructor;
-
-    /// A marker indicating a `fn` requires manual modelling in ProVerif.
-    pv_handwritten;
-
-    /// This macro inserts a verbatim Lean proof into the extracted code.
-    legacy_lean_proof;
-
-    /// This macro inserts a verbatim Lean proof showing that the `requires`-condition is panic-free.
-    /// The proof is inserted into the `pureRequires` field of the Lean spec.
-    legacy_lean_pure_requires_proof;
-
-    /// This macro inserts a verbatim Lean proof showing that the `ensures`-condition is panic-free.
-    /// The proof is inserted into the `pureEnsures` field of the Lean spec.
-    legacy_lean_pure_ensures_proof;
-
-    /// Use the proof method `grind`. This influences the tactic and spec set used by Lean.
-    legacy_lean_proof_method_grind;
-
-    /// Use the proof method `bv_decide`. This influences the tactic and spec set used by Lean.
-    legacy_lean_proof_method_bv_decide;
 
     /// Marks a newtype `struct RefinedT(T);` as a refinement type. The
     /// struct should have exactly one unnamed private field.
@@ -230,6 +150,244 @@ passthrough_attributes! {
     /// refinement type: the use of such a type yields static proof
     /// obligations.
     refinement_type;
+}
+
+attribute_macros! {
+    /// When extracting to F*, wrap this item in `#push-options "..."` and
+    /// `#pop-options`.
+    fn fstar_options(attr, item) {
+        let item: TokenStream = item.into();
+        let lit_str = parse_macro_input!(attr as LitStr);
+        let payload = format!(r#"#push-options "{}""#, lit_str.value());
+        let payload = LitStr::new(&payload, lit_str.span());
+        quote! {
+            #[::hax_lib::fstar::before(#payload)]
+            #[::hax_lib::fstar::after(r#"#pop-options"#)]
+            #item
+        }
+        .into()
+    }
+
+    /// Postprocess an item with a given tactic. This macro takes the tactic in
+    /// parameter: this may be a Rust identifier or a raw snippet of F* code as a
+    /// string literal.
+    fn fstar_postprocess_with(attr, item) {
+        let item: TokenStream = item.into();
+        let payload: String = if let Ok(s) = syn::parse::<LitStr>(attr.clone()) {
+            s.value()
+        } else {
+            let e = parse_macro_input!(attr as Expr);
+            format!(" ${{ {} }} ", e.to_token_stream())
+        };
+        let payload = format!("[@@FStar.Tactics.postprocess_with ({payload})]");
+        let payload: Lit = Lit::Str(syn::LitStr::new(&payload, Span::call_site()));
+        quote! {#[::hax_lib::fstar::before(#payload)] #item}.into()
+    }
+
+    /// Allows to add SMT patterns to a lemma.
+    /// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
+    fn fstar_smt_pat(attr, item) {
+        let phi: syn::Expr = parse_macro_input!(attr);
+        let item: FnLike = parse_macro_input!(item);
+        let (requires, attr) = make_fn_decoration(
+            phi,
+            item.sig.clone(),
+            FnDecorationKind::SMTPat,
+            None,
+            None,
+            SelfProjection::Unknown,
+        );
+        quote! {#requires #attr #item}.into()
+    }
+
+    /// Include this item in the Hax translation. This overrides any exclusion resulting of `-i` flag.
+    fn include(attr, item) {
+        let item: TokenStream = item.into();
+        let _ = parse_macro_input!(attr as parse::Nothing);
+        let attr = AttrPayload::ItemStatus(ItemStatus::Included { late_skip: false });
+        quote! {#attr #item}.into()
+    }
+
+    /// Exclude this item from the Hax translation.
+    fn exclude(attr, item) {
+        let item: TokenStream = item.into();
+        let _ = parse_macro_input!(attr as parse::Nothing);
+        let attr = AttrPayload::ItemStatus(ItemStatus::Excluded { modeled_by: None });
+        let charon = charon_attr(quote! {exclude});
+        quote! {#attr #charon #item}.into()
+    }
+
+    /// Provide a measure for a function: this measure will be used once
+    /// extracted in a backend for checking termination. The expression
+    /// that decreases can be of any type. (TODO: this is probably as it
+    /// is true only for F*, see #297)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hax_lib_macros::*;
+    /// #[decreases((m, n))]
+    /// pub fn ackermann(m: u64, n: u64) -> u64 {
+    ///     match (m, n) {
+    ///         (0, _) => n + 1,
+    ///         (_, 0) => ackermann(m - 1, 1),
+    ///         _ => ackermann(m - 1, ackermann(m, n - 1)),
+    ///     }
+    /// }
+    /// ```
+    fn decreases(attr, item) {
+        let phi: syn::Expr = parse_macro_input!(attr);
+        let item: FnLike = parse_macro_input!(item);
+        let (requires, attr) = make_fn_decoration(
+            phi,
+            item.sig.clone(),
+            FnDecorationKind::Decreases,
+            None,
+            None,
+            SelfProjection::Unknown,
+        );
+        quote! {#requires #attr #item}.into()
+    }
+
+    /// Add a logical precondition to a function.
+    // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
+    /// In the case of a function that has one or more `&mut` inputs, in
+    /// the `ensures` clause, you can refer to such an `&mut` input `x` as
+    /// `x` for its "past" value and `future(x)` for its "future" value.
+    ///
+    /// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
+    /// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
+    /// the precondition, e.g. `fstar!("true")`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hax_lib_macros::*;
+    /// #[requires(x.len() == y.len())]
+    // #[requires(x.len() == y.len() && forall(|i: usize| i >= x.len() || y[i] > 0))] (TODO: commented out for now, see #297)
+    /// pub fn div_pairwise(x: Vec<u64>, y: Vec<u64>) -> Vec<u64> {
+    ///     x.iter()
+    ///         .copied()
+    ///         .zip(y.iter().copied())
+    ///         .map(|(x, y)| x / y)
+    ///         .collect()
+    /// }
+    /// ```
+    fn requires(attr, item) {
+        let phi: syn::Expr = parse_macro_input!(attr);
+        let item: FnLike = parse_macro_input!(item);
+        let (requires, attr) = make_fn_decoration(
+            phi.clone(),
+            item.sig.clone(),
+            FnDecorationKind::Requires,
+            None,
+            None,
+            SelfProjection::Unknown,
+        );
+        let mut item_with_debug = item.clone();
+        item_with_debug
+            .block
+            .stmts
+            .insert(0, parse_quote! {debug_assert!(#phi);});
+        quote! {
+            #requires #attr
+            // TODO: disable `assert!`s for now (see #297)
+            #item
+            // #[cfg(    all(not(#HaxCfgOptionName),     debug_assertions )) ] #item_with_debug
+            // #[cfg(not(all(not(#HaxCfgOptionName),     debug_assertions )))] #item
+        }
+        .into()
+    }
+
+    /// Mark an item transparent: the extraction will not
+    /// make it opaque regardless of the `-i` flag default.
+    fn transparent(_attr, item) {
+        let item: Item = parse_macro_input!(item);
+        let attr = AttrPayload::NeverErased;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating a `fn` as a ProVerif process read.
+    fn process_read(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::ProcessRead;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating a `fn` as a ProVerif process write.
+    fn process_write(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::ProcessWrite;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating a `fn` as a ProVerif process initialization.
+    fn process_init(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::ProcessInit;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating an `enum` as describing the protocol messages.
+    fn protocol_messages(_attr, item) {
+        let item: ItemEnum = parse_macro_input!(item);
+        let attr = AttrPayload::ProtocolMessages;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating a `fn` should be automatically translated to a ProVerif constructor.
+    fn pv_constructor(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::PVConstructor;
+        quote! {#attr #item}.into()
+    }
+
+    /// A marker indicating a `fn` requires manual modelling in ProVerif.
+    fn pv_handwritten(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::PVHandwritten;
+        quote! {#attr #item}.into()
+    }
+
+    /// This macro inserts a verbatim Lean proof into the extracted code.
+    fn legacy_lean_proof(payload, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let payload = parse_macro_input!(payload as LitStr).value();
+        let attr = AttrPayload::Proof(payload);
+        quote! {#attr #item}.into()
+    }
+
+    /// This macro inserts a verbatim Lean proof showing that the `requires`-condition is panic-free.
+    /// The proof is inserted into the `pureRequires` field of the Lean spec.
+    fn legacy_lean_pure_requires_proof(payload, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let payload = parse_macro_input!(payload as LitStr).value();
+        let attr = AttrPayload::PureRequiresProof(payload);
+        quote! {#attr #item}.into()
+    }
+
+    /// This macro inserts a verbatim Lean proof showing that the `ensures`-condition is panic-free.
+    /// The proof is inserted into the `pureEnsures` field of the Lean spec.
+    fn legacy_lean_pure_ensures_proof(payload, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let payload = parse_macro_input!(payload as LitStr).value();
+        let attr = AttrPayload::PureEnsuresProof(payload);
+        quote! {#attr #item}.into()
+    }
+
+    /// Use the proof method `grind`. This influences the tactic and spec set used by Lean.
+    fn legacy_lean_proof_method_grind(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::ProofMethod(hax_lib_macros_types::ProofMethod::Grind);
+        quote! {#attr #item}.into()
+    }
+
+    /// Use the proof method `bv_decide`. This influences the tactic and spec set used by Lean.
+    fn legacy_lean_proof_method_bv_decide(_attr, item) {
+        let item: ItemFn = parse_macro_input!(item);
+        let attr = AttrPayload::ProofMethod(hax_lib_macros_types::ProofMethod::BvDecide);
+        quote! {#attr #item}.into()
+    }
 }
 
 /// Mark a `Proof<{STATEMENT}>`-returning function as a lemma, where

--- a/hax-lib/macros/src/lib.rs
+++ b/hax-lib/macros/src/lib.rs
@@ -132,8 +132,8 @@ passthrough_attributes! {
     /// pub struct BoundedU64<const MIN: u64, const MAX: u64>(u64);
     /// ```
     ///
-    /// This macro will generate an implementation of the [`Deref`] trait
-    /// and of the [`hax_lib::Refinement`] type. Those two traits are
+    /// This macro will generate an implementation of the [`Deref`](core::ops::Deref)
+    /// trait and of the `hax_lib::Refinement` trait. Those two traits are
     /// the only interface to this newtype: one is allowed only to
     /// construct or destruct refined type via those smart constructors
     /// and destructors, ensuring the abstraction.
@@ -185,7 +185,8 @@ attribute_macros! {
     }
 
     /// Allows to add SMT patterns to a lemma.
-    /// For more informations about SMT patterns, please take a look here: https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns.
+    /// For more informations about SMT patterns, please take a look here:
+    /// <https://fstar-lang.org/tutorial/book/under_the_hood/uth_smt.html#designing-a-library-with-smt-patterns>.
     fn fstar_smt_pat(attr, item) {
         let phi: syn::Expr = parse_macro_input!(attr);
         let item: FnLike = parse_macro_input!(item);
@@ -425,7 +426,7 @@ pub fn lemma(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
-/// Enable the following attrubutes in the annotated item and sub-items.
+/// Enable the following attributes in the annotated item and sub-items.
 ///
 /// ### `refine` (on a field in a struct)
 /// Refine a type with a logical formula.
@@ -515,7 +516,7 @@ pub fn int(payload: TokenStream) -> TokenStream {
 ///
 /// Note that loop invariants are unstable (this will be handled in a
 /// better way in the future, see
-/// https://github.com/hacspec/hax/issues/858) and only supported on
+/// <https://github.com/hacspec/hax/issues/858>) and only supported on
 /// specific `for` loops with specific iterators:
 ///
 ///  - `for i in start..end {...}`
@@ -596,8 +597,8 @@ pub fn trait_fn_decoration(attr: TokenStream, item: TokenStream) -> TokenStream 
 /// Defines the item-level quoting attributes of a backend: `<BACKEND>_before`
 /// and `<BACKEND>_after`.
 macro_rules! item_quoting_proc_macros {
-    ($backend:ident, $($name:ident),*) => {$(
-        #[doc = concat!("This macro inlines verbatim ", stringify!($backend)," code before a Rust item.")]
+    ($backend:ident, $(($name:ident, $position:literal)),*) => {$(
+        #[doc = concat!("This macro inlines verbatim ", stringify!($backend), " code ", $position, " a Rust item.")]
         ///
         /// This macro takes a string literal containing backend
         /// code. Just as backend expression macros, this literal can
@@ -677,7 +678,7 @@ macro_rules! quoting_proc_macros {
             { let _ = payload; dummy::unsafe_expr() }
         }
 
-        item_quoting_proc_macros!($backend, $before, $after);
+        item_quoting_proc_macros!($backend, ($before, "before"), ($after, "after"));
 
         #[doc = concat!("Replaces a Rust item with some verbatim ", stringify!($backend)," code.")]
         #[proc_macro_attribute]

--- a/hax-lib/macros/src/quote.rs
+++ b/hax-lib/macros/src/quote.rs
@@ -195,15 +195,13 @@ pub(super) fn retarget_on_inherent_impl(
                 .to_compile_error(),
             );
         }
-        None => {
-            return Some(
-                syn::Error::new(
-                    span,
-                    "hax: this `impl` block is empty, there is no item to attach this annotation to.",
-                )
-                .to_compile_error(),
+        None => return Some(
+            syn::Error::new(
+                span,
+                "hax: this `impl` block is empty, there is no item to attach this annotation to.",
             )
-        }
+            .to_compile_error(),
+        ),
     };
     attrs.push(parse_quote! {#attr});
     Some(quote! {#item_impl})

--- a/hax-lib/macros/src/rewrite_self.rs
+++ b/hax-lib/macros/src/rewrite_self.rs
@@ -83,7 +83,10 @@ mod rewrite_self {
                 ..
             } = self;
             if typ.is_none() && !self_spans.is_empty() {
-                let mut error = Error::new(Span::call_site(), "This macro doesn't work on trait or impl items: you need to add a `#[hax_lib::attributes]` on the enclosing impl block or trait.");
+                let mut error = Error::new(
+                    Span::call_site(),
+                    "This macro doesn't work on trait or impl items: you need to add a `#[hax_lib::attributes]` on the enclosing impl block or trait.",
+                );
                 for SpanWrapper(span) in self_spans {
                     let use_site = Error::new(
                         span,
@@ -140,11 +143,22 @@ impl RewriteSelf {
         qself: &mut Option<QSelf>,
         path: &mut Path,
     ) {
-        let (None, Path { leading_colon: None, segments }) = (&*qself, &*path) else {
+        let (
+            None,
+            Path {
+                leading_colon: None,
+                segments,
+            },
+        ) = (&*qself, &*path)
+        else {
             return;
         };
         let mut segments = segments.iter();
-        let Some(PathSegment { ident, arguments: PathArguments::None }) = segments.next() else {
+        let Some(PathSegment {
+            ident,
+            arguments: PathArguments::None,
+        }) = segments.next()
+        else {
             return;
         };
         let suffix: Vec<_> = segments.collect();

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -130,6 +130,13 @@ pub(crate) fn cfg_gate(tokens: TokenStream, pred: &Meta) -> TokenStream {
         .collect()
 }
 
+/// Emit one of charon's native `charon::*` markers. The lean backend drives charon
+/// directly, bypassing the engine, so it is the only one to set `cfg(charon)` on this
+/// crate's build; every other backend gets nothing.
+pub(crate) fn charon_attr(name: TokenStream) -> Option<TokenStream> {
+    cfg!(charon).then(|| quote! {#[charon::#name]})
+}
+
 /// Merge two `syn::Generics`, respecting lifetime orders
 pub(crate) fn merge_generics(x: Generics, y: Generics) -> Generics {
     Generics {

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -266,7 +266,10 @@ impl VisitMut for RewriteFuture {
                     *e = parse_quote! {#arg};
                     return;
                 }
-                Some(format!("Cannot find an input `{arg}` of type `&mut _`. In the context, `future` can be called on the following inputs: {:?}.", self.0))
+                Some(format!(
+                    "Cannot find an input `{arg}` of type `&mut _`. In the context, `future` can be called on the following inputs: {:?}.",
+                    self.0
+                ))
             }
             Some(Err(error_kind)) => {
                 let message = match error_kind {


### PR DESCRIPTION
Fixes #1759, and fixes #2087.

The dispatch between dummy and real implementation of the macros is re-architectured, with the doc comments moved to the top-level so that they make it into the rustdoc even without the `hax` cfg. It is nicer to have the real implementation code next to the doc comment so in the last commit I tried to pull the implementations to the `lib.rs` file but a few macros had to stay in `implementation.rs` because other macros depend on them (we can also accept to have documentation and implementation in different files).

Note: rustfmt didn't reach `implementation.rs` and other files before but it does now so the file has been formatted in the PR. The first commit only does this rustfmt pass.

AI-assisted for implementation with manual review.