### PR TITLE
feat(cli): add `cargo hax tools pin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes to cargo-hax:
  - Resolve aeneas and charon from the version manifest instead of `PATH`; use a `path` entry in `hax.toml` to point at a local build
  - Check that the `hax-lib` version in scope matches the `cargo-hax` version before processing
  - Add `cargo hax tools remove <tool>@<version>` and `cargo hax tools clean` to delete a cached tool version or the whole tool cache
+ - Add `cargo hax tools pin` to write version pins into `hax.toml`, either this release's defaults or a single `<name>@<version>` entry
 
 Changes to hax-lib:
  - Basis of core model testing infrastructure (cryspen/hax-evit/160, cryspen/hax-evit/164)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "tempfile",
  "tiny_http",
  "toml",
+ "toml_edit",
  "ureq",
  "version_check",
  "webpki-roots 0.26.11",

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ aeneas = "nightly-2026.07.01"
 charon = "nightly-2026.07.01"
 ```
 
+Or let `cargo hax tools pin` write them for you:
+
+```bash
+cargo hax tools pin                            # pin this release's defaults
+cargo hax tools pin charon@nightly-2026.07.01  # set one entry
+```
+
 You can also build or install `aeneas` and `charon` yourself (e.g. from source) and point to them with a `path` entry in `hax.toml` (e.g. `charon = { path = "vendor/bin/charon" }`).
 
 See [Managing tool versions](https://hax.cryspen.com/manual/tools/) in the manual for the full reference (`cargo hax tools`, the `hax.toml` schema, resolution order, and the `hax-lib` compatibility check).

--- a/cli/cargo-hax/Cargo.toml
+++ b/cli/cargo-hax/Cargo.toml
@@ -50,6 +50,7 @@ cargo_metadata.workspace = true
 extension-traits = "1.0.1"
 shlex = "1.3"
 toml = "0.8"
+toml_edit = "0.22"
 ureq = "2.10"
 # The TLS roots the downloader trusts: the bundled set, plus the platform's
 # own store. Kept on the versions `ureq` links, so that its

--- a/cli/cargo-hax/src/tools.rs
+++ b/cli/cargo-hax/src/tools.rs
@@ -14,6 +14,7 @@ pub mod defaults;
 pub mod haxlib;
 pub mod install;
 pub mod manifest;
+pub mod pin;
 pub mod project;
 pub mod resolve;
 mod subcommands;
@@ -190,5 +191,6 @@ pub fn run(command: &ToolsCommand, message_format: MessageFormat) -> i32 {
         } => subcommands::list(tool.as_deref(), *installed, *all, message_format),
         ToolsCommand::Remove { spec } => subcommands::remove(spec, message_format),
         ToolsCommand::Clean => subcommands::clean(message_format),
+        ToolsCommand::Pin { spec } => subcommands::pin(spec.as_deref(), message_format),
     }
 }

--- a/cli/cargo-hax/src/tools/pin.rs
+++ b/cli/cargo-hax/src/tools/pin.rs
@@ -1,0 +1,258 @@
+//! Format-preserving editing of `hax.toml` for `cargo hax tools pin`.
+//!
+//! Pins are written with `toml_edit`, so comments, formatting, and entries
+//! the command does not own survive: entries pinned to a `path` alone are
+//! skipped, unknown tools and keys are left alone, and an existing
+//! `{ version = "..." }` table keeps its shape with only the `version` key
+//! updated. New tables are appended at the end of the document, so a
+//! comment at the end of the file stays last and ends up below them.
+
+use hax_types::diagnostics::message::PinChange;
+
+/// The `hax.toml` table a pin is written to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Table {
+    Tools,
+    Versions,
+}
+
+impl Table {
+    fn name(self) -> &'static str {
+        match self {
+            Table::Tools => "tools",
+            Table::Versions => "versions",
+        }
+    }
+}
+
+/// One entry to write: its table, name, and version.
+pub struct Pin {
+    pub table: Table,
+    pub name: String,
+    pub version: String,
+}
+
+/// The result of applying pins to a `hax.toml`'s contents.
+pub struct Outcome {
+    /// The edited contents. Unchanged when `changes` is empty.
+    pub contents: String,
+    /// The entries that were written, in input order.
+    pub changes: Vec<PinChange>,
+    /// Names of path-pinned tools that were left untouched.
+    pub skipped_paths: Vec<String>,
+}
+
+/// Apply `pins` to the contents of a `hax.toml` (empty for a new file).
+/// The contents are arbitrary: nothing on the `pin` path loads the
+/// configuration, so a file that is not valid TOML reaches this and is
+/// reported as an error here.
+pub fn apply(contents: &str, pins: &[Pin]) -> Result<Outcome, String> {
+    let mut doc: toml_edit::DocumentMut =
+        contents.parse().map_err(|e| format!("invalid TOML: {e}"))?;
+    let mut changes = Vec::new();
+    let mut skipped_paths = Vec::new();
+
+    for pin in pins {
+        let table = doc
+            .entry(pin.table.name())
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let Some(table) = table.as_table_like_mut() else {
+            return Err(format!("`[{}]` is not a table", pin.table.name()));
+        };
+        // An entry declaring both `version` and `path` is invalid, so it is
+        // not a statement about how the binary is provided: pinning repairs
+        // it by writing the version and dropping `path`.
+        let mut drop_path = false;
+        let previous = match table.get(&pin.name) {
+            None => None,
+            // A plain version string.
+            Some(item) if item.as_str().is_some() => item.as_str().map(String::from),
+            Some(item) => match item.as_table_like() {
+                // A `{ path = "..." }` entry is the user's statement that
+                // the binary is provided outside version management.
+                Some(entry) if entry.contains_key("path") => {
+                    if !entry.contains_key("version") {
+                        skipped_paths.push(pin.name.clone());
+                        continue;
+                    }
+                    drop_path = true;
+                    entry
+                        .get("version")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                }
+                Some(entry) => entry
+                    .get("version")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                None => None,
+            },
+        };
+        if previous.as_deref() == Some(&pin.version) && !drop_path {
+            continue;
+        }
+        // Update an existing entry's value in place, keeping its decor
+        // (attached comments and spacing) and, for a `{ version = "..." }`
+        // table, its shape; a new entry, and an entry being repaired, is a
+        // plain string.
+        let updated_in_place = match table.get_mut(&pin.name).filter(|_| !drop_path) {
+            None => false,
+            Some(item) => {
+                let slot = match item.as_table_like_mut() {
+                    Some(entry) => entry.get_mut("version").and_then(|v| v.as_value_mut()),
+                    None => item.as_value_mut(),
+                };
+                match slot {
+                    Some(value) => {
+                        let decor = value.decor().clone();
+                        *value = pin.version.as_str().into();
+                        *value.decor_mut() = decor;
+                        true
+                    }
+                    None => false,
+                }
+            }
+        };
+        if !updated_in_place {
+            table.insert(&pin.name, toml_edit::value(&pin.version));
+        }
+        changes.push(PinChange {
+            name: pin.name.clone(),
+            version: pin.version.clone(),
+            previous,
+        });
+    }
+
+    Ok(Outcome {
+        contents: doc.to_string(),
+        changes,
+        skipped_paths,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools(name: &str, version: &str) -> Pin {
+        Pin {
+            table: Table::Tools,
+            name: name.into(),
+            version: version.into(),
+        }
+    }
+
+    fn versions(name: &str, version: &str) -> Pin {
+        Pin {
+            table: Table::Versions,
+            name: name.into(),
+            version: version.into(),
+        }
+    }
+
+    #[test]
+    fn creates_both_tables_in_an_empty_file() {
+        let outcome = apply(
+            "",
+            &[
+                tools("aeneas", "v1"),
+                tools("charon", "v2"),
+                versions("lean", "leanprover/lean4:v4.31.0"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.contents,
+            "[tools]\naeneas = \"v1\"\ncharon = \"v2\"\n\n\
+             [versions]\nlean = \"leanprover/lean4:v4.31.0\"\n"
+        );
+        assert_eq!(outcome.changes.len(), 3);
+        assert!(outcome.changes.iter().all(|c| c.previous.is_none()));
+    }
+
+    #[test]
+    fn rewrites_only_differing_entries_and_reports_the_previous_version() {
+        let outcome = apply(
+            "[tools]\naeneas = \"old\"\ncharon = \"v2\"\n",
+            &[tools("aeneas", "new"), tools("charon", "v2")],
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.contents,
+            "[tools]\naeneas = \"new\"\ncharon = \"v2\"\n"
+        );
+        assert_eq!(outcome.changes.len(), 1);
+        assert_eq!(outcome.changes[0].name, "aeneas");
+        assert_eq!(outcome.changes[0].previous.as_deref(), Some("old"));
+    }
+
+    #[test]
+    fn preserves_comments_formatting_and_foreign_entries() {
+        let contents = "# project pins\n[tools]\n# why this one\naeneas = \"old\"  # inline\n\
+                        future-tool = \"x\"\n\n[other]\nkey = 1\n";
+        let outcome = apply(contents, &[tools("aeneas", "new")]).unwrap();
+        assert_eq!(
+            outcome.contents,
+            "# project pins\n[tools]\n# why this one\naeneas = \"new\"  # inline\n\
+             future-tool = \"x\"\n\n[other]\nkey = 1\n"
+        );
+    }
+
+    #[test]
+    fn table_shaped_entries_keep_their_shape() {
+        let outcome = apply(
+            "[tools]\naeneas = { version = \"old\" }\n",
+            &[tools("aeneas", "new")],
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.contents,
+            "[tools]\naeneas = { version = \"new\" }\n"
+        );
+        assert_eq!(outcome.changes[0].previous.as_deref(), Some("old"));
+    }
+
+    #[test]
+    fn path_entries_are_skipped() {
+        let contents = "[tools]\naeneas = { path = \"/opt/aeneas\" }\n";
+        let outcome = apply(contents, &[tools("aeneas", "new")]).unwrap();
+        assert_eq!(outcome.contents, contents);
+        assert!(outcome.changes.is_empty());
+        assert_eq!(outcome.skipped_paths, ["aeneas"]);
+    }
+
+    #[test]
+    fn an_entry_declaring_both_version_and_path_is_repaired() {
+        for previous_version in ["old", "new"] {
+            let contents = format!(
+                "[tools]\naeneas = {{ version = \"{previous_version}\", path = \"/opt/a\" }}\n"
+            );
+            let outcome = apply(&contents, &[tools("aeneas", "new")]).unwrap();
+            assert_eq!(outcome.contents, "[tools]\naeneas = \"new\"\n");
+            assert_eq!(outcome.changes.len(), 1);
+            assert!(outcome.skipped_paths.is_empty());
+        }
+    }
+
+    #[test]
+    fn a_trailing_comment_stays_at_the_end_of_the_file() {
+        let outcome = apply(
+            "[versions]\nlean = \"v1\"\n# end of file\n",
+            &[tools("aeneas", "v1")],
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.contents,
+            "[versions]\nlean = \"v1\"\n\n[tools]\naeneas = \"v1\"\n# end of file\n"
+        );
+    }
+
+    #[test]
+    fn identical_pins_change_nothing() {
+        let contents = "[tools]\naeneas = \"v1\"\n";
+        let outcome = apply(contents, &[tools("aeneas", "v1")]).unwrap();
+        assert_eq!(outcome.contents, contents);
+        assert!(outcome.changes.is_empty());
+        assert!(outcome.skipped_paths.is_empty());
+    }
+}

--- a/cli/cargo-hax/src/tools/project.rs
+++ b/cli/cargo-hax/src/tools/project.rs
@@ -81,6 +81,34 @@ pub struct MemberCrate {
     pub hax_lib: Option<String>,
 }
 
+/// The directory roots of the current project, as `cargo metadata` reports
+/// them. Discovering them reads no `hax.toml`, so a command that writes one
+/// is not blocked by a file that configuration loading rejects.
+#[derive(Debug, Clone)]
+pub struct ProjectLayout {
+    pub workspace_root: PathBuf,
+    pub member_roots: Vec<PathBuf>,
+}
+
+impl ProjectLayout {
+    pub fn load(message_format: MessageFormat) -> Result<Self, String> {
+        // The layout needs no resolve graph, and asking for one would make
+        // discovery fail on a project whose dependencies do not resolve.
+        let metadata = run_cargo_metadata(&CargoArgs::default(), Deps::Skip)?;
+        let layout = Self {
+            workspace_root: metadata.workspace_root.clone().into(),
+            member_roots: metadata
+                .packages
+                .iter()
+                .filter(|package| metadata.workspace_members.contains(&package.id))
+                .map(package_root)
+                .collect(),
+        };
+        warn_stray_hax_tomls(&layout.workspace_root, &layout.member_roots, message_format);
+        Ok(layout)
+    }
+}
+
 /// The `hax.toml` configuration of the current project.
 #[derive(Debug, Clone)]
 pub struct ProjectContext {
@@ -131,26 +159,7 @@ impl ProjectContext {
     /// crates, as that build processes.
     pub fn load_for(cargo_flags: &[String], message_format: MessageFormat) -> Result<Self, String> {
         let cargo_args = CargoArgs::parse(cargo_flags);
-        let mut command = cargo_metadata::MetadataCommand::new();
-        if let Some(path) = &cargo_args.manifest_path {
-            command.manifest_path(path);
-        }
-        command.other_options(cargo_args.metadata_args);
-        let metadata = command.exec().map_err(|e| match e {
-            cargo_metadata::Error::CargoMetadata { stderr }
-                if cargo_args.manifest_path.is_none() =>
-            {
-                format!(
-                    "`cargo metadata` failed (this command must be run inside a \
-                     Cargo project):\n{}",
-                    stderr.trim()
-                )
-            }
-            cargo_metadata::Error::CargoMetadata { stderr } => {
-                format!("`cargo metadata` failed:\n{}", stderr.trim())
-            }
-            e => format!("`cargo metadata` failed: {e}"),
-        })?;
+        let metadata = run_cargo_metadata(&cargo_args, Deps::Resolve)?;
 
         let workspace_root: PathBuf = metadata.workspace_root.clone().into();
         let workspace_config = load_hax_toml(&workspace_root, message_format)?;
@@ -190,11 +199,7 @@ impl ProjectContext {
             .iter()
             .filter(|p| metadata.workspace_members.contains(&p.id))
         {
-            let root: PathBuf = package
-                .manifest_path
-                .parent()
-                .expect("a Cargo.toml always has a parent directory")
-                .into();
+            let root = package_root(package);
             let config = if root == workspace_root {
                 None
             } else {
@@ -210,11 +215,7 @@ impl ProjectContext {
 
         let root_package = metadata.root_package().map(|package| RootPackage {
             name: package.name.clone(),
-            dir: package
-                .manifest_path
-                .parent()
-                .expect("a Cargo.toml always has a parent directory")
-                .into(),
+            dir: package_root(package),
         });
         let ctx = ProjectContext {
             workspace_root,
@@ -246,29 +247,79 @@ impl ProjectContext {
         }
     }
 
-    /// Warn about `hax.toml` files in directories between the invocation
-    /// directory and the workspace root that are not member-crate roots:
-    /// they have no effect, which is usually a misplaced file.
     fn warn_stray_files(&self, message_format: MessageFormat) {
-        // `cargo metadata` reports canonical paths (symlinks resolved), so
-        // canonicalize the invocation directory too; otherwise a symlinked
-        // checkout (e.g. `/tmp` -> `/private/tmp` on macOS) makes the
-        // `starts_with` and per-member comparisons below spuriously fail.
-        let Ok(invocation_dir) = std::env::current_dir().and_then(|dir| std::fs::canonicalize(dir))
-        else {
-            return;
-        };
-        if !invocation_dir.starts_with(&self.workspace_root) {
-            return;
+        let member_roots: Vec<PathBuf> = self.members.iter().map(|m| m.root.clone()).collect();
+        warn_stray_hax_tomls(&self.workspace_root, &member_roots, message_format);
+    }
+}
+
+/// Whether the resolve graph is needed. Skipping it (`--no-deps`) skips
+/// dependency resolution, which needs neither the network nor a resolvable
+/// dependency set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Deps {
+    Resolve,
+    Skip,
+}
+
+/// Run `cargo metadata` for the project of the invocation directory.
+fn run_cargo_metadata(args: &CargoArgs, deps: Deps) -> Result<cargo_metadata::Metadata, String> {
+    let mut command = cargo_metadata::MetadataCommand::new();
+    if let Some(path) = &args.manifest_path {
+        command.manifest_path(path);
+    }
+    if deps == Deps::Skip {
+        command.no_deps();
+    }
+    command.other_options(args.metadata_args.clone());
+    command.exec().map_err(|e| match e {
+        cargo_metadata::Error::CargoMetadata { stderr } if args.manifest_path.is_none() => {
+            format!(
+                "`cargo metadata` failed (this command must be run inside a \
+                 Cargo project):\n{}",
+                stderr.trim()
+            )
         }
-        for dir in invocation_dir.ancestors() {
-            if dir == self.workspace_root {
-                break;
-            }
-            let candidate = dir.join("hax.toml");
-            if candidate.is_file() && !self.members.iter().any(|m| m.root == dir) {
-                HaxMessage::StrayHaxToml { path: candidate }.report(message_format, None);
-            }
+        cargo_metadata::Error::CargoMetadata { stderr } => {
+            format!("`cargo metadata` failed:\n{}", stderr.trim())
+        }
+        e => format!("`cargo metadata` failed: {e}"),
+    })
+}
+
+fn package_root(package: &cargo_metadata::Package) -> PathBuf {
+    package
+        .manifest_path
+        .parent()
+        .expect("a Cargo.toml always has a parent directory")
+        .into()
+}
+
+/// Warn about `hax.toml` files in directories between the invocation
+/// directory and the workspace root that are not member-crate roots:
+/// they have no effect, which is usually a misplaced file.
+fn warn_stray_hax_tomls(
+    workspace_root: &Path,
+    member_roots: &[PathBuf],
+    message_format: MessageFormat,
+) {
+    // `cargo metadata` reports canonical paths (symlinks resolved), so
+    // canonicalize the invocation directory too; otherwise a symlinked
+    // checkout (e.g. `/tmp` -> `/private/tmp` on macOS) makes the
+    // `starts_with` and per-member comparisons below spuriously fail.
+    let Ok(invocation_dir) = std::env::current_dir().and_then(std::fs::canonicalize) else {
+        return;
+    };
+    if !invocation_dir.starts_with(workspace_root) {
+        return;
+    }
+    for dir in invocation_dir.ancestors() {
+        if dir == workspace_root {
+            break;
+        }
+        let candidate = dir.join("hax.toml");
+        if candidate.is_file() && !member_roots.iter().any(|root| root == dir) {
+            HaxMessage::StrayHaxToml { path: candidate }.report(message_format, None);
         }
     }
 }

--- a/cli/cargo-hax/src/tools/subcommands.rs
+++ b/cli/cargo-hax/src/tools/subcommands.rs
@@ -10,7 +10,7 @@ use hax_types::diagnostics::message::{
 
 use super::defaults::defaults;
 use super::install::{Installed, ensure_installed};
-use super::project::ProjectContext;
+use super::project::{ProjectContext, ProjectLayout};
 use super::resolve::{Resolution, Resolved, resolve_tool, resolve_version};
 use super::{DECLARED_VERSION_KEYS, MANAGED_TOOLS, cache, manifest};
 
@@ -183,6 +183,169 @@ pub fn clean(message_format: MessageFormat) -> i32 {
             message_format,
         ),
     }
+}
+
+/// `cargo hax tools pin`: write pins into `hax.toml`, creating the file
+/// when missing. Without an argument, pins this release's defaults, which
+/// is also how a project moves its pins forward after updating hax; with
+/// one, sets a single entry. Nothing is installed.
+pub fn pin(spec: Option<&str>, message_format: MessageFormat) -> i32 {
+    use super::pin::{Pin, Table};
+
+    let defaults = defaults();
+    let pins: Vec<Pin> = match spec {
+        Some(spec) => {
+            let Some((name, version)) = spec.split_once('@') else {
+                return error(
+                    format!("`{spec}` is not a `<name>@<version>` specification"),
+                    message_format,
+                );
+            };
+            let table = if MANAGED_TOOLS.contains(&name) {
+                Table::Tools
+            } else if DECLARED_VERSION_KEYS.contains(&name) {
+                Table::Versions
+            } else {
+                return error(
+                    format!(
+                        "`{name}` is not a pinnable name (tools: {}; versions: {})",
+                        MANAGED_TOOLS.join(", "),
+                        DECLARED_VERSION_KEYS.join(", ")
+                    ),
+                    message_format,
+                );
+            };
+            let validation = match table {
+                Table::Tools => manifest::validate_version_id(version),
+                Table::Versions => super::config::validate_declared_version(name, version),
+            };
+            if let Err(message) = validation {
+                return error(message, message_format);
+            }
+            // A version the manifest does not list is written anyway: it
+            // may postdate this release. Installing it will go through the
+            // unverified fallback, so say so now, at pin time.
+            if table == Table::Tools && !manifest::manifest().knows_version(name, version) {
+                HaxMessage::GenericWarning {
+                    message: format!(
+                        "{name} {version} is not in this release's manifest; installing \
+                         it will go through the unverified fallback"
+                    ),
+                }
+                .report(message_format, None);
+            }
+            vec![Pin {
+                table,
+                name: name.to_string(),
+                version: version.to_string(),
+            }]
+        }
+        None => MANAGED_TOOLS
+            .iter()
+            .map(|tool| Pin {
+                table: Table::Tools,
+                name: tool.to_string(),
+                version: defaults.tools[*tool].clone(),
+            })
+            .chain(DECLARED_VERSION_KEYS.iter().map(|key| Pin {
+                table: Table::Versions,
+                name: key.to_string(),
+                version: defaults.versions[*key].clone(),
+            }))
+            .collect(),
+    };
+
+    // Only the project layout is needed, not its configuration: pinning
+    // must work on a `hax.toml` that configuration loading rejects, since
+    // rewriting an entry is how such a file is repaired.
+    let layout = match ProjectLayout::load(message_format) {
+        Ok(layout) => layout,
+        Err(message) => return error(message, message_format),
+    };
+    let target_dir = pin_target_dir(&layout);
+    let path = target_dir.join("hax.toml");
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return error(
+                format!("could not read {}: {e}", path.display()),
+                message_format,
+            );
+        }
+    };
+    let outcome = match super::pin::apply(&contents, &pins) {
+        Ok(outcome) => outcome,
+        Err(message) => {
+            return error(
+                format!("could not edit {}: {message}", path.display()),
+                message_format,
+            );
+        }
+    };
+    // The named entry of a `<name>@<version>` invocation was not written,
+    // so the request was not satisfied. The bare form pins whatever it can:
+    // a path entry there is the committed configuration doing its job, and
+    // is reported as a skip.
+    if spec.is_some() && outcome.changes.is_empty() && !outcome.skipped_paths.is_empty() {
+        return error(
+            format!(
+                "tool `{}` is pinned to a path; nothing was written to {}",
+                outcome.skipped_paths.join(", "),
+                path.display()
+            ),
+            message_format,
+        );
+    }
+    // The override is announced only when one is actually written: a run
+    // that changes nothing writes no file to warn about.
+    if !outcome.changes.is_empty() {
+        if target_dir != layout.workspace_root {
+            HaxMessage::GenericWarning {
+                message: format!(
+                    "writing a per-crate override for the member crate at {}; \
+                     run `cargo hax tools pin` at {} to pin the whole project",
+                    target_dir.display(),
+                    layout.workspace_root.display(),
+                ),
+            }
+            .report(message_format, None);
+        }
+        if let Err(e) = std::fs::write(&path, &outcome.contents) {
+            return error(
+                format!("could not write {}: {e}", path.display()),
+                message_format,
+            );
+        }
+    }
+    HaxMessage::ToolsPinned {
+        path,
+        changes: outcome.changes,
+        skipped: outcome.skipped_paths,
+    }
+    .report(message_format, None);
+    0
+}
+
+/// The directory whose `hax.toml` `pin` edits: the member crate the
+/// invocation directory is inside, if any (authoring an override for that
+/// crate), the workspace root otherwise. This is the one place where the
+/// invocation directory matters: reading never depends on it, but an
+/// override is written standing in the crate that wants it.
+fn pin_target_dir(layout: &ProjectLayout) -> std::path::PathBuf {
+    // `cargo metadata` reports canonical paths; canonicalize the invocation
+    // directory too, as the stray-file check does.
+    let Ok(invocation_dir) = std::env::current_dir().and_then(std::fs::canonicalize) else {
+        return layout.workspace_root.clone();
+    };
+    layout
+        .member_roots
+        .iter()
+        .filter(|root| **root != layout.workspace_root)
+        .filter(|root| invocation_dir.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+        .unwrap_or_else(|| layout.workspace_root.clone())
 }
 
 /// How many versions per tool `list` shows without `--all`.

--- a/cli/cargo-hax/tests/tools_pin.rs
+++ b/cli/cargo-hax/tests/tools_pin.rs
@@ -1,0 +1,404 @@
+//! End-to-end tests for `cargo hax tools pin`: which `hax.toml` is edited,
+//! what the two forms write, and what they leave untouched, exercised
+//! through the real binary on a temporary Cargo workspace.
+
+mod common;
+
+use std::path::Path;
+use std::process::Command;
+
+use common::write_crate;
+
+/// A workspace with two members, no `hax.toml` anywhere.
+fn workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"a\", \"b\"]\nresolver = \"2\"\n",
+    )
+    .unwrap();
+    write_crate(&dir.path().join("a"), "a");
+    write_crate(&dir.path().join("b"), "b");
+    dir
+}
+
+fn run(args: &[&str], current_dir: &Path) -> (String, bool) {
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-hax"))
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .expect("could not run cargo-hax");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ),
+        output.status.success(),
+    )
+}
+
+/// The versions the binary under test defaults to, read from `tools show`.
+fn defaults(dir: &Path) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-hax"))
+        .args(["--message-format", "json", "tools", "show"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    serde_json::from_str(stdout.lines().last().unwrap()).unwrap()
+}
+
+fn default_of(show: &serde_json::Value, section: &str, name: &str) -> String {
+    show["ToolsShow"][section]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == name)
+        .unwrap()["version"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn bare_pin_writes_the_defaults_and_is_idempotent() {
+    let dir = workspace();
+    let show = defaults(dir.path());
+
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(output.contains("Pinned aeneas"), "{output}");
+    assert!(output.contains("Pinned lean"), "{output}");
+    // The hint replaces installing, which `pin` deliberately does not do.
+    assert!(
+        output.contains("run `cargo hax tools install` to pre-fetch"),
+        "{output}"
+    );
+
+    // Every managed tool and declared key is pinned at its default.
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    for (section, name) in [
+        ("tools", "aeneas"),
+        ("tools", "charon"),
+        ("versions", "lean"),
+        ("versions", "hax-lean-lib"),
+    ] {
+        let version = default_of(&show, section, name);
+        assert!(
+            written.contains(&format!("{name} = \"{version}\"")),
+            "{written}"
+        );
+    }
+    assert!(
+        written.contains("[tools]") && written.contains("[versions]"),
+        "{written}"
+    );
+    // Pinning the defaults means nothing deviates from them, so no
+    // non-default-version notice is produced afterwards.
+    let (output, _) = run(&["tools", "show"], dir.path());
+    assert!(!output.contains("tested with"), "{output}");
+
+    // Running again changes nothing and says so.
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(output.contains("already pins these versions"), "{output}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("hax.toml")).unwrap(),
+        written
+    );
+}
+
+#[test]
+fn bare_pin_rewrites_outdated_entries_and_reports_the_previous_version() {
+    let dir = workspace();
+    let show = defaults(dir.path());
+    let charon = default_of(&show, "tools", "charon");
+    std::fs::write(
+        dir.path().join("hax.toml"),
+        "# our pins\n[tools]\naeneas = \"nightly-1111.01.01\"  # old\n",
+    )
+    .unwrap();
+
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(output.contains("(was nightly-1111.01.01)"), "{output}");
+
+    // The outdated entry is rewritten in place, the missing ones added,
+    // and comments and formatting survive.
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.starts_with("# our pins\n"), "{written}");
+    assert!(written.contains("  # old"), "{written}");
+    assert!(!written.contains("nightly-1111.01.01"), "{written}");
+    assert!(
+        written.contains(&format!("charon = \"{charon}\"")),
+        "{written}"
+    );
+}
+
+#[test]
+fn pin_sets_one_entry_in_the_table_the_name_belongs_to() {
+    let dir = workspace();
+
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], dir.path());
+    assert!(success, "{output}");
+    assert!(
+        output.contains("Pinned charon nightly-2026.07.16"),
+        "{output}"
+    );
+
+    // A declared-only key goes to `[versions]`, not `[tools]`.
+    let (output, success) = run(
+        &["tools", "pin", "lean@leanprover/lean4:v4.31.0"],
+        dir.path(),
+    );
+    assert!(success, "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    let tools = written.find("[tools]").unwrap();
+    let versions = written.find("[versions]").unwrap();
+    assert!(written.find("charon =").unwrap() > tools, "{written}");
+    assert!(written.find("lean =").unwrap() > versions, "{written}");
+    // Only the named entry is written: the argument form does not pin the
+    // remaining defaults.
+    assert!(!written.contains("aeneas"), "{written}");
+    assert!(!written.contains("hax-lean-lib"), "{written}");
+}
+
+#[test]
+fn pinning_a_version_outside_the_manifest_warns_but_writes_it() {
+    let dir = workspace();
+    let (output, success) = run(&["tools", "pin", "charon@nightly-9999.01.01"], dir.path());
+    assert!(success, "{output}");
+    assert!(
+        output.contains("not in this release's manifest"),
+        "{output}"
+    );
+    assert!(output.contains("unverified fallback"), "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.contains("nightly-9999.01.01"), "{written}");
+}
+
+#[test]
+fn a_path_entry_is_left_untouched() {
+    let dir = workspace();
+    let contents = "[tools]\ncharon = { path = \"/opt/charon\" }\n";
+    std::fs::write(dir.path().join("hax.toml"), contents).unwrap();
+
+    // The named entry is the whole request, so not writing it fails.
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], dir.path());
+    assert!(!success, "{output}");
+    assert!(output.contains("pinned to a path"), "{output}");
+    assert!(output.contains("nothing was written"), "{output}");
+    assert!(!output.contains("already pins these versions"), "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.contains("/opt/charon"), "{written}");
+    assert!(!written.contains("nightly-2026.07.16"), "{written}");
+
+    // The bare form pins everything else and keeps the path entry.
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(output.contains("pinned to a path"), "{output}");
+    assert!(output.contains("Pinned aeneas"), "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.contains("/opt/charon"), "{written}");
+}
+
+#[test]
+fn only_path_entries_left_reports_a_skip_not_an_unchanged_file() {
+    let dir = workspace();
+    let show = defaults(dir.path());
+    // A file that leaves `pin` nothing to write: both tools are path
+    // pinned, both declared versions already hold their default.
+    let contents = format!(
+        "[tools]\naeneas = {{ path = \"/opt/aeneas\" }}\ncharon = {{ path = \"/opt/charon\" }}\n\
+         [versions]\nlean = \"{}\"\nhax-lean-lib = \"{}\"\n",
+        default_of(&show, "versions", "lean"),
+        default_of(&show, "versions", "hax-lean-lib"),
+    );
+    std::fs::write(dir.path().join("hax.toml"), &contents).unwrap();
+
+    // The bare form wrote nothing, and does not claim the file pins what
+    // was asked for.
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(
+        output.contains("Skipped aeneas (pinned to a path)"),
+        "{output}"
+    );
+    assert!(
+        output.contains("Skipped charon (pinned to a path)"),
+        "{output}"
+    );
+    assert!(output.contains("Unchanged ./hax.toml"), "{output}");
+    assert!(!output.contains("already pins these versions"), "{output}");
+
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], dir.path());
+    assert!(!success, "{output}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("hax.toml")).unwrap(),
+        contents
+    );
+}
+
+#[test]
+fn pin_repairs_a_hax_toml_the_project_rejects() {
+    let dir = workspace();
+    std::fs::write(
+        dir.path().join("hax.toml"),
+        "[tools]\ncharon = \"nightly 2026\"\n",
+    )
+    .unwrap();
+    // The file is rejected by everything that loads the configuration.
+    let (output, success) = run(&["tools", "show"], dir.path());
+    assert!(!success, "{output}");
+
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], dir.path());
+    assert!(success, "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.contains("nightly-2026.07.16"), "{written}");
+    let (output, success) = run(&["tools", "show"], dir.path());
+    assert!(success, "{output}");
+}
+
+#[test]
+fn a_rejected_member_file_does_not_block_pinning_at_the_root() {
+    let dir = workspace();
+    std::fs::write(
+        dir.path().join("b").join("hax.toml"),
+        "[tools]\ncharon = \"nightly 2026\"\n",
+    )
+    .unwrap();
+
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], dir.path());
+    assert!(success, "{output}");
+    let written = std::fs::read_to_string(dir.path().join("hax.toml")).unwrap();
+    assert!(written.contains("nightly-2026.07.16"), "{written}");
+}
+
+#[test]
+fn inside_a_member_crate_pin_edits_that_crate() {
+    let dir = workspace();
+    let member = dir.path().join("b");
+
+    let (output, success) = run(&["tools", "pin", "charon@nightly-2026.07.16"], &member);
+    assert!(success, "{output}");
+    // Creating an override is worth saying at write time: the override
+    // warning of the other subcommands cannot see a file that does not
+    // exist yet.
+    assert!(output.contains("per-crate override"), "{output}");
+    // The member's own file is written; the workspace root is untouched.
+    let written = std::fs::read_to_string(member.join("hax.toml")).unwrap();
+    assert!(written.contains("nightly-2026.07.16"), "{written}");
+    assert!(!dir.path().join("hax.toml").exists());
+
+    // The override warning applies to the file just created.
+    let (output, _) = run(&["tools", "show"], dir.path());
+    assert!(
+        output.contains("overrides the workspace tool configuration"),
+        "{output}"
+    );
+}
+
+#[test]
+fn a_member_run_writing_nothing_does_not_announce_an_override() {
+    let dir = workspace();
+    let member = dir.path().join("b");
+
+    let (output, success) = run(&["tools", "pin"], &member);
+    assert!(success, "{output}");
+    assert!(output.contains("per-crate override"), "{output}");
+
+    // Nothing is written the second time, so there is no override to
+    // announce.
+    let (output, success) = run(&["tools", "pin"], &member);
+    assert!(success, "{output}");
+    assert!(!output.contains("per-crate override"), "{output}");
+}
+
+#[test]
+fn a_project_whose_dependencies_do_not_resolve_can_still_be_pinned() {
+    let dir = workspace();
+    // Pinning needs the project's directories, not its dependency graph:
+    // an unresolvable dependency (or a cold registry cache offline) must
+    // not stand between a project and its pins.
+    std::fs::write(
+        dir.path().join("a").join("Cargo.toml"),
+        "[package]\nname = \"a\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+         [dependencies]\nno-such-package-hax-test = \"1\"\n",
+    )
+    .unwrap();
+
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(success, "{output}");
+    assert!(dir.path().join("hax.toml").exists());
+}
+
+#[test]
+fn outside_a_cargo_project_pin_fails_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+    let (output, success) = run(&["tools", "pin"], dir.path());
+    assert!(!success);
+    assert!(
+        output.contains("must be run inside a Cargo project"),
+        "{output}"
+    );
+    assert!(!dir.path().join("hax.toml").exists());
+}
+
+#[test]
+fn json_message_format_emits_structured_output() {
+    let dir = workspace();
+    std::fs::write(
+        dir.path().join("hax.toml"),
+        "[tools]\naeneas = { path = \"/opt/aeneas\" }\ncharon = \"nightly-2026.07.01\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-hax"))
+        .args([
+            "--message-format",
+            "json",
+            "tools",
+            "pin",
+            "charon@nightly-2026.07.16",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pinned = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .find_map(|message| message.get("ToolsPinned").cloned())
+        .expect("no `ToolsPinned` message");
+    assert_eq!(
+        pinned["changes"],
+        serde_json::json!([{
+            "name": "charon",
+            "version": "nightly-2026.07.16",
+            "previous": "nightly-2026.07.01",
+        }])
+    );
+    assert_eq!(pinned["skipped"], serde_json::json!([] as [&str; 0]));
+    assert!(
+        pinned["path"].as_str().unwrap().ends_with("hax.toml"),
+        "{pinned}"
+    );
+}
+
+#[test]
+fn malformed_pin_specs_are_rejected() {
+    let dir = workspace();
+    for (spec, expected) in [
+        ("charon", "<name>@<version>"),
+        ("unknown@v1", "not a pinnable name"),
+        ("charon@../escape", "not a valid version identifier"),
+        ("lean@../escape", "not a valid value"),
+    ] {
+        let (output, success) = run(&["tools", "pin", spec], dir.path());
+        assert!(!success, "{spec}: {output}");
+        assert!(output.contains(expected), "{spec}: {output}");
+    }
+    assert!(!dir.path().join("hax.toml").exists());
+}

--- a/docs/manual/tools.md
+++ b/docs/manual/tools.md
@@ -40,6 +40,22 @@ cargo hax tools show
 
 When a member crate of a workspace overrides a version, `show` lists the differing entries under that crate.
 
+### `tools pin`
+
+`cargo hax tools pin` writes version pins into the current project's `hax.toml`, creating the file if it does not exist.
+
+```bash
+cargo hax tools pin                                # pin this release's defaults
+cargo hax tools pin charon@nightly-2026.07.01      # set one managed tool
+cargo hax tools pin lean@leanprover/lean4:v4.31.0  # set one declared version
+```
+
+Without an argument, `pin` writes the built-in default version of every managed tool and declared version, freezing what this release resolves to. Run it again after upgrading hax to move the pins forward. With a `<name>@<version>` argument, it sets that one entry: managed tools go to `[tools]`, declared versions to `[versions]`. A version this release's manifest does not know is written anyway, with a warning that installing it will go through the unverified fallback.
+
+Editing preserves the rest of the file: formatting, comments, and entries `pin` does not know. A tool pinned to a `path` is reported and left alone, since `pin` writes version entries only. Pointing a tool at a [local build](#using-a-local-build), and unpinning one, are done by hand.
+
+Inside a member crate of a workspace, `pin` writes that crate's own `hax.toml`, creating a [per-crate override](#per-crate-overrides) and warning that it does. Anywhere else it writes the workspace root's.
+
 ### `tools install`
 
 `cargo hax tools install`, run inside a project, downloads and caches everything that project resolves to (the union across all workspace crates: workspace pins, per-member overrides, and defaults). This is what you want in CI, or before going offline, so the later extraction run does not have to download anything.
@@ -102,7 +118,7 @@ cargo hax tools clean
 
 Pinning versions is an advanced option, only needed when the defaults do not work for your project. hax neither checks nor guarantees that a pinned combination of `aeneas`, `charon`, Lean toolchain, and Lean library versions works together; testing that is your responsibility, including after upgrading hax.
 
-To pin versions for a project, commit a `hax.toml` at the workspace root. It has two tables.
+To pin versions for a project, commit a `hax.toml` at the workspace root. It has two tables. [`tools pin`](#tools-pin) writes this file for you.
 
 ```toml
 [tools]

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -553,6 +553,15 @@ pub enum ToolsCommand {
     /// Delete the entire tool cache. Later runs download what they need
     /// again.
     Clean,
+    /// Write version pins into the project's `hax.toml`, creating the
+    /// file when missing.
+    Pin {
+        /// A `<name>@<version>` specification to write as one entry,
+        /// accepting managed tools (e.g. `charon@nightly-2026.07.01`)
+        /// and declared versions (e.g. `lean@leanprover/lean4:v4.31.0`).
+        /// When absent, pins the built-in defaults of this release.
+        spec: Option<String>,
+    },
 }
 
 impl<E: Extension> Command<E> {

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -119,6 +119,16 @@ pub struct InstalledTool {
     pub status: InstallStatus,
 }
 
+/// One entry a `pin` run wrote into `hax.toml`.
+#[derive_group(Serializers)]
+#[derive(Debug, Clone, JsonSchema, Hash, Eq, PartialEq)]
+pub struct PinChange {
+    pub name: String,
+    pub version: String,
+    /// The version the entry pinned before, if it existed.
+    pub previous: Option<String>,
+}
+
 #[derive_group(Serializers)]
 #[derive(Debug, Clone, JsonSchema, Hash, Eq, PartialEq)]
 #[repr(u8)]
@@ -251,6 +261,14 @@ pub enum HaxMessage {
     ToolsCleaned {
         removed: usize,
     } = 26,
+    /// The result of `cargo hax tools pin`: the entries written into the
+    /// edited `hax.toml`, and the path-pinned ones left untouched. Empty
+    /// `changes` means the file was not written.
+    ToolsPinned {
+        path: PathBuf,
+        changes: Vec<PinChange>,
+        skipped: Vec<String>,
+    } = 27,
 }
 
 impl HaxMessage {
@@ -579,6 +597,11 @@ impl HaxMessage {
                 };
                 format!("{:>12} {removed} {noun}", "Removed".bold().green())
             }
+            Self::ToolsPinned {
+                path,
+                changes,
+                skipped,
+            } => render_tools_pinned(&path, &changes, &skipped),
         }
     }
 }
@@ -739,6 +762,54 @@ fn render_tools_list(tools: &[ToolListing], installed_only: bool) -> String {
         blocks.push(lines.join("\n"));
     }
     blocks.join("\n\n")
+}
+
+/// `tools pin`: one Cargo-style line per skipped and per written entry,
+/// closed by the state of the file.
+fn render_tools_pinned(
+    path: &std::path::Path,
+    changes: &[PinChange],
+    skipped: &[String],
+) -> String {
+    use colored::Colorize;
+    let path = relative_to_cwd(path.to_path_buf());
+    let mut lines: Vec<String> = skipped
+        .iter()
+        .map(|name| {
+            format!(
+                "{:>12} {name} (pinned to a path)",
+                "Skipped".bold().yellow()
+            )
+        })
+        .chain(changes.iter().map(|change| {
+            let previous = match &change.previous {
+                Some(previous) => format!(" (was {previous})"),
+                None => String::new(),
+            };
+            format!(
+                "{:>12} {} {}{previous}",
+                "Pinned".bold().green(),
+                change.name,
+                change.version
+            )
+        }))
+        .collect();
+    lines.push(if !changes.is_empty() {
+        format!(
+            "{:>12} {} (run `cargo hax tools install` to pre-fetch)",
+            "Wrote".bold().green(),
+            path.display()
+        )
+    } else if !skipped.is_empty() {
+        format!("{:>12} {}", "Unchanged".bold().green(), path.display())
+    } else {
+        format!(
+            "{:>12} {} already pins these versions",
+            "Unchanged".bold().green(),
+            path.display()
+        )
+    });
+    lines.join("\n")
 }
 
 /// `tools install`: one Cargo-style line per version now in the cache.


### PR DESCRIPTION
Writes version pins into a project's `hax.toml` instead of editing it by hand.

```bash
cargo hax tools pin                            # pin this release's defaults
cargo hax tools pin charon@nightly-2026.07.01  # set one entry
```

Without an argument, `pin` writes the built-in default of every managed tool and declared version, so a project can freeze what its current hax resolves to and move the pins forward after an upgrade. With a `<name>@<version>` argument, it sets that single entry.

Editing is format-preserving: comments, formatting, and entries `pin` does not know survive. Entries pinned to a `path` are left alone and reported. In a workspace member crate, `pin` writes that crate's own `hax.toml` as a per-crate override, warning that it does.

*Assisted by AI. Reviewed manually.*