### PR TITLE
feat!: drop support for macOS on Intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
           - ubuntu-latest    # linux-x86_64
           - ubuntu-24.04-arm # linux-aarch64
           - macos-latest     # macos-aarch64
-          - macos-15-intel   # macos-x86_64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -22,7 +22,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04
           - macos-latest
-          - macos-15-intel
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tools_end_to_end.yml
+++ b/.github/workflows/tools_end_to_end.yml
@@ -26,14 +26,12 @@ jobs:
       # oldest, glibc being backward compatible, so the 22.04 images cover the
       # newer ones and both architectures are held to that floor; on macOS the
       # newest, since what refuses a binary there is the code-signing policy,
-      # which Apple only tightens. `macos-15-intel` is pinned for want of a
-      # floating Intel label, not for its version.
+      # which Apple only tightens.
       matrix:
         os:
           - ubuntu-22.04     # linux-x86_64
           - ubuntu-22.04-arm # linux-aarch64
           - macos-latest     # macos-aarch64
-          - macos-15-intel   # macos-x86_64
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Miscellaneous:
  - Update flags for the charon/aeneas pipeline (#2051)
  - Fix missing tools in the Nix dev shells (#2131)
  - Check examples through `just check-examples` instead of a Nix flake check (#2131)
- - Document the supported platforms: Linux and macOS, on both `x86_64` and `aarch64`. Windows is not supported and is no longer built in CI
+ - Document the supported platforms: Linux (`x86_64` and `aarch64`) and macOS (`aarch64`). Windows and macOS on Intel are not supported and are no longer built in CI
 
 ## 0.3.7
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Use `--help` on any subcommand for options (e.g. `cargo hax into fstar --z3rlimi
 
 ## Installation
 
-hax is supported on Linux and macOS, on both `x86_64` and `aarch64`. Windows is not supported; use [WSL](https://learn.microsoft.com/windows/wsl/) there.
+hax is supported on Linux (`x86_64` and `aarch64`) and macOS (`aarch64`). Windows is not supported; use [WSL](https://learn.microsoft.com/windows/wsl/) there.
 
 <details open>
   <summary><b>Manual installation</b></summary>

--- a/cli/cargo-hax/src/tools/install/fixtures.rs
+++ b/cli/cargo-hax/src/tools/install/fixtures.rs
@@ -67,7 +67,6 @@ pub fn binary_for(platform: &str) -> Vec<u8> {
     match platform {
         "linux-x86_64" => elf(0x3E),
         "linux-aarch64" => elf(0xB7),
-        "macos-x86_64" => macho(0x0100_0007),
         "macos-aarch64" => macho(0x0100_000C),
         other => panic!("no executable fixture for platform {other}"),
     }

--- a/cli/cargo-hax/src/tools/install/manifest_artifacts.rs
+++ b/cli/cargo-hax/src/tools/install/manifest_artifacts.rs
@@ -5,7 +5,7 @@
 //! file, an archive's layout can move out from under `entry_points`, and an
 //! artifact can be published under the wrong platform's name. None of that is
 //! visible without fetching the artifact, so the tests that fetch one are
-//! `#[ignore]`d and left to CI. They cover all four supported platforms from
+//! `#[ignore]`d and left to CI. They cover every supported platform from
 //! whichever one runs them: downloading, hashing and reading an archive are
 //! platform-independent. Whether a binary *runs* is left to the tests that
 //! install and run the real artifacts natively.
@@ -235,6 +235,9 @@ fn binary_platform(path: &Path) -> Result<Option<String>, String> {
     if u32::from_le_bytes([header[0], header[1], header[2], header[3]]) == 0xFEED_FACF {
         return Ok(
             match u32::from_le_bytes([header[4], header[5], header[6], header[7]]) {
+                // Intel Macs are unsupported, but recognizing the type lets
+                // an x86_64 binary published under the aarch64 key be
+                // reported as a mismatch rather than pass unrecognized.
                 0x0100_0007 => Some("macos-x86_64".to_string()),
                 0x0100_000C => Some("macos-aarch64".to_string()),
                 _ => None,

--- a/cli/cargo-hax/src/tools/manifest.rs
+++ b/cli/cargo-hax/src/tools/manifest.rs
@@ -75,12 +75,7 @@ pub fn embedded() -> Manifest {
 /// The platforms hax publishes pre-built tool artifacts for, as the keys
 /// the manifest uses. A platform outside this set installs nothing: it
 /// resolves to the escape hatch of a user-provided binary.
-pub const SUPPORTED_PLATFORMS: &[&str] = &[
-    "linux-x86_64",
-    "linux-aarch64",
-    "macos-x86_64",
-    "macos-aarch64",
-];
+pub const SUPPORTED_PLATFORMS: &[&str] = &["linux-x86_64", "linux-aarch64", "macos-aarch64"];
 
 /// The platform key of the running binary, derived from its compile-time
 /// target: `<os>-<arch>` with `os` in `linux`/`macos` and `arch` in
@@ -243,8 +238,9 @@ mod tests {
     /// platform and silently fall through to the unverified path.
     #[test]
     fn platform_key_of_a_supported_target_is_a_manifest_key() {
-        let supported_target = cfg!(any(target_os = "linux", target_os = "macos"))
-            && cfg!(any(target_arch = "x86_64", target_arch = "aarch64"));
+        let supported_target = (cfg!(target_os = "linux")
+            && cfg!(any(target_arch = "x86_64", target_arch = "aarch64")))
+            || (cfg!(target_os = "macos") && cfg!(target_arch = "aarch64"));
         if supported_target {
             let key = platform_key();
             assert!(
@@ -256,7 +252,7 @@ mod tests {
 
     /// Manifest lookups must key on the platform they are given, for each
     /// supported platform rather than only the host's. The fixture is
-    /// host-independent, so every runner exercises all four keys.
+    /// host-independent, so every runner exercises every key.
     #[test]
     fn lookups_select_the_entry_of_each_supported_platform() {
         let entries = SUPPORTED_PLATFORMS

--- a/cli/cargo-hax/tools-manifest.toml
+++ b/cli/cargo-hax/tools-manifest.toml
@@ -8,7 +8,7 @@
 # unverified and with a warning.
 #
 # Entries are only added, never removed: every version ever published stays
-# installable with verification. Adding a version is a single reviewed
+# installable with verification on the supported platforms. Adding a version is a single reviewed
 # commit; generate its entries with `just add-tool-version <tool> <version>`,
 # which hashes the artifacts themselves and checks them the way an install
 # does, and record the provenance in a comment when it is not obvious from
@@ -33,11 +33,6 @@ url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.07.21-52
 sha256 = "53b2907dc12c3b92b30a43fab6f146b1b8f41ef1257f89a675823d5a0cdf9b2f"
 entry_points = { aeneas = "aeneas" }
 
-[tools.aeneas."nightly-2026.07.21-52fd438".macos-x86_64]
-url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.07.21-52fd438/aeneas-macos-x86_64.tar.gz"
-sha256 = "35023a75488567155bbc8e695dfd2af856089c9a6d670f329c68527fb4c8b43c"
-entry_points = { aeneas = "aeneas" }
-
 [tools.aeneas."nightly-2026.07.21-52fd438".macos-aarch64]
 url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.07.21-52fd438/aeneas-macos-aarch64.tar.gz"
 sha256 = "791ea4a091f02aa628375a796c76ef33b161fb19d0a45c830aa22af18c74d3d5"
@@ -53,11 +48,6 @@ url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.08.04-81
 sha256 = "f64e8ad17b41a00d8d514114a2e0533551641f5910396631047e053b0370f145"
 entry_points = { aeneas = "aeneas" }
 
-[tools.aeneas."nightly-2026.08.04-8125bcf".macos-x86_64]
-url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.08.04-8125bcf/aeneas-macos-x86_64.tar.gz"
-sha256 = "406854ead5e381486d0846e9f6b0bde1eca52ad3204140cb73b07bb69ecced61"
-entry_points = { aeneas = "aeneas" }
-
 [tools.aeneas."nightly-2026.08.04-8125bcf".macos-aarch64]
 url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.08.04-8125bcf/aeneas-macos-aarch64.tar.gz"
 sha256 = "5094612d66e58f091bd5fb2b549a70af989a39cce369c59e2a9a099dd58cd081"
@@ -71,11 +61,6 @@ entry_points = { aeneas = "aeneas" }
 [tools.aeneas."nightly-2026.08.18-ae2f343".linux-aarch64]
 url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.08.18-ae2f343/aeneas-linux-aarch64.tar.gz"
 sha256 = "6be2852c4b4790bb7395229e7bf8ac622591d9477bea8af44cf920f9e3f778fb"
-entry_points = { aeneas = "aeneas" }
-
-[tools.aeneas."nightly-2026.08.18-ae2f343".macos-x86_64]
-url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.08.18-ae2f343/aeneas-macos-x86_64.tar.gz"
-sha256 = "ded1c4572efa55416fb1b9b6784606ed6773b2df5efa69fe557d8a049041b9ab"
 entry_points = { aeneas = "aeneas" }
 
 [tools.aeneas."nightly-2026.08.18-ae2f343".macos-aarch64]
@@ -97,11 +82,6 @@ url = "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.1
 sha256 = "0a1c9d4d04e2d4bc60564323f18778b3a210f29f39cbd03316c5aab1c260d628"
 entry_points = { charon = "charon", charon-driver = "charon-driver" }
 
-[tools.charon."nightly-2026.07.16".macos-x86_64]
-url = "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.16/charon-macos-x86_64.tar.gz"
-sha256 = "44ac5d23b2d300f61c16a63e3140a694e2fd1856209dc2d9a6e35fb9fbbac89e"
-entry_points = { charon = "charon", charon-driver = "charon-driver" }
-
 [tools.charon."nightly-2026.07.16".macos-aarch64]
 url = "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.16/charon-macos-aarch64.tar.gz"
 sha256 = "beade7d7d0a3618c3fae4c242741c1575e376fd709a124273a73207f28ceef15"
@@ -115,11 +95,6 @@ entry_points = { charon = "charon", charon-driver = "charon-driver" }
 [tools.charon."nightly-2026.07.24".linux-aarch64]
 url = "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.24/charon-linux-aarch64.tar.gz"
 sha256 = "3178b2bba550fec945516dee893e12cf31be7821d740956f390c5401a5b95352"
-entry_points = { charon = "charon", charon-driver = "charon-driver" }
-
-[tools.charon."nightly-2026.07.24".macos-x86_64]
-url = "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.24/charon-macos-x86_64.tar.gz"
-sha256 = "aec42eb2b36f7428e9fe5c390e53c3e222bccd4a6f025aafe8266211bfcf171a"
 entry_points = { charon = "charon", charon-driver = "charon-driver" }
 
 [tools.charon."nightly-2026.07.24".macos-aarch64]
@@ -143,10 +118,6 @@ entry_points = { aeneas = "aeneas" }
 url = "https://github.com/cryspen/aeneas/releases/download/{version}/aeneas-linux-aarch64.tar.gz"
 entry_points = { aeneas = "aeneas" }
 
-[fallback.aeneas.macos-x86_64]
-url = "https://github.com/cryspen/aeneas/releases/download/{version}/aeneas-macos-x86_64.tar.gz"
-entry_points = { aeneas = "aeneas" }
-
 [fallback.aeneas.macos-aarch64]
 url = "https://github.com/cryspen/aeneas/releases/download/{version}/aeneas-macos-aarch64.tar.gz"
 entry_points = { aeneas = "aeneas" }
@@ -157,10 +128,6 @@ entry_points = { charon = "charon", charon-driver = "charon-driver" }
 
 [fallback.charon.linux-aarch64]
 url = "https://github.com/AeneasVerif/charon/releases/download/{version}/charon-linux-aarch64.tar.gz"
-entry_points = { charon = "charon", charon-driver = "charon-driver" }
-
-[fallback.charon.macos-x86_64]
-url = "https://github.com/AeneasVerif/charon/releases/download/{version}/charon-macos-x86_64.tar.gz"
 entry_points = { charon = "charon", charon-driver = "charon-driver" }
 
 [fallback.charon.macos-aarch64]

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -26,7 +26,7 @@ Note:
 
 ## Installation
 
-hax is supported on Linux and macOS, on both `x86_64` and `aarch64`. Windows is not supported; use [WSL](https://learn.microsoft.com/windows/wsl/) there.
+hax is supported on Linux (`x86_64` and `aarch64`) and macOS (`aarch64`). Windows is not supported; use [WSL](https://learn.microsoft.com/windows/wsl/) there.
 
 ### Manual installation
 

--- a/docs/manual/tools.md
+++ b/docs/manual/tools.md
@@ -26,7 +26,7 @@ You do not have to install anything up front. The first time a `cargo hax into l
 
 The cache lives under `$XDG_CACHE_HOME/hax/tools/` (falling back to `~/.cache/hax/tools/` when `XDG_CACHE_HOME` is unset, empty, or not an absolute path), with one directory per tool and version. Downloads are verified before they are moved into place, so an interrupted download never leaves a half-installed version behind. They use the proxy and the certificate store the environment configures. The cache only grows; drop versions you no longer need with [`tools remove`](#tools-remove), or all of them with [`tools clean`](#tools-clean).
 
-Pre-built binaries are available for the platforms hax supports: Linux and macOS, on both `x86_64` and `aarch64`. On any other platform there is nothing to download, and hax reports so, naming the version it wanted; build `aeneas` and `charon` yourself and point hax at them as described under [Using a local build](#using-a-local-build).
+Pre-built binaries are available for the platforms hax supports: Linux (`x86_64` and `aarch64`) and macOS (`aarch64`). On any other platform there is nothing to download, and hax reports so, naming the version it wanted; build `aeneas` and `charon` yourself and point hax at them as described under [Using a local build](#using-a-local-build).
 
 ## The `cargo hax tools` subcommands
 


### PR DESCRIPTION
Remove the `macos-x86_64` platform. macOS is supported on `aarch64` only.

- Drop the `macos-x86_64` entries and fallback templates from the tool manifest and remove the platform from `SUPPORTED_PLATFORMS`; on an Intel Mac, hax now reports that no pre-built binaries exist and points at a user-provided build
- Remove the `macos-15-intel` runners from CI
- Update the supported-platform statements in the README and the manual

The Mach-O `x86_64` cputype stays recognized in the artifact check, so an Intel binary published under the `aarch64` key is still reported as a mismatch.

*Assisted by AI. Reviewed manually.*