### PR TITLE
fix: suppress cfg-warnings

### DIFF
--- a/cli/cargo-hax/src/cargo_hax.rs
+++ b/cli/cargo-hax/src/cargo_hax.rs
@@ -72,12 +72,32 @@ fn rust_log_style() -> String {
     })
 }
 
+/// The `cfg` names that hax uses: `hax`, `hax_backend_<name>`, and the hax_lib-internal
+/// `hax_compilation`.
+pub fn hax_cfg_names() -> impl Iterator<Item = String> {
+    ["hax".to_string(), "hax_compilation".to_string()]
+        .into_iter()
+        .chain(
+            BackendName::iter()
+                .map(|backend| format!("hax_backend_{}", backend.to_string().replace('-', "_"))),
+        )
+}
+
+/// `--check-cfg` declarations for the cfg names that hax uses.
+fn check_cfg_flags() -> String {
+    hax_cfg_names()
+        .map(|name| format!("--check-cfg cfg({name})"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// We set `cfg(hax)` so that client crates can include dependencies
-/// or cfg-gate pieces of code.
+/// or cfg-gate pieces of code. Moreover, we use `--check-cfg` to
+/// suppress warnings about all cfg-names that hax uses.
 const RUSTFLAGS: &str = "RUSTFLAGS";
 pub fn rustflags() -> String {
     let rustflags = std::env::var(RUSTFLAGS).unwrap_or("".into());
-    [rustflags, "--cfg hax".into()].join(" ")
+    [rustflags, "--cfg hax".into(), check_cfg_flags()].join(" ")
 }
 
 /// Find an external binary: check the given env var, then `PATH`.

--- a/hax-bounded-integers/Cargo.toml
+++ b/hax-bounded-integers/Cargo.toml
@@ -13,3 +13,9 @@ description = "Newtypes for working with bounded integers with hax"
 duplicate = "2.0.1"
 hax-lib.workspace = true
 paste = "1.0.15"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(hax)',
+    'cfg(hax_compilation)',
+] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,4 +32,12 @@ syn = { version = "2.0.114", features = ["full"] }
 [workspace]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(hax_backend_coq)', 'cfg(hax_backend_fstar)', 'cfg(hax_compilation)', 'cfg(hax_backend_legacy_lean)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(hax)',
+    'cfg(hax_backend_coq)',
+    'cfg(hax_backend_fstar)',
+    'cfg(hax_backend_lean)',
+    'cfg(hax_backend_legacy_lean)',
+    'cfg(hax_backend_proverif)',
+    'cfg(hax_compilation)',
+] }


### PR DESCRIPTION
The Lean examples currently produce a couple of "unexpected cfg" warnings. This PR fixes that by adding `--check-cfg ...` to the RUSTFLAGS used by hax when calling Rust.

The two changes to the `Cargo.toml` files are not directly related:
- `hax_bounded_integers` also emits similar warnings when compiled, which is why I added `unexpected_cfgs`
- I list of backends in `tests/Cargo.toml` was incomplete.

I used Claude, reviewed and edited the code.

[skip changelog]