### PR TITLE
fix(lean): include `core` trait with default methods when extracting with charon+aeneas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changes to cargo-hax:
    run's target directory are accepted, and a lost or partial report set fails the run instead
    of silently producing an incomplete extraction
  - Exit with a failing status whenever an error was reported
+ - Make traits from `core` with default methods visible to charon so that impls of these traits have the right defaulted implementations (#2172)
 
 Changes to the hax-lib crate:
  - Add `hax_lib::ensures_ref`, an `ensures` whose closure takes the result by reference,

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -26,6 +26,29 @@ const CHARON_RESERVED_FLAGS: &[&str] = &["--dest-file"];
 // Aeneas flags that trigger a warning when passed by the user.
 const AENEAS_WARN_FLAGS: &[&str] = &["-backend", "-dest", "-subdir", "-split-files"];
 
+/// The provided methods the `CoreModels` structures declare as fields. Charon
+/// drops a provided method the crate never calls, and aeneas then emits the
+/// trait impl without that field, which Lean rejects (#2172); naming them as
+/// translation roots keeps them. Must match the structures' fields exactly:
+/// these are the only nine methods the model crates give a default body.
+const CHARON_DEFAULT_METHOD_ROOTS: &[&str] = &[
+    "core::cmp::PartialEq::ne",
+    "core::cmp::PartialOrd::lt",
+    "core::cmp::PartialOrd::le",
+    "core::cmp::PartialOrd::gt",
+    "core::cmp::PartialOrd::ge",
+    // Only a crate with its own `impl Step` reaches these.
+    "core::iter::range::Step::forward",
+    "core::iter::range::Step::forward_unchecked",
+    "core::iter::range::Step::backward",
+    "core::iter::range::Step::backward_unchecked",
+];
+
+fn picks_roots(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--start-from" || arg.starts_with("--start-from="))
+}
+
 /// Shell-split a user-supplied extra-args string, reporting a fatal error on
 /// unmatched quotes. Returns an empty vector if `s` is `None`.
 fn shell_split(s: Option<&str>, who: &str, message_format: MessageFormat) -> Vec<String> {
@@ -470,6 +493,14 @@ pub fn run(
         "--rustc-arg=--cfg=hax_compilation",
         "--rustc-arg=--cfg=hax_backend_lean",
     ]);
+    // Naming a root suppresses charon's implicit `crate` one, so restore it
+    // unless the caller picked its own roots.
+    if !picks_roots(&selection_flags) && !picks_roots(&user_charon_args) {
+        charon_cmd.args(["--start-from", "crate"]);
+    }
+    for root in CHARON_DEFAULT_METHOD_ROOTS {
+        charon_cmd.args(["--start-from", root]);
+    }
     // User-supplied charon flags go before the `--` cargo separator.
     charon_cmd.args(&selection_flags);
     charon_cmd.args(&user_charon_args);

--- a/hax-lib/core-models/tests/client_test/src/lib.rs
+++ b/hax-lib/core-models/tests/client_test/src/lib.rs
@@ -120,6 +120,22 @@ pub fn ge_usize(x: usize, y: usize) -> bool {
     x >= y
 }
 
+/// Derived impls whose provided methods the crate never calls: charon drops
+/// those unless they are named as translation roots, and Lean then rejects the
+/// impl (cryspen/hax#2172).
+#[derive(PartialEq)]
+pub enum DerivedPartialEq {
+    A,
+    B,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct DerivedOrd(pub u8);
+
+pub fn derived_eq(x: &DerivedPartialEq, y: &DerivedPartialEq) -> bool {
+    x == y
+}
+
 // ----- Bitwise --------------------------------------------------------------
 
 pub fn xor_u64(x: u64, y: u64) -> u64 {


### PR DESCRIPTION
Fixes #2172

In a situation where a trait from core has a default method, and an impl of this trait is extracted (and doesn't override the default), charon+aeneas need to `include` the trait definition in order to produce the right call to the default implementation in the extraction of the trait impl. 

This PR injects in all extractions the `include` statements for the traits currently in core-models which have default methods.