### PR TITLE
ci: release workflow fixes

### DIFF
--- a/.github/workflows/bertie.yml
+++ b/.github/workflows/bertie.yml
@@ -25,10 +25,34 @@ jobs:
         with:
           path: hax
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      # Bertie pins the published `hax-lib`, which `cargo-hax` only accepts
+      # at its own release version: between a version bump and the release
+      # that publishes it, the extraction cannot run, so it is skipped
+      # instead of failing the merge queue.
+      - name: Check the `hax-lib` version Bertie pins
+        id: haxlib
+        run: |
+          set -o pipefail
+          binary="$(cargo metadata --format-version 1 --no-deps \
+            --manifest-path hax/Cargo.toml \
+            | jq -r '.packages[] | select(.name == "cargo-hax") | .version')"
+          found="$(awk -F '"' '/^name = "hax-lib"$/ { getline; print $2 }' \
+            Cargo.lock)"
+          if [ "${binary%%-*}" = "${found%%-*}" ]; then
+            echo "compatible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "compatible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skipping the extraction: cargo-hax $binary" \
+              "requires hax-lib ${binary%%-*}, but Bertie pins hax-lib $found"
+          fi
+
+      - if: steps.haxlib.outputs.compatible == 'true'
+        uses: DeterminateSystems/nix-installer-action@main
       - name: ⤵ Install hax
+        if: steps.haxlib.outputs.compatible == 'true'
         run: |
           nix profile install ./hax
 
       - name: 🏃 Extract fstar
+        if: steps.haxlib.outputs.compatible == 'true'
         run: ./hax-driver.py extract-fstar

--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -73,26 +73,56 @@ jobs:
           printf '\n[patch.crates-io]\nhax-lib = { path = "../hax/hax-lib" }\n' >> Cargo.toml
           cargo update -p hax-lib
 
-      - if: runner.environment == 'github-hosted'
+      # The patch above only takes effect while the local `hax-lib` satisfies
+      # the requirement libcrux declares: between a version bump and the
+      # release that publishes it, the lockfile keeps the published version,
+      # which `cargo-hax` rejects, so the extraction is skipped instead of
+      # failing the merge queue.
+      - name: Check the `hax-lib` version libcrux resolved
+        id: haxlib
+        run: |
+          set -o pipefail
+          binary="$(cargo metadata --format-version 1 --no-deps \
+            --manifest-path hax/Cargo.toml \
+            | jq -r '.packages[] | select(.name == "cargo-hax") | .version')"
+          found="$(awk -F '"' '/^name = "hax-lib"$/ { getline; print $2 }' \
+            libcrux/Cargo.lock)"
+          if [ "${binary%%-*}" = "${found%%-*}" ]; then
+            echo "compatible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "compatible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skipping the extraction: cargo-hax $binary" \
+              "requires hax-lib ${binary%%-*}, but libcrux resolved" \
+              "hax-lib $found"
+          fi
+
+      - if: >-
+          steps.haxlib.outputs.compatible == 'true' &&
+          runner.environment == 'github-hosted'
         uses: DeterminateSystems/nix-installer-action@main
       - name: Set up Cachix
+        if: steps.haxlib.outputs.compatible == 'true'
         uses: cachix/cachix-action@v15
         with:
           name: fstar-nix-versions
           push: false
-    
+
       - name: ⤵ Install hax
+        if: steps.haxlib.outputs.compatible == 'true'
         run: |
           nix profile install ./hax
 
       - name: ⤵ Install FStar
+        if: steps.haxlib.outputs.compatible == 'true'
         run: nix profile install github:FStarLang/FStar/v2025.02.17
 
       - name: 🏃 Extract ML-KEM crate
+        if: steps.haxlib.outputs.compatible == 'true'
         working-directory: libcrux/libcrux-ml-kem
         run: ./hax.py extract
-  
+
       - name: 🏃 Lax ML-KEM crate
+        if: steps.haxlib.outputs.compatible == 'true'
         working-directory: libcrux/libcrux-ml-kem
         run: |
           env FSTAR_HOME=${{ github.workspace }}/fstar \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,12 +133,29 @@ jobs:
           tar -cf - -C target/${{ matrix.target }}/release cargo-hax \
             | zstd -9 -T0 -o "$ARCHIVE"
 
+      # The release notes: the released version's changelog section, which the
+      # version bump renames from `[Unreleased]`. A pre-release keeps
+      # `[Unreleased]` in place, has no section of its own, and so gets an
+      # empty body. Headings match with and without brackets, covering the
+      # sections that predate the bracketed form.
+      - name: Extract the changelog section
+        if: env.PUBLISHED != 'true'
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
+        run: |
+          awk -v version="$VERSION" '
+            /^## / { heading = $2; gsub(/[][]/, "", heading)
+                     on = (heading == version); next }
+            on { print }
+          ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+
       - name: Release
         if: env.PUBLISHED != 'true'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           prerelease: ${{ contains(needs.tag.outputs.version, '-') }}
+          body_path: ${{ runner.temp }}/release-notes.md
           files: ${{ env.ARCHIVE }}
 
   # Installs the release the way every user's `cargo binstall` does, once the

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -144,11 +144,13 @@ jobs:
           git push --force origin "$branch"
           title="$(jq -rn --arg s "chore: release v$version" '$s | @uri')"
           body="$(jq -rn --arg s "${PR_BODY//__BRANCH__/$branch}" '$s | @uri')"
+          url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/main...$branch?quick_pull=1&title=$title&body=$body"
           {
             echo "### Release v$version"
             echo
-            echo "[Open the release PR]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/main...$branch?quick_pull=1&title=$title&body=$body) to continue; the release stalls without it."
+            echo "[Open the release PR]($url) to continue."
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=Open the release PR for v$version::$url"
 
   # Queues the publish once a release PR merges. The head-repository check
   # keeps a fork branch that happens to be named `release/...` from counting

--- a/.github/workflows/standalone_install.yml
+++ b/.github/workflows/standalone_install.yml
@@ -63,7 +63,12 @@ jobs:
       # from the working tree: it would fail on any change that spans `hax-types`
       # and `cargo-hax`, and between a version bump and the release that follows
       # it. The install step already builds the working tree.
+      #
+      # Skipped on release PRs: the tarball's lockfile resolves the sibling
+      # crates from crates.io at the bumped version, which is only published
+      # once the PR merges.
       - name: Check the published tarball
+        if: "!startsWith(github.head_ref, 'release/')"
         run: |
           cargo package --locked --no-verify -p cargo-hax
           tar --extract --directory "$RUNNER_TEMP" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,4 @@ hax-rust-engine-macros = { path = "rust-engine/macros", version = "=0.4.0-rc.1" 
 
 [workspace.metadata.release]
 owners = ["github:cryspen:tools"]
+pre-release-commit-message = "chore: release v{{version}}"


### PR DESCRIPTION
Fixes for issues found while running the first release through the `Release PR` workflow:

- Skip the published-tarball check on release PRs: its lockfile resolves the sibling crates from crates.io at the bumped version, which is only published once the PR merges.
- Skip the Bertie and ML-KEM extractions when the external repository's `hax-lib` does not match this tree's `cargo-hax`, which is the case between a version bump and its release, so they no longer fail the merge queue.
- Include the version in the bump commit message (`chore: release v<version>` instead of `chore: Release`).
- Surface the release PR link as a run annotation, in addition to the run summary.
- Fill the GitHub release body with the released version's changelog section; pre-releases, which have no section, keep an empty body.

*Assisted by AI. Reviewed manually.*

[skip changelog]