### PR TITLE
ci: extract an example in the tool end-to-end checks

### DIFF
--- a/.github/workflows/tools_end_to_end.yml
+++ b/.github/workflows/tools_end_to_end.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Walk the documented setup flow in a project
         run: just test-tools-cli
 
+      # A full extraction, beyond launching the tools: an artifact can start
+      # and still fail once it runs for real, so each platform extracts an
+      # example end to end.
+      - name: Extract an example to Lean
+        run: just test-tools-extract
+
   # The status check to require on `main`: one context, named after nothing that
   # moves, where the matrix leg names follow the runner images. Requiring it is
   # a repository setting; without that, a failure here does not stop a merge.

--- a/justfile
+++ b/justfile
@@ -101,6 +101,16 @@ add-tool-version tool version:
 test-tools-install:
   cargo test -p cargo-hax --bin cargo-hax -- --ignored host_install
 
+# Extract an example to Lean with the managed tools: a full charon and aeneas run, beyond the launch checks of `test-tools-install`. Reaches the network, and installs into the tool cache.
+test-tools-extract:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cargo build -q -p cargo-hax --bin cargo-hax
+  # `examples/` is its own workspace, so the binary is invoked by path.
+  HAX="$PWD/target/debug/cargo-hax"
+  cd examples/barrett
+  "$HAX" into lean
+
 # Walk the documented tool setup flow from inside an example project, the way a user would: resolution, the `hax-lib` check, and the install of what the project resolves to. Reaches the network.
 test-tools-cli:
   #!/usr/bin/env bash


### PR DESCRIPTION
The end-to-end checks only asserted that the managed tools launch, which the macOS charon artifacts of `nightly-2026.08.20` pass despite linking their libraries from nix store paths; the breakage only surfaced during the release, in the first real extraction on macOS. Every supported platform now extracts `examples/barrett` to Lean with the managed tools, so a broken artifact fails the PR pinning it.

*Assisted by AI. Reviewed manually.*

[skip changelog]