### PR TITLE
fix(core-models): model `IndexMut` for `[T; N]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Changes to the hax-lib crate:
 
 Changes to core models:
  - Improve core models library (#2049, #2157, #2077, #2160)
+ - Model `IndexMut` for `[T; N]`, so writing through an array range
+   (`arr[a..b].copy_from_slice(src)`) extracts instead of referring to a nonexistent
+   `core.Array.Insts.CoreOpsIndexIndexMut.index_mut` (#2174)
  - Add core model testing infrastructure
 
 Changes to the F* backend and library:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Changes to core models:
  - Improve core models library (#2049, #2157, #2077, #2160)
  - Model `IndexMut` for `[T; N]`, so writing through an array range
    (`arr[a..b].copy_from_slice(src)`) extracts instead of referring to a nonexistent
-   `core.Array.Insts.CoreOpsIndexIndexMut.index_mut` (#2174)
+   `core.Array.Insts.CoreOpsIndexIndexMut.index_mut` (#2187, fix #2174)
  - Add core model testing infrastructure
 
 Changes to the F* backend and library:

--- a/cli/cargo-hax/defaults.toml
+++ b/cli/cargo-hax/defaults.toml
@@ -19,7 +19,7 @@ lean = "leanprover/lean4:v4.31.0"
 # The Lean library that extracted code builds against. This is a tag in
 # `cryspen/hax-lean`, pushed by `.github/workflows/deploy_hax_lean.yml`; it
 # must match `version` in `hax-lib/proof-libs/lean/lakefile.toml`.
-hax-lean-lib = "v0.3.12"
+hax-lean-lib = "v0.3.13"
 
 # The default opaque set for proof scenarios: trait impls that are
 # routinely derived but rarely worth translating. Applied to every Lean

--- a/hax-lib/core-models/alloc/src/vec/tests.rs
+++ b/hax-lib/core-models/alloc/src/vec/tests.rs
@@ -98,8 +98,16 @@ proptest! {
         }
     }
 
+    // `use_last` reaches the `n == len - 1` arm, which returns the popped
+    // element directly; a uniform index hits it about once every `len` cases,
+    // so leaving it to chance makes the arm's coverage flaky.
     #[test]
-    fn test_swap_remove(v in prop::collection::vec(any::<u8>(), 1..50), idx in 0usize..50) {
+    fn test_swap_remove(
+        v in prop::collection::vec(any::<u8>(), 1..50),
+        idx in 0usize..50,
+        use_last in any::<bool>(),
+    ) {
+        let idx = if use_last { v.len() - 1 } else { idx };
         if idx < v.len() {
             let mut model = v.inject();
             let mut std_v = v.clone();

--- a/hax-lib/core-models/core-models/src/core/array.rs
+++ b/hax-lib/core-models/core-models/src/core/array.rs
@@ -52,6 +52,12 @@ impl<T, const N: usize> Array<T, N> {
     pub fn as_slice(s: &[T; N]) -> &[T] {
         array_as_slice(s)
     }
+    /// See [`std::array::as_mut_slice`]
+    // Lean-only, like the `IndexMut` impl below that consumes it.
+    #[cfg(not(hax_backend_fstar))]
+    pub fn as_mut_slice(s: &mut [T; N]) -> &mut [T] {
+        array_as_mut_slice(s)
+    }
     /// See [`std::array::each_ref`]
     pub fn each_ref(s: &[T; N]) -> [&T; N] {
         array_from_fn(|i| array_index(s, i))
@@ -87,6 +93,20 @@ where
     type Output = <[T] as Index<I>>::Output;
     fn index(&self, i: I) -> &Self::Output {
         self.as_slice().index(i)
+    }
+}
+
+/// Mirrors the `Index<I>` impl above; without it, writing through a range does
+/// not extract (cryspen/hax#2174). Lean-only, like the slice impl it delegates to.
+#[cfg(not(hax_backend_fstar))]
+#[hax_lib::attributes]
+#[cfg_attr(hax_backend_legacy_lean, hax_lib::exclude)]
+impl<T, I, const N: usize> crate::ops::index::IndexMut<I> for [T; N]
+where
+    [T]: crate::ops::index::IndexMut<I>,
+{
+    fn index_mut(&mut self, i: I) -> &mut Self::Output {
+        <[T] as crate::ops::index::IndexMut<I>>::index_mut(Array::as_mut_slice(self), i)
     }
 }
 
@@ -289,6 +309,16 @@ mod tests {
             );
         }
 
+        #[cfg(not(hax_backend_fstar))]
+        #[test]
+        fn test_as_mut_slice(arr in any::<[u8; 4]>(), idx in 0usize..4, x in any::<u8>()) {
+            let mut model_arr = arr.inject();
+            super::Array::<u8, 4>::as_mut_slice(&mut model_arr)[idx] = x;
+            let mut expected = arr;
+            expected[idx] = x;
+            prop_assert_eq!(model_arr, expected.inject());
+        }
+
         #[test]
         fn test_index_usize(arr in any::<[u8; 4]>(), idx in 0usize..4) {
             let model_arr = arr.inject();
@@ -381,6 +411,26 @@ mod tests {
                 ),
                 &arr[start..end]
             );
+        }
+
+        #[cfg(not(hax_backend_fstar))]
+        #[test]
+        fn test_model_index_mut_range(
+            arr in any::<[u8; 8]>(),
+            start in 0usize..8,
+            len in 0usize..8,
+            fill in any::<u8>(),
+        ) {
+            let end = (start + len).min(8);
+            let mut m = arr.inject();
+            <[u8; 8] as crate::ops::index::IndexMut<crate::ops::range::Range<usize>>>::index_mut(
+                &mut m,
+                crate::ops::range::Range { start, end },
+            )
+            .fill(fill);
+            let mut expected = arr;
+            expected[start..end].fill(fill);
+            prop_assert_eq!(m, expected.inject());
         }
 
         // The F* variant has one `Index` impl per range kind, all going through

--- a/hax-lib/core-models/rust_primitives/src/lib.rs
+++ b/hax-lib/core-models/rust_primitives/src/lib.rs
@@ -52,6 +52,10 @@ pub mod slice {
     pub fn array_as_slice<T, const N: usize>(s: &[T; N]) -> &[T] {
         &s[..]
     }
+    // Lean-only: the F* models lower indexed assignment to `Array.update`.
+    pub fn array_as_mut_slice<T, const N: usize>(s: &mut [T; N]) -> &mut [T] {
+        &mut s[..]
+    }
     pub fn array_slice<T, const N: usize>(a: &[T; N], b: usize, e: usize) -> &[T] {
         &a[b..e]
     }
@@ -365,6 +369,15 @@ mod tests {
             let mut s = super::sequence::seq_create(x, 1);
             super::sequence::seq_to_slice_mut(&mut s)[0] = y;
             prop_assert_eq!(super::sequence::seq_to_slice(&s), &[y][..]);
+        }
+
+        #[test]
+        fn test_array_as_mut_slice(a in any::<[u8; 4]>(), i in 0usize..4, x in any::<u8>()) {
+            let mut model = a;
+            super::slice::array_as_mut_slice(&mut model)[i] = x;
+            let mut expected = a;
+            expected[i] = x;
+            prop_assert_eq!(model, expected);
         }
 
         #[test]

--- a/hax-lib/core-models/tests/client_test/src/lib.rs
+++ b/hax-lib/core-models/tests/client_test/src/lib.rs
@@ -219,6 +219,11 @@ pub fn array_index_val(a: [u32; 4], i: usize) -> u32 {
     a[i]
 }
 
+/// Covers `<[T; N] as IndexMut<Range<usize>>>::index_mut` (cryspen/hax#2174).
+pub fn array_write_range(a: &mut [u8; 8], src: &[u8]) {
+    a[0..src.len()].copy_from_slice(src);
+}
+
 // ----- Slices ---------------------------------------------------------------
 
 pub fn slice_len(x: &[u8]) -> usize {

--- a/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/array.rs
+++ b/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/array.rs
@@ -22,6 +22,45 @@ pub fn test_index_range_to_full() -> bool {
     a[..8] == [1, 2, 3, 4, 5, 6, 7, 8]
 }
 
+// ----- IndexMut --------------------------------------------------------------
+//
+// The write-back offsets of `<[T; N] as IndexMut<I>>::index_mut` (cryspen/hax#2174).
+
+#[rust_lean_test]
+pub fn test_index_mut_range_middle() -> bool {
+    let mut a: [u8; 8] = [0; 8];
+    a[2..5].copy_from_slice(&[7, 8, 9]);
+    a == [0, 0, 7, 8, 9, 0, 0, 0]
+}
+
+#[rust_lean_test]
+pub fn test_index_mut_range_from() -> bool {
+    let mut a: [u8; 4] = [1, 2, 3, 4];
+    a[2..].copy_from_slice(&[9, 9]);
+    a == [1, 2, 9, 9]
+}
+
+#[rust_lean_test]
+pub fn test_index_mut_range_to() -> bool {
+    let mut a: [u8; 4] = [1, 2, 3, 4];
+    a[..2].copy_from_slice(&[9, 9]);
+    a == [9, 9, 3, 4]
+}
+
+#[rust_lean_test]
+pub fn test_index_mut_range_full_reverse() -> bool {
+    let mut a: [u8; 4] = [1, 2, 3, 4];
+    a[..].reverse();
+    a == [4, 3, 2, 1]
+}
+
+#[rust_lean_test]
+pub fn test_index_mut_range_empty_is_noop() -> bool {
+    let mut a: [u8; 4] = [1, 2, 3, 4];
+    a[2..2].copy_from_slice(&[]);
+    a == [1, 2, 3, 4]
+}
+
 // ----- PartialEq -------------------------------------------------------------
 
 #[rust_lean_test]

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -40,8 +40,17 @@ def array.Array.as_slice
   {T : Type} {N : Std.Usize} (s : Array T N) : RustM (Slice T) := do
   rust_primitives.slice.array_as_slice s
 
+/-- [core_models::array::{core_models::array::Array<T, N>}::as_mut_slice]:
+    Source: 'core-models/src/core/array.rs', lines 58:4-60:5
+    Visibility: public -/
+def array.Array.as_mut_slice
+  {T : Type} {N : Std.Usize} (s : Array T N) :
+  RustM ((Slice T) × (Slice T → Array T N))
+  := do
+  rust_primitives.slice.array_as_mut_slice s
+
 /-- [core_models::array::{core_models::array::Array<T, N>}::each_ref::{impl core::ops::function::FnMut<(usize,), &'_ T> for core_models::array::{core_models::array::Array<T, N>}::each_ref::closure<'_0, T, N>}::call_mut]:
-    Source: 'core-models/src/core/array.rs', lines 57:22-57:43 -/
+    Source: 'core-models/src/core/array.rs', lines 63:22-63:43 -/
 def
   array.Array.each_ref.closure.Insts.CoreOpsFunctionFnMutTupleUsizeSharedT.call_mut
   {T : Type} {N : Std.Usize} (c : array.Array.each_ref.closure T N)
@@ -52,7 +61,7 @@ def
   ok (t, c)
 
 /-- [core_models::array::{core_models::array::Array<T, N>}::each_ref::{impl core::ops::function::FnOnce<(usize,), &'_ T> for core_models::array::{core_models::array::Array<T, N>}::each_ref::closure<'_0, T, N>}::call_once]:
-    Source: 'core-models/src/core/array.rs', lines 57:22-57:43 -/
+    Source: 'core-models/src/core/array.rs', lines 63:22-63:43 -/
 def
   array.Array.each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedT.call_once
   {T : Type} {N : Std.Usize} (c : array.Array.each_ref.closure T N)
@@ -65,7 +74,7 @@ def
   ok t
 
 /-- Trait implementation: [core_models::array::{core_models::array::Array<T, N>}::each_ref::{impl core::ops::function::FnOnce<(usize,), &'_ T> for core_models::array::{core_models::array::Array<T, N>}::each_ref::closure<'_0, T, N>}]
-    Source: 'core-models/src/core/array.rs', lines 57:22-57:43 -/
+    Source: 'core-models/src/core/array.rs', lines 63:22-63:43 -/
 @[reducible]
 def array.Array.each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedT
   (T : Type) (N : Std.Usize) : core.ops.function.FnOnce
@@ -75,7 +84,7 @@ def array.Array.each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedT
 }
 
 /-- Trait implementation: [core_models::array::{core_models::array::Array<T, N>}::each_ref::{impl core::ops::function::FnMut<(usize,), &'_ T> for core_models::array::{core_models::array::Array<T, N>}::each_ref::closure<'_0, T, N>}]
-    Source: 'core-models/src/core/array.rs', lines 57:22-57:43 -/
+    Source: 'core-models/src/core/array.rs', lines 63:22-63:43 -/
 @[reducible]
 def array.Array.each_ref.closure.Insts.CoreOpsFunctionFnMutTupleUsizeSharedT (T
   : Type) (N : Std.Usize) : core.ops.function.FnMut
@@ -88,7 +97,7 @@ def array.Array.each_ref.closure.Insts.CoreOpsFunctionFnMutTupleUsizeSharedT (T
 }
 
 /-- [core_models::array::{core_models::array::Array<T, N>}::each_ref]:
-    Source: 'core-models/src/core/array.rs', lines 56:4-58:5
+    Source: 'core-models/src/core/array.rs', lines 62:4-64:5
     Visibility: public -/
 def array.Array.each_ref
   {T : Type} {N : Std.Usize} (s : Array T N) : RustM (Array T N) := do
@@ -97,7 +106,7 @@ def array.Array.each_ref
     N) s
 
 /-- [core_models::array::from_fn]:
-    Source: 'core-models/src/core/array.rs', lines 62:0-64:1
+    Source: 'core-models/src/core/array.rs', lines 68:0-70:1
     Visibility: public -/
 def array.from_fn
   {T : Type} {F : Type} (N : Std.Usize) (coreopsfunctionFnMutFTupleUsizeTInst :
@@ -107,7 +116,7 @@ def array.from_fn
   rust_primitives.slice.array_from_fn N coreopsfunctionFnMutFTupleUsizeTInst f
 
 /-- [core_models::array::{impl core_models::iter::traits::collect::IntoIterator<T, core_models::array::iter::IntoIter<T, N>> for [T; N]}::into_iter]:
-    Source: 'core-models/src/core/array.rs', lines 70:4-72:5
+    Source: 'core-models/src/core/array.rs', lines 76:4-78:5
     Visibility: public -/
 def Array.Insts.CoreIterTraitsCollectIntoIteratorTIntoIter.into_iter
   {T : Type} {N : Std.Usize} (self : Array T N) :
@@ -117,7 +126,7 @@ def Array.Insts.CoreIterTraitsCollectIntoIteratorTIntoIter.into_iter
   ok s
 
 /-- Trait implementation: [core_models::array::{impl core_models::iter::traits::collect::IntoIterator<T, core_models::array::iter::IntoIter<T, N>> for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 67:0-73:1 -/
+    Source: 'core-models/src/core/array.rs', lines 73:0-79:1 -/
 @[reducible]
 def Array.Insts.CoreIterTraitsCollectIntoIteratorTIntoIter (T : Type) (N
   : Std.Usize) : iter.traits.collect.IntoIterator (Array T N) T
@@ -127,7 +136,7 @@ def Array.Insts.CoreIterTraitsCollectIntoIteratorTIntoIter (T : Type) (N
 }
 
 /-- [core_models::array::{impl core_models::ops::index::Index<I, Clause0_Output> for [T; N]}::index]:
-    Source: 'core-models/src/core/array.rs', lines 88:4-90:5
+    Source: 'core-models/src/core/array.rs', lines 94:4-96:5
     Visibility: public -/
 def Array.Insts.CoreOpsIndexIndex.index
   {T : Type} {I : Type} {Clause0_Output : Type} {N : Std.Usize}
@@ -139,7 +148,7 @@ def Array.Insts.CoreOpsIndexIndex.index
   opsindexIndexSliceIClause0_OutputInst.index s i
 
 /-- Trait implementation: [core_models::array::{impl core_models::ops::index::Index<I, Clause0_Output> for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 83:0-91:1 -/
+    Source: 'core-models/src/core/array.rs', lines 89:0-97:1 -/
 @[reducible]
 def Array.Insts.CoreOpsIndexIndex {T : Type} {I : Type} {Clause0_Output
   : Type} (N : Std.Usize) (opsindexIndexSliceIClause0_OutputInst :
@@ -149,8 +158,38 @@ def Array.Insts.CoreOpsIndexIndex {T : Type} {I : Type} {Clause0_Output
     opsindexIndexSliceIClause0_OutputInst
 }
 
+/-- [core_models::array::{impl core_models::ops::index::IndexMut<I, Clause0_Clause0_Output> for [T; N]}::index_mut]:
+    Source: 'core-models/src/core/array.rs', lines 108:4-110:5
+    Visibility: public -/
+def Array.Insts.CoreOpsIndexIndexMut.index_mut
+  {T : Type} {I : Type} {Clause0_Clause0_Output : Type} {N : Std.Usize}
+  (opsindexIndexMutSliceIClause0_Clause0_OutputInst : ops.index.IndexMut (Slice
+  T) I Clause0_Clause0_Output) (self : Array T N) (i : I) :
+  RustM (Clause0_Clause0_Output × (Clause0_Clause0_Output → Array T N))
+  := do
+  let (s, as_mut_slice_back) ← array.Array.as_mut_slice self
+  let (t, index_mut_back) ←
+    opsindexIndexMutSliceIClause0_Clause0_OutputInst.index_mut s i
+  let back := fun t1 => let s1 := index_mut_back t1
+                        as_mut_slice_back s1
+  ok (t, back)
+
+/-- Trait implementation: [core_models::array::{impl core_models::ops::index::IndexMut<I, Clause0_Clause0_Output> for [T; N]}]
+    Source: 'core-models/src/core/array.rs', lines 104:0-111:1 -/
+@[reducible]
+def Array.Insts.CoreOpsIndexIndexMut {T : Type} {I : Type}
+  {Clause0_Clause0_Output : Type} (N : Std.Usize)
+  (opsindexIndexMutSliceIClause0_Clause0_OutputInst : ops.index.IndexMut (Slice
+  T) I Clause0_Clause0_Output) : ops.index.IndexMut (Array T N) I
+  Clause0_Clause0_Output := {
+  IndexInst := Array.Insts.CoreOpsIndexIndex N
+    opsindexIndexMutSliceIClause0_Clause0_OutputInst.IndexInst
+  index_mut := Array.Insts.CoreOpsIndexIndexMut.index_mut
+    opsindexIndexMutSliceIClause0_Clause0_OutputInst
+}
+
 /-- [core_models::array::{impl core_models::clone::Clone for [T; N]}::clone]:
-    Source: 'core-models/src/core/array.rs', lines 147:4-149:5
+    Source: 'core-models/src/core/array.rs', lines 167:4-169:5
     Visibility: public -/
 def Array.Insts.CoreCloneClone.clone
   {T : Type} {N : Std.Usize} (cloneCloneInst : clone.Clone T)
@@ -160,7 +199,7 @@ def Array.Insts.CoreCloneClone.clone
   ok self
 
 /-- Trait implementation: [core_models::array::{impl core_models::clone::Clone for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 146:0-150:1 -/
+    Source: 'core-models/src/core/array.rs', lines 166:0-170:1 -/
 @[reducible]
 def Array.Insts.CoreCloneClone {T : Type} (N : Std.Usize)
   (cloneCloneInst : clone.Clone T) : clone.Clone (Array T N) := {
@@ -168,7 +207,7 @@ def Array.Insts.CoreCloneClone {T : Type} (N : Std.Usize)
 }
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]: loop body 0:
-    Source: 'core-models/src/core/array.rs', lines 163:12-170:9
+    Source: 'core-models/src/core/array.rs', lines 183:12-190:9
     Visibility: public -/
 @[rust_loop_body]
 def Array.Insts.CoreCmpPartialEqArray.eq_loop.body
@@ -188,7 +227,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq_loop.body
   else ok (done true)
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]: loop 0:
-    Source: 'core-models/src/core/array.rs', lines 163:12-170:9
+    Source: 'core-models/src/core/array.rs', lines 183:12-190:9
     Visibility: public -/
 @[rust_loop]
 def Array.Insts.CoreCmpPartialEqArray.eq_loop
@@ -202,7 +241,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq_loop
     i
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::eq]:
-    Source: 'core-models/src/core/array.rs', lines 161:8-170:9
+    Source: 'core-models/src/core/array.rs', lines 181:8-190:9
     Visibility: public -/
 @[reducible]
 def Array.Insts.CoreCmpPartialEqArray.eq
@@ -214,7 +253,7 @@ def Array.Insts.CoreCmpPartialEqArray.eq
     0#usize
 
 /-- [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}::ne]:
-    Source: 'core-models/src/core/array.rs', lines 158:8-160:9
+    Source: 'core-models/src/core/array.rs', lines 178:8-180:9
     Visibility: public -/
 def Array.Insts.CoreCmpPartialEqArray.ne
   {T : Type} {U : Type} {N : Std.Usize} (cmpPartialEqInst : cmp.PartialEq T U)
@@ -226,7 +265,7 @@ def Array.Insts.CoreCmpPartialEqArray.ne
   ok (b = false)
 
 /-- Trait implementation: [core_models::array::equality::{impl core_models::cmp::PartialEq<[U; N]> for [T; N]}]
-    Source: 'core-models/src/core/array.rs', lines 156:4-171:5 -/
+    Source: 'core-models/src/core/array.rs', lines 176:4-191:5 -/
 @[reducible]
 def Array.Insts.CoreCmpPartialEqArray {T : Type} {U : Type} (N :
   Std.Usize) (cmpPartialEqInst : cmp.PartialEq T U) : cmp.PartialEq (Array T N)
@@ -236,7 +275,7 @@ def Array.Insts.CoreCmpPartialEqArray {T : Type} {U : Type} (N :
 }
 
 /-- [core_models::array::iter::{impl core_models::iter::traits::iterator::Iterator<T> for core_models::array::iter::IntoIter<T, N>}::next]:
-    Source: 'core-models/src/core/array.rs', lines 181:8-188:9
+    Source: 'core-models/src/core/array.rs', lines 201:8-208:9
     Visibility: public -/
 def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
   {T : Type} {N : Std.Usize} (self : array.iter.IntoIter T N) :
@@ -250,7 +289,7 @@ def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
     ok (option.Option.Some res, s)
 
 /-- Trait implementation: [core_models::array::iter::{impl core_models::iter::traits::iterator::Iterator<T> for core_models::array::iter::IntoIter<T, N>}]
-    Source: 'core-models/src/core/array.rs', lines 179:4-189:5 -/
+    Source: 'core-models/src/core/array.rs', lines 199:4-209:5 -/
 @[reducible]
 def array.iter.IntoIter.Insts.CoreIterTraitsIteratorIterator (T : Type)
   (N : Std.Usize) : iter.traits.iterator.Iterator (array.iter.IntoIter T N) T

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -34,7 +34,7 @@ def array.Array (T : Type) (N : Std.Usize) := Array T N
 -/
 
 /-- [core_models::array::{core_models::array::Array<T, N>}::each_ref::closure]
-    Source: 'core-models/src/core/array.rs', lines 57:22-57:43 -/
+    Source: 'core-models/src/core/array.rs', lines 63:22-63:43 -/
 @[reducible]
 def array.Array.each_ref.closure (T : Type) (N : Std.Usize) := Array T N
 
@@ -46,7 +46,7 @@ structure iter.traits.collect.IntoIterator (Self : Type) (Self_Item : Type)
   into_iter : Self → RustM Self_IntoIter
 
 /-- [core_models::array::iter::IntoIter]
-    Source: 'core-models/src/core/array.rs', lines 177:4-177:55
+    Source: 'core-models/src/core/array.rs', lines 197:4-197:55
     Visibility: public -/
 @[reducible]
 def array.iter.IntoIter (T : Type) (N : Std.Usize) :=
@@ -57,6 +57,15 @@ def array.iter.IntoIter (T : Type) (N : Std.Usize) :=
     Visibility: public -/
 structure ops.index.Index (Self : Type) (Idx : Type) (Self_Output : Type) where
   index : Self → Idx → RustM Self_Output
+
+/-- Trait declaration: [core_models::ops::index::IndexMut]
+    Source: 'core-models/src/core/ops.rs', lines 155:4-157:5
+    Visibility: public -/
+structure ops.index.IndexMut (Self : Type) (Idx : Type) (Self_Clause0_Output :
+  Type) where
+  IndexInst : ops.index.Index Self Idx Self_Clause0_Output
+  index_mut : Self → Idx → RustM (Self_Clause0_Output ×
+    (Self_Clause0_Output → Self))
 
 /-- Trait declaration: [core_models::clone::Clone]
     Source: 'core-models/src/core/clone.rs', lines 13:0-16:1
@@ -707,15 +716,6 @@ structure ops.bit.BitOrAssign (Self : Type) (Rhs : Type) where
 inductive ops.control_flow.ControlFlow (B : Type) (C : Type) where
 | Continue : C → ops.control_flow.ControlFlow B C
 | Break : B → ops.control_flow.ControlFlow B C
-
-/-- Trait declaration: [core_models::ops::index::IndexMut]
-    Source: 'core-models/src/core/ops.rs', lines 155:4-157:5
-    Visibility: public -/
-structure ops.index.IndexMut (Self : Type) (Idx : Type) (Self_Clause0_Output :
-  Type) where
-  IndexInst : ops.index.Index Self Idx Self_Clause0_Output
-  index_mut : Self → Idx → RustM (Self_Clause0_Output ×
-    (Self_Clause0_Output → Self))
 
 /-
 /-- Trait declaration: [core_models::ops::function::FnOnce]

--- a/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
@@ -183,6 +183,14 @@ def rust_primitives.slice.array_as_slice
   {T : Type} {N : Std.Usize} : Array T N → RustM (Slice T) :=
   fun a => ok (Array.to_slice a)
 
+/-- [rust_primitives::slice::array_as_mut_slice]: `&mut a[..]` as a slice plus
+    its write-back. -/
+@[spec]
+def rust_primitives.slice.array_as_mut_slice
+  {T : Type} {N : Std.Usize} :
+  Array T N → RustM ((Slice T) × (Slice T → Array T N)) :=
+  fun a => ok (Array.to_slice_mut a)
+
 @[spec]
 def rust_primitives.slice.array_slice
   {T : Type} {N : Std.Usize} :

--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "hax"
-version = "0.3.12"
+version = "0.3.13"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
Fixes #2174

The F* backend rewrites array updates with a custom mechanism so we never needed this impl before. This should allow to work with array updates in lean as well, through a core-models impl.