### PR TITLE
fix: swap order of mutable args in postconditions for lean backend

### DIFF
--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -444,13 +444,18 @@ pub fn run(
     // crates with `--cfg hax` too, so hax-lib macros expand consistently. `--cfg
     // charon` additionally makes them emit charon's own `charon::opaque`/`exclude`
     // markers: this lane bypasses the engine, so those are how a `hax_lib::opaque`
-    // reaches aeneas.
+    // reaches aeneas. `--cfg hax_backend_lean` has to be repeated here, on the host
+    // build: the `--rustc-arg` above only reaches the crate charon instruments, and
+    // the macros need the flag at expansion time to pick the postcondition argument
+    // order. Aeneas returns `(result, mutated borrows...)` where the engine returns
+    // `(mutated args..., result)`, so the tuple the generated `ensures` function
+    // takes is ordered to match whichever lane consumes it.
     charon_cmd.args([
         "--",
         "-Zhost-config",
         "-Ztarget-applies-to-host",
         "--config",
-        r#"host.rustflags=["--cfg","hax","--cfg","charon"]"#,
+        r#"host.rustflags=["--cfg","hax","--cfg","charon","--cfg","hax_backend_lean"]"#,
     ]);
     // Register the tool-attribute namespaces through `RUSTFLAGS`, which cargo applies
     // to every target crate. `--rustc-arg` only reaches the crate charon instruments,

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -440,16 +440,7 @@ pub fn run(
     // User-supplied charon flags go before the `--` cargo separator.
     charon_cmd.args(&selection_flags);
     charon_cmd.args(&user_charon_args);
-    // Everything after `--` is forwarded to cargo: build the host (proc-macro)
-    // crates with `--cfg hax` too, so hax-lib macros expand consistently. `--cfg
-    // charon` additionally makes them emit charon's own `charon::opaque`/`exclude`
-    // markers: this lane bypasses the engine, so those are how a `hax_lib::opaque`
-    // reaches aeneas. `--cfg hax_backend_lean` has to be repeated here, on the host
-    // build: the `--rustc-arg` above only reaches the crate charon instruments, and
-    // the macros need the flag at expansion time to pick the postcondition argument
-    // order. Aeneas returns `(result, mutated borrows...)` where the engine returns
-    // `(mutated args..., result)`, so the tuple the generated `ensures` function
-    // takes is ordered to match whichever lane consumes it.
+    // Extra flags that charon will forward to cargo. Meant mostly for `hax_lib`.
     charon_cmd.args([
         "--",
         "-Zhost-config",

--- a/hax-lib/macros/Cargo.toml
+++ b/hax-lib/macros/Cargo.toml
@@ -25,4 +25,4 @@ quote = { workspace = true }
 hax-lib = { path = ".." }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(charon)', 'cfg(doc_cfg)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(charon)', 'cfg(hax_backend_lean)', 'cfg(doc_cfg)'] }

--- a/hax-lib/macros/src/lib.rs
+++ b/hax-lib/macros/src/lib.rs
@@ -255,6 +255,9 @@ attribute_macros! {
     /// In the case of a function that has one or more `&mut` inputs, in
     /// the `ensures` clause, you can refer to such an `&mut` input `x` as
     /// `x` for its "past" value and `future(x)` for its "future" value.
+    /// Where those future values sit relative to the result in the generated
+    /// postcondition is backend-dependent, since each backend orders the tuple
+    /// its functions return differently.
     ///
     /// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
     /// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -137,6 +137,15 @@ pub(crate) fn charon_attr(name: TokenStream) -> Option<TokenStream> {
     cfg!(charon).then(|| quote! {#[charon::#name]})
 }
 
+/// Whether the future arguments of a postcondition come after the result binder
+/// instead of before it. The aeneas/lean lane returns `(result, &mut args...)` while
+/// the engine lanes return `(&mut args..., result)`; the lean backend is the only one
+/// to set `cfg(hax_backend_lean)` on this crate's build (see `host.rustflags` in
+/// `cli/cargo-hax/src/aeneas.rs`).
+pub(crate) fn future_args_last() -> bool {
+    cfg!(hax_backend_lean)
+}
+
 /// Merge two `syn::Generics`, respecting lifetime orders
 pub(crate) fn merge_generics(x: Generics, y: Generics) -> Generics {
     Generics {
@@ -429,8 +438,13 @@ pub fn make_fn_decoration(
                 };
 
                 if !is_output_typ_unit || pats.is_empty() {
-                    pats.push(ret_binder.to_token_stream());
-                    tys.push(quote! {#output_typ});
+                    if future_args_last() {
+                        pats.insert(0, ret_binder.to_token_stream());
+                        tys.insert(0, quote! {#output_typ});
+                    } else {
+                        pats.push(ret_binder.to_token_stream());
+                        tys.push(quote! {#output_typ});
+                    }
                 }
 
                 sig.inputs

--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -137,11 +137,9 @@ pub(crate) fn charon_attr(name: TokenStream) -> Option<TokenStream> {
     cfg!(charon).then(|| quote! {#[charon::#name]})
 }
 
-/// Whether the future arguments of a postcondition come after the result binder
-/// instead of before it. The aeneas/lean lane returns `(result, &mut args...)` while
-/// the engine lanes return `(&mut args..., result)`; the lean backend is the only one
-/// to set `cfg(hax_backend_lean)` on this crate's build (see `host.rustflags` in
-/// `cli/cargo-hax/src/aeneas.rs`).
+/// Whether the future value of mutable arguments (used by postconditions) come before or after the
+/// result binder. The legacy engine expect future values before the return one, while the aeneas
+/// engine expects the opposite.
 pub(crate) fn future_args_last() -> bool {
     cfg!(hax_backend_lean)
 }


### PR DESCRIPTION
hax_lib and aeneas have different conventions for returning the future value of mutable arguments (`hax_lib`: future values before the return value, `aeneas`: future values after the return value). This commit makes the swap when the lean backend is selected, via the `hax_backend_lean` cfg flag.

It's not end-to-end tested on CI, because all tests on the lean backend are disabled for now.

(Note: the name `hax_backend_lean` for the cfg was also suggested in #2183, but this PR does not remove the `charon` cfg.)

Fixes #2175, https://github.com/cryspen/aeneas/issues/16
*AI-assisted*
[skip changelog]