### PR TITLE
fix(cli): harden extraction integrity in the driver channel and the lean pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Changes to cargo-hax:
  - Add proof scenarios: named extraction configurations committed as `[scenario.<name>]` tables in
    `hax.toml`, run with the new `cargo hax extract [NAME]...` subcommand into per-scenario
    `proofs/<scenario>/<backend>/` directories
+ - Validate driver reports on cargo's stderr: only haxmeta files of workspace crates under the
+   run's target directory are accepted, and a lost or partial report set fails the run instead
+   of silently producing an incomplete extraction
 
 Changes to the hax-lib crate:
  - Remove dependency to proc_macro_error2 (unmaintained) (#2039)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes to cargo-hax:
  - Validate driver reports on cargo's stderr: only haxmeta files of workspace crates under the
    run's target directory are accepted, and a lost or partial report set fails the run instead
    of silently producing an incomplete extraction
+ - Exit with a failing status whenever an error was reported
 
 Changes to the hax-lib crate:
  - Remove dependency to proc_macro_error2 (unmaintained) (#2039)

--- a/cli/cargo-hax/src/aeneas.rs
+++ b/cli/cargo-hax/src/aeneas.rs
@@ -19,8 +19,11 @@ pub(crate) mod package;
 
 const BACKEND_DIR: &str = "lean";
 
-// Flags that should trigger a warning when passed to charon/aeneas
-const CHARON_WARN_FLAGS: &[&str] = &["--dest-file"];
+// Charon flags that are rejected when passed by the user: aeneas is always
+// run on the LLBC file hax chooses, so redirecting charon's output severs
+// the charon→aeneas handoff.
+const CHARON_RESERVED_FLAGS: &[&str] = &["--dest-file"];
+// Aeneas flags that trigger a warning when passed by the user.
 const AENEAS_WARN_FLAGS: &[&str] = &["-backend", "-dest", "-subdir", "-split-files"];
 
 /// Shell-split a user-supplied extra-args string, reporting a fatal error on
@@ -71,21 +74,21 @@ fn args_source(
     }
 }
 
-/// Warn if the extra args (the scenario's `<tool>-args` key or the
+/// Warn if the extra aeneas args (the scenario's `<tool>-args` key or the
 /// `--<tool>-args` flag) re-specify a flag that the pipeline already sets
 /// and relies on (e.g. those controlling where output is written). Such
 /// flags are still forwarded (the tools keep the last occurrence), but
-/// overriding them can break the charon→aeneas handoff or the layout the
-/// generated proof project assumes.
-fn warn_on_reserved_flags(
+/// overriding them can break the layout the generated proof project
+/// assumes.
+fn warn_on_overridden_pipeline_flags(
     scenario_args: &[String],
     cli_args: &[String],
-    reserved: &[&str],
+    pipeline_flags: &[&str],
     tool: &str,
     message_format: MessageFormat,
 ) {
     let combined: Vec<String> = scenario_args.iter().chain(cli_args).cloned().collect();
-    let overridden = overridden_flags(&combined, reserved);
+    let overridden = overridden_flags(&combined, pipeline_flags);
     if !overridden.is_empty() {
         HaxMessage::GenericWarning {
             message: format!(
@@ -399,6 +402,50 @@ pub fn run(
         crate_name.as_deref().unwrap_or("output").replace('-', "_")
     ));
 
+    // Parse once so we can both inspect and forward the user's charon flags.
+    // Rejected before anything is deleted or run, so a pure usage error
+    // leaves the previous run's artifacts intact.
+    let scenario_charon_args = &options.scenario.charon_args;
+    let cli_charon_args = shell_split(options.charon_args.as_deref(), "charon", message_format);
+    let mut user_charon_args = scenario_charon_args.clone();
+    user_charon_args.extend(cli_charon_args.iter().cloned());
+    let reserved_charon_flags = overridden_flags(&user_charon_args, CHARON_RESERVED_FLAGS);
+    if !reserved_charon_flags.is_empty() {
+        HaxMessage::GenericError {
+            message: format!(
+                "{} overrides {}, which hax reserves: aeneas is always run on the \
+                 LLBC file hax chooses, so redirecting charon's output would make \
+                 the extraction read a stale or missing file",
+                args_source(
+                    scenario_charon_args,
+                    &cli_charon_args,
+                    &reserved_charon_flags,
+                    "charon"
+                ),
+                reserved_charon_flags.join(" and ")
+            ),
+        }
+        .report(message_format, None);
+        return true;
+    }
+
+    // The charon→aeneas handoff is this file: remove any LLBC a previous run
+    // left, so a charon run that produces none is caught by the existence
+    // check below instead of feeding aeneas stale code.
+    if let Err(e) = fs::remove_file(&llbc_file)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        HaxMessage::GenericError {
+            message: format!(
+                "failed to remove the previous LLBC file {}: {}",
+                llbc_file.display(),
+                e
+            ),
+        }
+        .report(message_format, None);
+        return true;
+    }
+
     // Running charon
 
     HaxMessage::Step {
@@ -406,20 +453,6 @@ pub fn run(
         target: "charon".to_string(),
     }
     .report(message_format, None);
-
-    // Parse once so we can both inspect and forward the user's charon flags.
-    // `--dest-file` is reserved: its value is fed verbatim to aeneas below.
-    let scenario_charon_args = &options.scenario.charon_args;
-    let cli_charon_args = shell_split(options.charon_args.as_deref(), "charon", message_format);
-    let mut user_charon_args = scenario_charon_args.clone();
-    user_charon_args.extend(cli_charon_args.iter().cloned());
-    warn_on_reserved_flags(
-        scenario_charon_args,
-        &cli_charon_args,
-        CHARON_WARN_FLAGS,
-        "charon",
-        message_format,
-    );
     // The unified item-selection keys, compiled to charon's selection
     // flags; the verbatim extra arguments follow them.
     let selection_flags = options.scenario.selection_flags();
@@ -497,6 +530,19 @@ pub fn run(
         }
     }
 
+    // The file was removed above, so its presence proves this charon run
+    // wrote it.
+    if !llbc_file.is_file() {
+        HaxMessage::GenericError {
+            message: format!(
+                "charon exited successfully but did not produce {}",
+                llbc_file.display()
+            ),
+        }
+        .report(message_format, None);
+        return true;
+    }
+
     // Running Aeneas
 
     // The output-layout flags are reserved: overriding them moves the output
@@ -508,7 +554,7 @@ pub fn run(
         .copied()
         .filter(|flag| !(layout_warned && matches!(*flag, "-dest" | "-subdir")))
         .collect();
-    warn_on_reserved_flags(
+    warn_on_overridden_pipeline_flags(
         scenario_aeneas_args,
         &cli_aeneas_args,
         &aeneas_warn_flags,

--- a/cli/cargo-hax/src/cargo_hax.rs
+++ b/cli/cargo-hax/src/cargo_hax.rs
@@ -762,6 +762,17 @@ fn run_command(options: &Options, haxmeta_files: Vec<EmitHaxMetaMessage>) -> boo
     }
 }
 
+/// Exits the process, downgrading a successful code to a failure when an
+/// error-severity message was reported: a reported error and a zero exit
+/// status must never combine. Every exit path that can carry code 0 goes
+/// through here.
+fn exit(code: i32) -> ! {
+    if code == 0 && hax_types::diagnostics::message::errors_reported() {
+        std::process::exit(1)
+    }
+    std::process::exit(code)
+}
+
 fn main() {
     let args: Vec<String> = get_args("hax");
     let mut options = match &args[..] {
@@ -786,7 +797,7 @@ fn main() {
     // The `tools` subcommands never involve the hax frontend: handle them
     // directly and exit.
     if let Command::Tools(ref command) = options.command {
-        std::process::exit(tools::run(command, options.message_format));
+        exit(tools::run(command, options.message_format));
     }
 
     // `extract` resolves the proof scenarios of the project and re-enters
@@ -800,7 +811,7 @@ fn main() {
         ref hermeticity,
     } = options.command
     {
-        std::process::exit(scenario::run(
+        exit(scenario::run(
             names,
             packages,
             &options.cargo_flags,
@@ -875,7 +886,7 @@ fn main() {
             options.message_format,
             project,
         );
-        std::process::exit(if error { 1 } else { 0 });
+        exit(if error { 1 } else { 0 });
     }
 
     let (haxmeta_files, exit_code) = options
@@ -894,7 +905,7 @@ fn main() {
         .unwrap_or_else(|| compute_haxmeta_files(&options));
     let error = run_command(&options, haxmeta_files);
 
-    std::process::exit(if exit_code == 0 && error {
+    exit(if exit_code == 0 && error {
         1
     } else {
         exit_code

--- a/cli/cargo-hax/src/cargo_hax.rs
+++ b/cli/cargo-hax/src/cargo_hax.rs
@@ -6,11 +6,11 @@ use hax_types::driver_api::*;
 use hax_types::engine_api::*;
 use is_terminal::IsTerminal;
 use serde_jsonlines::BufReadExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::BufRead;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 mod aeneas;
@@ -373,14 +373,6 @@ fn run_engine(
     error
 }
 
-/// Uses `cargo metadata` to compute a derived target directory.
-fn target_dir(suffix: &str) -> PathBuf {
-    let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
-    let mut dir = metadata.target_directory;
-    dir.push(suffix);
-    dir.into()
-}
-
 /// Gets hax version: if hax is being compiled from a dirty git repo,
 /// then this function taints the hax version with the hash of the
 /// current executable. This makes sure cargo doesn't cache across
@@ -433,6 +425,49 @@ fn get_hax_rustc_driver_path(message_format: MessageFormat) -> PathBuf {
     path
 }
 
+/// Parses and validates one `::hax-driver::`-prefixed line from cargo's
+/// stderr. That stream is shared with everything the build runs (proc
+/// macros, build scripts), so a report is only accepted when it names a
+/// `.haxmeta` file of a workspace crate under this run's target directory
+/// (`target_dir` must be canonical); anything else is an error, never a
+/// trusted input or a panic.
+fn accept_driver_message(
+    msg: &str,
+    target_dir: &Path,
+    workspace_crates: &HashSet<String>,
+) -> Result<EmitHaxMetaMessage, String> {
+    let msg: HaxDriverMessage = serde_json::from_str(msg)
+        .map_err(|e| format!("malformed hax driver message on cargo's stderr: {e}"))?;
+    let HaxDriverMessage::EmitHaxMeta(data) = msg;
+    let path = data.path.canonicalize().map_err(|e| {
+        format!(
+            "hax driver message names an unreadable haxmeta file {}: {e}",
+            data.path.display()
+        )
+    })?;
+    if !path.starts_with(target_dir) {
+        return Err(format!(
+            "hax driver message names a haxmeta file outside the target directory {}: {}",
+            target_dir.display(),
+            path.display()
+        ));
+    }
+    // The driver names its output `<crate_name>-<cg_metadata>.haxmeta`.
+    let crate_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_suffix(".haxmeta"))
+        .and_then(|stem| stem.rsplit_once('-'))
+        .map(|(crate_name, _cg_metadata)| crate_name);
+    match crate_name {
+        Some(name) if workspace_crates.contains(name) => Ok(data),
+        _ => Err(format!(
+            "hax driver message names a haxmeta file that belongs to no workspace crate: {}",
+            path.display()
+        )),
+    }
+}
+
 /// Calls `cargo` with a custom driver which computes `haxmeta` files
 /// in `TARGET`. One `haxmeta` file is produced by crate. Each
 /// `haxmeta` file contains the full AST of one crate.
@@ -441,6 +476,62 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
     // Resolved before anything else, so that a missing driver is reported
     // instead of installing a toolchain for a run that cannot happen.
     let driver = get_hax_rustc_driver_path(options.message_format);
+    // `cargo metadata` yields both the target directory the driver writes
+    // into and the workspace members, the two facts the driver's reports
+    // are validated against. It gets the `-C ... ;` flags it understands
+    // (`--manifest-path`, feature selection, ...), so that it describes the
+    // same workspace as the `cargo check` below.
+    let cargo_args = tools::project::CargoArgs::parse(&options.cargo_flags);
+    let report_error_and_abort = |message: String| {
+        HaxMessage::GenericError { message }.report(options.message_format, None);
+        (vec![], 1)
+    };
+    let metadata = match tools::project::run_cargo_metadata(&cargo_args, tools::project::Deps::Skip)
+    {
+        Ok(metadata) => metadata,
+        Err(message) => return report_error_and_abort(message),
+    };
+    // An explicit `--target-dir` among the cargo flags beats the
+    // `CARGO_TARGET_DIR` environment variable, so when one is given the
+    // build writes there verbatim and no `hax` subdirectory can be imposed.
+    let (target_dir, custom_target_dir) = match &cargo_args.target_dir {
+        Some(dir) => (PathBuf::from(dir), false),
+        None => {
+            let mut dir: PathBuf = metadata.target_directory.clone().into();
+            if !options.no_custom_target_directory {
+                dir.push("hax");
+            }
+            (dir, !options.no_custom_target_directory)
+        }
+    };
+    // The driver's reports are matched against the canonical target
+    // directory, resolved once here. It is created first: on a fresh
+    // project no build has made it yet, and canonicalization needs an
+    // existing path.
+    if let Err(e) = fs::create_dir_all(&target_dir) {
+        return report_error_and_abort(format!(
+            "could not create the target directory {}: {e}",
+            target_dir.display()
+        ));
+    }
+    let target_dir = match target_dir.canonicalize() {
+        Ok(dir) => dir,
+        Err(e) => {
+            return report_error_and_abort(format!(
+                "could not resolve the target directory {}: {e}",
+                target_dir.display()
+            ));
+        }
+    };
+    // The driver names its haxmeta file after the rustc crate it compiled,
+    // i.e. after the cargo target (lib, bins, ...), not after the package.
+    let workspace_crates: HashSet<String> = metadata
+        .packages
+        .iter()
+        .filter(|package| metadata.workspace_members.contains(&package.id))
+        .flat_map(|package| &package.targets)
+        .map(|target| target.name.replace('-', "_"))
+        .collect();
     let mut cmd = {
         let mut cmd = process::Command::new("cargo");
         if let Some(toolchain) = toolchain() {
@@ -458,8 +549,8 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
             cmd.args([MSG_FMT_FLAG, "json"]);
         }
         cmd.stderr(std::process::Stdio::piped());
-        if !options.no_custom_target_directory {
-            cmd.env("CARGO_TARGET_DIR", target_dir("hax"));
+        if custom_target_dir {
+            cmd.env("CARGO_TARGET_DIR", &target_dir);
         };
         cmd.env("RUSTC_WORKSPACE_WRAPPER", driver)
             .env(RUST_LOG_STYLE, rust_log_style())
@@ -474,16 +565,42 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
     };
 
     let mut child = cmd.spawn().unwrap();
-    let haxmeta_files = {
+    let mut channel_error = false;
+    let mut haxmeta_files = {
         let mut haxmeta_files = vec![];
         let stderr = child.stderr.take().unwrap();
         let stderr = std::io::BufReader::new(stderr);
-        for line in std::io::BufReader::new(stderr).lines().flatten() {
+        for line in std::io::BufReader::new(stderr).lines() {
+            let line = match line {
+                Ok(line) => line,
+                // A line the channel cannot represent (e.g. invalid UTF-8)
+                // could hide a driver report: fail rather than risk a
+                // silently incomplete extraction. The stream is still
+                // drained, so the build is not blocked on a full pipe.
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                    HaxMessage::GenericError {
+                        message: format!("unreadable line on cargo's stderr: {e}"),
+                    }
+                    .report(options.message_format, None);
+                    channel_error = true;
+                    continue;
+                }
+                Err(e) => {
+                    HaxMessage::GenericError {
+                        message: format!("could not read cargo's stderr: {e}"),
+                    }
+                    .report(options.message_format, None);
+                    channel_error = true;
+                    break;
+                }
+            };
             if let Some(msg) = line.strip_prefix(HAX_DRIVER_STDERR_PREFIX) {
-                use HaxDriverMessage;
-                let msg = serde_json::from_str(msg).unwrap();
-                match msg {
-                    HaxDriverMessage::EmitHaxMeta(data) => haxmeta_files.push(data),
+                match accept_driver_message(msg, &target_dir, &workspace_crates) {
+                    Ok(data) => haxmeta_files.push(data),
+                    Err(message) => {
+                        HaxMessage::GenericError { message }.report(options.message_format, None);
+                        channel_error = true;
+                    }
                 }
             } else {
                 eprintln!("{}", line);
@@ -496,9 +613,25 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
         .wait()
         .expect("`driver-hax-frontend-exporter`: could not start?");
 
+    // A corrupt driver channel makes the collected set untrustworthy:
+    // producing output from it would overwrite a previous good extraction
+    // with a possibly truncated one.
+    if channel_error {
+        haxmeta_files.clear();
+    }
     let exit_code = if !status.success() {
         HaxMessage::CargoBuildFailure.report(options.message_format, None);
         status.code().unwrap_or(254)
+    } else if channel_error {
+        1
+    } else if haxmeta_files.is_empty() {
+        HaxMessage::GenericError {
+            message: "the build succeeded, but the hax driver reported no haxmeta file: \
+                      the extraction would be empty"
+                .into(),
+        }
+        .report(options.message_format, None);
+        1
     } else {
         0
     };
@@ -766,4 +899,51 @@ fn main() {
     } else {
         exit_code
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> HashSet<String> {
+        HashSet::from(["my_crate".to_string()])
+    }
+
+    fn message_for(path: &Path) -> String {
+        serde_json::to_string(&HaxDriverMessage::EmitHaxMeta(EmitHaxMetaMessage {
+            working_dir: None,
+            manifest_dir: None,
+            path: path.to_path_buf(),
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn a_marker_line_from_a_compiled_crate_cannot_inject_a_haxmeta() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        // The caller hands the function a canonical target directory.
+        let target = target.canonicalize().unwrap();
+
+        // A well-formed report for a file outside the target directory.
+        let outside = dir.path().join("my_crate-0123456789abcdef.haxmeta");
+        std::fs::write(&outside, b"").unwrap();
+        assert!(accept_driver_message(&message_for(&outside), &target, &workspace()).is_err());
+
+        // A well-formed report under the target directory for a crate that
+        // is no workspace member.
+        let foreign = target.join("victim-0123456789abcdef.haxmeta");
+        std::fs::write(&foreign, b"").unwrap();
+        assert!(accept_driver_message(&message_for(&foreign), &target, &workspace()).is_err());
+
+        // A marker-prefixed line that is not a driver message is an error,
+        // not a panic.
+        assert!(accept_driver_message("not json", &target, &workspace()).is_err());
+
+        // The driver's own report is accepted.
+        let legit = target.join("my_crate-0123456789abcdef.haxmeta");
+        std::fs::write(&legit, b"").unwrap();
+        assert!(accept_driver_message(&message_for(&legit), &target, &workspace()).is_ok());
+    }
 }

--- a/cli/cargo-hax/src/tools/project.rs
+++ b/cli/cargo-hax/src/tools/project.rs
@@ -18,10 +18,13 @@ use super::config::{self, HaxToml, ScenarioEntry};
 /// manifest and which crates a run processes. Everything else in
 /// `-C ... ;` is `cargo check`'s business alone.
 #[derive(Debug, Default)]
-struct CargoArgs {
+pub(crate) struct CargoArgs {
     /// `--manifest-path`, verbatim (Cargo resolves a relative value
     /// against the invocation directory, and so does `cargo metadata`).
     manifest_path: Option<String>,
+    /// `--target-dir`, verbatim. It beats the `CARGO_TARGET_DIR`
+    /// environment variable, so a run that passes it builds there.
+    pub(crate) target_dir: Option<String>,
     /// The `-p`/`--package` values, verbatim. A value that names a
     /// workspace member lets the `hax-lib` gate check exactly the selected
     /// crates; any other spec form (paths, globs, `name@version`) is
@@ -40,7 +43,7 @@ struct CargoArgs {
 }
 
 impl CargoArgs {
-    fn parse(flags: &[String]) -> Self {
+    pub(crate) fn parse(flags: &[String]) -> Self {
         const FORWARDED: &[&str] = &[
             "--offline",
             "--locked",
@@ -62,6 +65,10 @@ impl CargoArgs {
                 args.manifest_path = flags.next().cloned();
             } else if let Some(path) = flag.strip_prefix("--manifest-path=") {
                 args.manifest_path = Some(path.to_string());
+            } else if flag == "--target-dir" {
+                args.target_dir = flags.next().cloned();
+            } else if let Some(path) = flag.strip_prefix("--target-dir=") {
+                args.target_dir = Some(path.to_string());
             } else if flag == "-p" || flag == "--package" {
                 if let Some(spec) = flags.next() {
                     args.package_specs.push(spec.clone());
@@ -432,13 +439,16 @@ impl ProjectContext {
 /// dependency resolution, which needs neither the network nor a resolvable
 /// dependency set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Deps {
+pub(crate) enum Deps {
     Resolve,
     Skip,
 }
 
 /// Run `cargo metadata` for the project of the invocation directory.
-fn run_cargo_metadata(args: &CargoArgs, deps: Deps) -> Result<cargo_metadata::Metadata, String> {
+pub(crate) fn run_cargo_metadata(
+    args: &CargoArgs,
+    deps: Deps,
+) -> Result<cargo_metadata::Metadata, String> {
     let mut command = cargo_metadata::MetadataCommand::new();
     if let Some(path) = &args.manifest_path {
         command.manifest_path(path);
@@ -548,6 +558,18 @@ mod tests {
             assert_eq!(args.manifest_path.as_deref(), Some("../a/Cargo.toml"));
             assert!(!args.selects_packages());
         }
+    }
+
+    #[test]
+    fn the_target_dir_is_read_in_both_spellings() {
+        for flags in [
+            vec!["--target-dir", "../build"],
+            vec!["--target-dir=../build"],
+        ] {
+            assert_eq!(parse(&flags).target_dir.as_deref(), Some("../build"));
+        }
+        // Arguments past a bare `--` are rustc's.
+        assert_eq!(parse(&["--", "--target-dir", "../build"]).target_dir, None);
     }
 
     #[test]

--- a/cli/cargo-hax/tests/common.rs
+++ b/cli/cargo-hax/tests/common.rs
@@ -148,10 +148,25 @@ pub fn path_entries(bin: &Path) -> String {
     )
 }
 
+/// A shell fragment that writes an empty file at the `--dest-file`
+/// argument, satisfying the pipeline's check that charon produced its LLBC
+/// file.
+pub const WRITE_DEST_FILE: &str = "prev=''\n\
+    for arg in \"$@\"; do\n\
+    \tif [ \"$prev\" = '--dest-file' ]; then : > \"$arg\"; fi\n\
+    \tprev=\"$arg\"\n\
+    done\n";
+
+/// A charon stub: records its invocation in the working directory like
+/// [`stub`] and writes an empty LLBC file at its `--dest-file` argument.
+pub fn charon_stub() -> String {
+    format!("#!/bin/sh\necho \"$@\" > charon-invoked\n{WRITE_DEST_FILE}exit 0\n")
+}
+
 /// Stub executables for the whole pipeline in `bin`: marker-recording
 /// charon and charon-driver stubs, and `aeneas_stub` as aeneas.
 pub fn stub_pipeline_tools(bin: &Path, aeneas_stub: &str) {
-    write_executable(&bin.join("charon"), &stub("charon-invoked"));
+    write_executable(&bin.join("charon"), &charon_stub());
     write_executable(&bin.join("charon-driver"), &stub("driver-invoked"));
     write_executable(&bin.join("aeneas"), aeneas_stub);
 }

--- a/cli/cargo-hax/tests/scenarios.rs
+++ b/cli/cargo-hax/tests/scenarios.rs
@@ -7,18 +7,23 @@ mod common;
 
 use std::path::Path;
 
-/// A charon stub that records its invocation and fails when the
-/// environment says so, to exercise per-scenario `env` and the failure
-/// summary.
-const CHARON_STUB: &str = "#!/bin/sh\n\
-    if [ -n \"$SCENARIO_FAIL\" ]; then exit 1; fi\n\
-    echo \"$@\" > charon-invoked\n\
-    exit 0\n";
+/// A charon stub that records its invocation, writes its LLBC file, and
+/// fails when the environment says so, to exercise per-scenario `env` and
+/// the failure summary.
+fn charon_stub() -> String {
+    format!(
+        "#!/bin/sh\n\
+         if [ -n \"$SCENARIO_FAIL\" ]; then exit 1; fi\n\
+         echo \"$@\" > charon-invoked\n\
+         {}exit 0\n",
+        common::WRITE_DEST_FILE
+    )
+}
 
 /// The stub pipeline, with a charon that honors `$SCENARIO_FAIL`.
 fn stub_tools(bin: &Path) {
     common::stub_pipeline_tools(bin, &common::stub("aeneas-invoked"));
-    common::write_executable(&bin.join("charon"), CHARON_STUB);
+    common::write_executable(&bin.join("charon"), &charon_stub());
 }
 
 /// A crate with stub tools and the given extra `hax.toml` contents.

--- a/cli/cargo-hax/tests/tools_pipeline.rs
+++ b/cli/cargo-hax/tests/tools_pipeline.rs
@@ -47,6 +47,55 @@ fn path_entry_runs_the_supplied_binaries_with_a_notice() {
 }
 
 #[test]
+fn a_charon_run_that_produced_no_llbc_must_not_extract_from_a_stale_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let crate_dir = dir.path().join("crate");
+    write_crate(&crate_dir);
+    let bin = dir.path().join("bin");
+    stub_pipeline_tools(&bin, &stub("aeneas-invoked"));
+    // A charon that exits 0 without writing its `--dest-file`.
+    common::write_executable(&bin.join("charon"), &stub("charon-invoked"));
+    write_path_entries(&crate_dir, &bin);
+    // An LLBC file left by an earlier run.
+    let llbc = crate_dir.join("proofs/lean/llbc/fixture.llbc");
+    std::fs::create_dir_all(llbc.parent().unwrap()).unwrap();
+    std::fs::write(&llbc, "stale").unwrap();
+
+    let (output, success) = run_backend(&crate_dir, &[]);
+    assert!(!success, "{output}");
+    assert!(output.contains("did not produce"), "{output}");
+    // The stale file is gone and aeneas never ran.
+    assert!(!llbc.exists());
+    assert!(!crate_dir.join("aeneas-invoked").exists());
+}
+
+#[test]
+fn overriding_charons_dest_file_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let crate_dir = dir.path().join("crate");
+    write_crate(&crate_dir);
+    let bin = dir.path().join("bin");
+    stub_pipeline_tools(&bin, &stub("aeneas-invoked"));
+    write_path_entries(&crate_dir, &bin);
+    // An LLBC file left by an earlier, successful run.
+    let llbc = crate_dir.join("proofs/lean/llbc/fixture.llbc");
+    std::fs::create_dir_all(llbc.parent().unwrap()).unwrap();
+    std::fs::write(&llbc, "previous").unwrap();
+
+    let (output, success) = common::run_hax(
+        &["into", "lean", "--charon-args=--dest-file /elsewhere.llbc"],
+        &crate_dir,
+        &[],
+    );
+    assert!(!success, "{output}");
+    assert!(output.contains("--dest-file"), "{output}");
+    assert!(output.contains("hax reserves"), "{output}");
+    // The error precedes any tool run and any file removal.
+    assert!(!crate_dir.join("charon-invoked").exists());
+    assert!(llbc.exists());
+}
+
+#[test]
 fn missing_sibling_executable_is_a_clear_error() {
     let dir = tempfile::tempdir().unwrap();
     let crate_dir = dir.path().join("crate");
@@ -67,7 +116,7 @@ fn missing_sibling_executable_is_a_clear_error() {
 fn hax_toml_pin_installs_on_demand_and_runs_from_the_cache() {
     // Fixture archives holding executable stubs.
     let charon = make_archive(&[
-        ("charon", &stub("charon-invoked")),
+        ("charon", &common::charon_stub()),
         ("charon-driver", &stub("driver-invoked")),
     ]);
     let aeneas = make_archive(&[("aeneas", &stub("aeneas-invoked"))]);

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -285,8 +285,9 @@ INVOCATION:
   before each tool runs.
 
   Overriding a flag that controls where output is written (aeneas's -backend,
-  -dest, -subdir, or -split-files, or charon's --dest-file) may break the extraction
-  or the generated proof project. Overriding -dest or -subdir additionally disables
+  -dest, -subdir, or -split-files) may break the extraction or the generated
+  proof project. Charon's --dest-file is reserved and rejected: aeneas is always
+  run on the LLBC file hax chooses. Overriding -dest or -subdir additionally disables
   the generation and checking of the Lean package files and the clearing of stale
   extraction files, since hax no longer knows the package layout. Committing
   `project-files = false` in `hax.toml` disables the package files for every

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -310,6 +310,17 @@ impl HaxMessage {
     }
 }
 
+/// Whether this process reported an error-severity message.
+/// [`HaxMessage::report`] sets it, and [`errors_reported`] exposes it: a
+/// reported error and a successful exit status must never combine, so an
+/// exit path with a zero code has to consult it.
+static ERROR_REPORTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether an error-severity message was reported in this process.
+pub fn errors_reported() -> bool {
+    ERROR_REPORTED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 const ENGINE_BINARY_NAME: &str = "hax-engine";
 
 use annotate_snippets::{Level, Renderer};
@@ -336,7 +347,52 @@ fn relative_to_cwd(path: PathBuf) -> PathBuf {
 }
 
 impl HaxMessage {
+    /// Whether this message reports an error, i.e. renders at error level.
+    /// Reporting one commits the process to a failing exit status. Kept
+    /// exhaustive so that a new variant forces a decision here, matching
+    /// the level [`Self::render_styled`] gives it.
+    pub fn is_error(&self) -> bool {
+        match self {
+            Self::Diagnostic { .. }
+            | Self::BinaryNotFound { .. }
+            | Self::HaxEngineFailure { .. }
+            | Self::GenericError { .. }
+            | Self::HaxTomlError { .. }
+            | Self::HaxLibIncompatible { .. } => true,
+            Self::ScenarioSummary { failed, .. } => !failed.is_empty(),
+            Self::ProducedFile { .. }
+            | Self::CargoBuildFailure
+            | Self::WarnExperimentalBackend { .. }
+            | Self::ProfilingData(..)
+            | Self::Stats { .. }
+            | Self::GenericWarning { .. }
+            | Self::Step { .. }
+            | Self::SubprocessOutput { .. }
+            | Self::OutputTruncated { .. }
+            | Self::UnsupportedOption { .. }
+            | Self::HaxTomlWarning { .. }
+            | Self::MemberToolOverrides { .. }
+            | Self::StrayHaxToml { .. }
+            | Self::UnverifiedInstall { .. }
+            | Self::NonDefaultToolVersion { .. }
+            | Self::CachedUnverifiedToolInUse { .. }
+            | Self::ToolsShow { .. }
+            | Self::ToolsList { .. }
+            | Self::ToolsInstalled { .. }
+            | Self::LakefilePinDrift { .. }
+            | Self::ToolRemoved { .. }
+            | Self::ToolsCleaned { .. }
+            | Self::ToolsPinned { .. }
+            | Self::RootModuleMissingImport { .. }
+            | Self::RootModuleStaleImport { .. }
+            | Self::ScenarioDryRun { .. } => false,
+        }
+    }
+
     pub fn report(self, message_format: MessageFormat, rctx: Option<&mut ReportCtx>) {
+        if self.is_error() {
+            ERROR_REPORTED.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
         // A message that renders to nothing has nothing to print: a report
         // of an empty listing must not become a blank line.
         if let Some(rendered) = self.render(message_format, rctx)
@@ -346,6 +402,9 @@ impl HaxMessage {
         }
     }
     pub fn report_styled(self, rctx: Option<&mut ReportCtx>) {
+        if self.is_error() {
+            ERROR_REPORTED.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
         println!("{}", self.render_styled(rctx))
     }
 
@@ -903,4 +962,24 @@ fn render_tools_installed(installed: &[InstalledTool]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_reported_error_must_not_exit_successfully() {
+        let warning = HaxMessage::GenericWarning {
+            message: "w".into(),
+        };
+        assert!(!warning.is_error());
+
+        let error = HaxMessage::GenericError {
+            message: "e".into(),
+        };
+        assert!(error.is_error());
+        error.report(MessageFormat::Json, None);
+        assert!(errors_reported());
+    }
 }


### PR DESCRIPTION
Extraction runs could report an error and still exit 0, or leave truncated or stale output behind. This PR closes those gaps in three commits:

- **Fail the lean extraction when charon leaves no LLBC behind.** A charon run that exits 0 without writing its output file is now an error instead of feeding aeneas a stale LLBC. Overriding charon's `--dest-file` is rejected before anything is deleted or run, so a usage error leaves the previous run's artifact intact.
- **Validate haxmeta reports from the driver channel.** Cargo's stderr is shared with everything the build runs, so driver reports are only accepted when they name a haxmeta file of a workspace crate (matched by cargo target name) under the run's target directory. The validation honors the `-C ... ;` cargo flags (`--manifest-path`, `--target-dir`, feature selection), unreadable stderr lines fail the run instead of being dropped, and on a channel error no output is produced from the partial report set. A successful build that reports no haxmeta file at all is an error.
- **Never exit successfully after reporting an error.** Every exit path with code 0 now consults a process-wide flag set by error-severity reports, and the message-to-level mapping is exhaustive so a new variant forces a decision.

The empty-report guard relies on cargo replaying cached compiler stderr for fresh units, verified empirically: on a fully cached run the workspace wrapper does not run, but its marker lines are re-delivered from the cache.

*Assisted by AI. Reviewed manually.*