### PR TITLE
 ci: check and cache the documentation

### DIFF
--- a/.github/actions/open-issue-once/action.yml
+++ b/.github/actions/open-issue-once/action.yml
@@ -1,0 +1,60 @@
+name: Open an issue once
+description: >-
+  Open an issue for a failing scheduled or automated run, deduplicated by
+  exact title match against the open issues. The caller must set GH_TOKEN
+  in the step's environment.
+
+inputs:
+  title:
+    description: Issue title, also used to find an already open issue.
+    required: true
+  body:
+    description: Issue body.
+    required: true
+  label:
+    description: Label for a newly created issue. Empty adds no label.
+    default: ""
+  on-existing:
+    description: >-
+      What to do when an issue with the same title is already open:
+      "skip" (default) leaves it alone and appends a note to a new issue's
+      body explaining that behavior; "comment" posts the body as a comment
+      on the open issue.
+    default: skip
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        LABEL: ${{ inputs.label }}
+        ON_EXISTING: ${{ inputs.on-existing }}
+      run: |
+        set -euo pipefail
+        case "$ON_EXISTING" in
+          skip|comment) ;;
+          *)
+            echo "invalid on-existing value: $ON_EXISTING"
+            exit 1
+            ;;
+        esac
+        open="$(gh issue list --state open \
+          --search "\"$TITLE\" in:title" --json number,title \
+          --jq '.[] | select(.title == env.TITLE) | .number' | head -n 1)"
+        if [ -n "$open" ]; then
+          if [ "$ON_EXISTING" = comment ]; then
+            gh issue comment "$open" --body "$BODY"
+          else
+            echo "Issue #$open is already open, not opening another one."
+          fi
+          exit 0
+        fi
+        if [ "$ON_EXISTING" = skip ]; then
+          BODY="$BODY
+
+        This issue is opened once per breakage; while it stays open,
+        subsequent failing runs will not open or comment on anything."
+        fi
+        gh issue create --title "$TITLE" ${LABEL:+--label "$LABEL"} --body "$BODY"

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,0 +1,34 @@
+name: Docs build
+
+# The .#docs derivation builds the mkdocs site (which snippet-includes
+# markdown from anywhere in the repository) and the frontend rustdoc, so
+# the paths cover the snippet sources, the Rust sources, and the pinned
+# toolchain besides docs/ itself.
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**.md"
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "**.nix"
+      - "flake.lock"
+      - ".github/workflows/docs_build.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v15
+        with:
+          name: hax
+          skipPush: true
+      - name: Build documentation
+        run: nix build .#docs

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v15
+        with:
+          name: hax
+          skipPush: true
       - name: Resolve latest hax release
         id: latest_release
         env:

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -37,6 +37,6 @@ jobs:
       env:
         CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       run: |
-        nix build .# .#fstar --json \
+        nix build .# .#fstar .#docs --json \
           | jq -r '.[].outputs | to_entries[].value' \
           | cachix push hax

--- a/.github/workflows/markdown_links.yml
+++ b/.github/workflows/markdown_links.yml
@@ -1,0 +1,42 @@
+name: Markdown links
+
+# Checks the links in all repository markdown outside docs/, which is
+# part of the website; the links on the website itself are checked by
+# the Playwright docs tests.
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    if: github.repository == 'cryspen/hax'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        env:
+          # Authenticates github.com requests, which dominate the checked
+          # links and get rate-limited quickly when anonymous.
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          args: >-
+            --no-progress
+            --max-retries 5
+            --exclude-path docs
+            './**/*.md'
+          fail: true
+      - name: Open an issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/open-issue-once
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          label: tests
+          title: Scheduled markdown link checks are failing
+          body: |-
+            The scheduled [Markdown links](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) run failed on `${{ github.sha }}`.
+
+            See the run's log for the broken links.

--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: DeterminateSystems/determinate-nix-action@v3
+    - uses: cachix/cachix-action@v15
+      with:
+        name: hax
+        skipPush: true
     - uses: actions/setup-node@v5
       with:
         node-version: lts/*

--- a/.github/workflows/playwright-docs.yml
+++ b/.github/workflows/playwright-docs.yml
@@ -50,20 +50,13 @@ jobs:
         retention-days: 30
     - name: Open an issue on failure
       if: failure() && github.event_name == 'schedule'
+      uses: ./.github/actions/open-issue-once
       env:
         GH_TOKEN: ${{ github.token }}
-        TITLE: Scheduled Playwright docs tests are failing
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      run: |
-        set -euo pipefail
-        open=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
-        if [ -n "$open" ]; then
-          echo "Issue #$open is already open, not opening another one."
-          exit 0
-        fi
-        gh issue create --title "$TITLE" --label tests --body \
-          "The scheduled [Playwright Docs Tests]($RUN_URL) run failed on \`$GITHUB_SHA\`.
+      with:
+        label: tests
+        title: Scheduled Playwright docs tests are failing
+        body: |-
+          The scheduled [Playwright Docs Tests](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) run failed on `${{ github.sha }}`.
 
-        Download the \`playwright-report\` artifact from that run to see which
-        checks failed. This issue is opened once per breakage; while it stays
-        open, subsequent failing runs will not open or comment on anything."
+          Download the `playwright-report` artifact from that run to see which checks failed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,22 +178,17 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     permissions:
+      contents: read # for the checkout that provides the local action
       issues: write
     steps:
-      - env:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/open-issue-once
+        env:
           GH_TOKEN: ${{ github.token }}
-          TITLE: Release run for ${{ github.ref_name }} failed
-          BODY: |
+        with:
+          title: Release run for ${{ github.ref_name }} failed
+          on-existing: comment
+          body: |
             The `release` workflow failed, so the release may be missing assets: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             Once the cause is fixed, restart it with `gh workflow run release.yml --ref ${{ github.ref_name }}`; it publishes only the assets that are still missing.
-        run: |
-          number="$(gh issue list -R "$GITHUB_REPOSITORY" --state open \
-            --search "\"$TITLE\" in:title" --json number,title \
-            --jq '.[] | select(.title == env.TITLE) | .number' | head -n 1)"
-          if [ -n "$number" ]; then
-            gh issue comment "$number" -R "$GITHUB_REPOSITORY" --body "$BODY"
-          else
-            gh issue create -R "$GITHUB_REPOSITORY" \
-              --title "$TITLE" --body "$BODY"
-          fi

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -42,7 +42,7 @@ in stdenv.mkDerivation {
     mkdocs-awesome-nav
   ];
   buildPhase = ''
-    mkdocs build
+    mkdocs build --strict
   '';
   installPhase = ''
     mv site $out


### PR DESCRIPTION
- Add a scheduled link check over all repository markdown outside the website (lychee, authenticated, with retries).
- Add a PR check that builds `.#docs` whenever one of its inputs changes.
- Cache the docs build: push the `.#docs` closure to Cachix and pull it in the workflows that build the docs.
- Extract a shared `open-issue-once` action for filing deduplicated failure issues and use it in the link check, the Playwright docs tests and the release workflow.

*Assisted by AI. Reviewed manually.*

[skip changelog]