### PR TITLE
fix(hax-lib): don't add an extra arg when [cfg(hax_backend_lean)]

### DIFF
--- a/hax-lib/macros/src/utils.rs
+++ b/hax-lib/macros/src/utils.rs
@@ -144,6 +144,13 @@ pub(crate) fn future_args_last() -> bool {
     cfg!(hax_backend_lean)
 }
 
+/// Whether the decoration of a function without argument needs a padding unit argument. The legacy
+/// engine translates functions of arity zero to functions taking exactly one unit argument, while
+/// the aeneas engine keeps them of arity zero.
+pub(crate) fn pad_nullary_sig() -> bool {
+    !cfg!(hax_backend_lean)
+}
+
 /// Merge two `syn::Generics`, respecting lifetime orders
 pub(crate) fn merge_generics(x: Generics, y: Generics) -> Generics {
     Generics {
@@ -322,7 +329,7 @@ fn create_future_ident(name: &str) -> syn::Ident {
 /// we need a function of arity two.
 /// `fix_signature_arity` adds a `unit` if needed.
 fn add_unit_to_sig_if_needed(signature: &mut Signature) {
-    if signature.inputs.is_empty() {
+    if signature.inputs.is_empty() && pad_nullary_sig() {
         signature.inputs.push(parse_quote! {_: ()})
     }
 }

--- a/tests/src/legacy/attributes/lib.rs
+++ b/tests/src/legacy/attributes/lib.rs
@@ -243,6 +243,43 @@ mod future_self {
     }
 }
 
+/// The extra tuple an `ensures` receives carries the `future(_)` values and the
+/// result. The engine lanes order it `(futures..., result)`; the aeneas/Lean lane
+/// emits `(result, futures...)`, matching the tuple an Aeneas-extracted function
+/// returns. Only the engine lanes run here, so these cases guard against that
+/// ordering leaking into them. Each gives its futures and result *distinct* types,
+/// which is what makes the order visible: `swap_and_mut_req_ens` above is
+/// all-`u32`, so a permutation there renames binders and nothing else.
+mod future_and_result_order {
+    /// One `&mut` input, non-unit result: `(u32, bool)` in the engine lanes,
+    /// `(bool, u32)` in the aeneas/Lean lane.
+    #[hax_lib::ensures(|result| *future(x) == x.wrapping_add(1) && result == (*future(x) == 0))]
+    fn one_mut_and_result(x: &mut u32) -> bool {
+        *x = x.wrapping_add(1);
+        *x == 0
+    }
+
+    /// Two `&mut` inputs: pins the futures' order relative to each other as
+    /// well as relative to the result. `(u8, u64, bool)` in the engine lanes,
+    /// `(bool, u8, u64)` in the aeneas/Lean lane.
+    #[hax_lib::ensures(|result| *future(a) == a.wrapping_add(1)
+        && *future(b) == b.wrapping_add(2)
+        && result == (*future(a) == 0))]
+    fn two_mut_and_result(a: &mut u8, b: &mut u64) -> bool {
+        *a = a.wrapping_add(1);
+        *b = b.wrapping_add(2);
+        *a == 0
+    }
+
+    /// One `&mut` input, unit result: the result binder is dropped altogether,
+    /// so what is left is futures-only and the reordering is a no-op — both
+    /// lanes agree here.
+    #[hax_lib::ensures(|_| *future(x) == x.wrapping_add(1))]
+    fn one_mut_no_result(x: &mut u32) {
+        *x = x.wrapping_add(1);
+    }
+}
+
 mod replace_body {
     #[hax_lib::fstar::replace_body("magic ${x}")]
     fn f(x: u8, y: u8) -> u8 {


### PR DESCRIPTION
The extra argument added by `hax_lib` caused a conflict in spec generation (the arity were disagreeing), resulting in dropped pre/post conditions. This fix checks for the lean backend cfg flag to disable that extra unit argument. A test is added but not run on CI.

Fixes #2177, fixes https://github.com/cryspen/aeneas/issues/57
[skip changelog]
*AI-assited* 