### PR TITLE
fix(cli): list tool versions in manifest order

### DIFF
--- a/cli/cargo-hax/src/tools/manifest.rs
+++ b/cli/cargo-hax/src/tools/manifest.rs
@@ -37,11 +37,64 @@ pub struct FallbackTemplate {
     pub entry_points: Option<BTreeMap<String, String>>,
 }
 
+/// The versions of one tool, in manifest (file) order. Versions are only
+/// appended to the manifest, so this order is chronological, oldest first.
+#[derive(Debug, Clone, Default)]
+pub struct ToolVersions(Vec<(String, BTreeMap<String, ArtifactEntry>)>);
+
+impl ToolVersions {
+    pub fn get(&self, version: &str) -> Option<&BTreeMap<String, ArtifactEntry>> {
+        self.0
+            .iter()
+            .find(|(v, _)| v == version)
+            .map(|(_, platforms)| platforms)
+    }
+
+    pub fn contains_key(&self, version: &str) -> bool {
+        self.get(version).is_some()
+    }
+
+    pub fn keys(&self) -> impl DoubleEndedIterator<Item = &str> {
+        self.0.iter().map(|(version, _)| version.as_str())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &BTreeMap<String, ArtifactEntry>)> {
+        self.0
+            .iter()
+            .map(|(version, platforms)| (version, platforms))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolVersions {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ToolVersions;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a map of versions to platform entries")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::new();
+                while let Some(entry) = map.next_entry()? {
+                    entries.push(entry);
+                }
+                Ok(ToolVersions(entries))
+            }
+        }
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct Manifest {
     /// tool name -> version -> platform key -> artifact.
     #[serde(default)]
-    pub tools: BTreeMap<String, BTreeMap<String, BTreeMap<String, ArtifactEntry>>>,
+    pub tools: BTreeMap<String, ToolVersions>,
     /// tool name -> platform key -> template.
     #[serde(default)]
     pub fallback: BTreeMap<String, BTreeMap<String, FallbackTemplate>>,
@@ -91,12 +144,11 @@ impl Manifest {
     }
 
     /// The versions of a tool listed for verified installation, in the
-    /// manifest's (lexicographic, hence chronological for nightly tags)
-    /// order.
+    /// manifest's append-only, hence chronological, order: oldest first.
     pub fn versions_of(&self, tool: &str) -> Vec<&str> {
         self.tools
             .get(tool)
-            .map(|versions| versions.keys().map(String::as_str).collect())
+            .map(|versions| versions.keys().collect())
             .unwrap_or_default()
     }
 
@@ -171,7 +223,7 @@ mod tests {
     fn every_listed_entry_is_well_formed() {
         let manifest = parse(MANIFEST_TOML).expect("embedded manifest must parse");
         for (tool, versions) in &manifest.tools {
-            for (version, platforms) in versions {
+            for (version, platforms) in versions.iter() {
                 validate_version_id(version).unwrap();
                 for (platform, entry) in platforms {
                     let name = format!("{tool} {version} on {platform}");
@@ -192,6 +244,31 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Versions must come back in file order, not sorted: the manifest is
+    /// append-only, so file order is what makes `versions_of` chronological
+    /// even across tag schemes that do not sort lexicographically.
+    #[test]
+    fn versions_keep_manifest_order() {
+        let entry = |version| {
+            format!(
+                "[tools.aeneas.\"{version}\".linux-x86_64]\n\
+                 url = \"https://example.com/{version}.tar.gz\"\n\
+                 sha256 = \"{}\"\n",
+                "0".repeat(64)
+            )
+        };
+        let manifest = parse(&format!(
+            "{}{}",
+            entry("nightly-2026.08.24"),
+            entry("build-c983fb6")
+        ))
+        .unwrap();
+        assert_eq!(
+            manifest.versions_of("aeneas"),
+            ["nightly-2026.08.24", "build-c983fb6"]
+        );
     }
 
     #[test]

--- a/cli/cargo-hax/src/tools/subcommands.rs
+++ b/cli/cargo-hax/src/tools/subcommands.rs
@@ -382,14 +382,24 @@ pub fn list(
         let default = defaults.tools.get(tool);
 
         // The manifest's versions and any cached ones, merged into one list,
-        // newest first. A version installed through the fallback path can be
-        // newer than the manifest, so the two sets are sorted together rather
-        // than concatenated. Lexicographic order matches release order for
-        // the `nightly-YYYY.MM.DD` tags in use.
-        let mut all_versions: BTreeSet<String> = BTreeSet::new();
-        all_versions.extend(manifest.versions_of(tool).into_iter().map(String::from));
-        all_versions.extend(installed.iter().cloned());
-        let ordered: Vec<String> = all_versions.into_iter().rev().collect();
+        // newest first. The manifest is append-only, so reversing it yields
+        // release order regardless of the tag scheme. Cached versions the
+        // manifest does not know were installed through the fallback path,
+        // typically because they are newer than this binary's manifest, so
+        // they go on top.
+        let ordered: Vec<String> = installed
+            .iter()
+            .filter(|version| !manifest.knows_version(tool, version))
+            .rev()
+            .cloned()
+            .chain(
+                manifest
+                    .versions_of(tool)
+                    .into_iter()
+                    .rev()
+                    .map(String::from),
+            )
+            .collect();
 
         let recent = if all { ordered.len() } else { LIST_RECENT };
         let mut versions = Vec::new();

--- a/cli/cargo-hax/tests/tools_install.rs
+++ b/cli/cargo-hax/tests/tools_install.rs
@@ -486,16 +486,28 @@ fn list_truncates_and_filters() {
             "0".repeat(64),
         ));
     }
+    // A tag that sorts before the nightlies but, being appended last, is the
+    // newest release: it must top the list, and truncation must drop the
+    // oldest nightlies instead.
+    manifest.push_str(&format!(
+        "[tools.charon.\"build-abc1234\".{}]\nurl = \"https://example.com/build.tar.gz\"\nsha256 = \"{}\"\n",
+        platform(),
+        "0".repeat(64),
+    ));
     let env = Env::new(&manifest);
 
     let (output, success) = env.run(&["tools", "list", "charon"]);
     assert!(success);
     assert!(
-        output.contains("2 older versions omitted (use --all)"),
+        output.contains("3 older versions omitted (use --all)"),
         "{output}"
     );
     assert!(!output.contains("nightly-2026.01.00"), "{output}");
     assert!(output.contains("nightly-2026.01.11"), "{output}");
+    assert!(
+        output.find("build-abc1234").unwrap() < output.find("nightly-2026.01.11").unwrap(),
+        "{output}"
+    );
 
     let (output, _) = env.run(&["tools", "list", "charon", "--all"]);
     assert!(output.contains("nightly-2026.01.00"), "{output}");

--- a/cli/cargo-hax/tools-manifest.toml
+++ b/cli/cargo-hax/tools-manifest.toml
@@ -22,8 +22,10 @@
 
 # ---- aeneas -----------------------------------------------------------------
 # Provenance: pre-built archives published by the cryspen/aeneas fork's
-# nightly releases (upstream: AeneasVerif/aeneas). Archives are flat, with
-# the executable at the archive root.
+# releases (upstream: AeneasVerif/aeneas): `nightly-YYYY.MM.DD-<shortsha>`
+# tags from the scheduled nightly builds, `build-<shortsha>` tags from
+# on-demand builds of a specific commit. Archives are flat, with the
+# executable at the archive root.
 
 [tools.aeneas."nightly-2026.07.21-52fd438".linux-x86_64]
 url = "https://github.com/cryspen/aeneas/releases/download/nightly-2026.07.21-52fd438/aeneas-linux-x86_64.tar.gz"

--- a/cli/cargo-hax/tools-manifest.toml
+++ b/cli/cargo-hax/tools-manifest.toml
@@ -8,7 +8,9 @@
 # unverified and with a warning.
 #
 # Entries are only added, never removed: every version ever published stays
-# installable with verification on the supported platforms. Adding a version is a single reviewed
+# installable with verification on the supported platforms. Append new versions
+# at the end of their tool's section: file order is release order, and
+# `tools list` relies on it. Adding a version is a single reviewed
 # commit; generate its entries with `just add-tool-version <tool> <version>`,
 # which hashes the artifacts themselves and checks them the way an install
 # does, and record the provenance in a comment when it is not obvious from


### PR DESCRIPTION
`cargo hax tools list` sorted versions lexicographically, which matches release order only for `nightly-YYYY.MM.DD` tags. The new Aeneas `build-<shortsha>` tags (see #2207) sort before every nightly, so the current default was shown as the oldest version and would eventually be truncated as "old".

The manifest is append-only, so file order is release order regardless of the tag scheme. Versions are now parsed order-preserving and listed newest first by file position, with unknown cached versions (fallback installs) on top. The manifest header states the append-at-the-end invariant, and the Aeneas provenance comment now covers the `build-<shortsha>` channel.

*AI-assisted. Human-reviewed.*

[skip changelog]