### PR TITLE
fix(ci): skip tarball check while a release is in flight

### DIFF
--- a/.github/workflows/standalone_install.yml
+++ b/.github/workflows/standalone_install.yml
@@ -64,11 +64,19 @@ jobs:
       # and `cargo-hax`, and between a version bump and the release that follows
       # it. The install step already builds the working tree.
       #
-      # Skipped on release PRs: the tarball's lockfile resolves the sibling
-      # crates from crates.io at the bumped version, which is only published
-      # once the PR merges.
+      # Skipped while a release is in flight: the tarball's lockfile resolves
+      # the sibling crates from crates.io at the bumped version, which is only
+      # published after the release PR merges. On pull requests the branch name
+      # says so; on the push to `main` the merge commit message does; the merge
+      # queue offers neither, so it is skipped there altogether. Each merge
+      # produces its own push, so a regression from an ordinary queued change
+      # still surfaces on `main`; one in the release PR itself waits for the
+      # next non-release push or the weekly schedule.
       - name: Check the published tarball
-        if: "!startsWith(github.head_ref, 'release/')"
+        if: >-
+          github.event_name != 'merge_group' &&
+          !startsWith(github.head_ref, 'release/') &&
+          !contains(github.event.head_commit.message, 'from cryspen/release/')
         run: |
           cargo package --locked --no-verify -p cargo-hax
           tar --extract --directory "$RUNNER_TEMP" \


### PR DESCRIPTION
The `install-and-extract` job skips the `cargo package` tarball check on release PRs, since the tarball's lockfile pins the sibling crates at the bumped version, which is only published after the release merges. That skip tested `github.head_ref`, which is empty on `merge_group` and `push` events, so the check ran and failed both in the merge queue and on the subsequent push to `main`.

The check is now skipped in the merge queue altogether, and on pushes to `main` whose head commit is a release merge, detected via the merge commit message. Each queued merge produces its own push, so regressions from ordinary changes still surface on `main`; a regression in the release PR itself is caught by the next non-release push or the weekly scheduled run.

*AI-assisted. Human-reviewed.*

[skip changelog]