### PR TITLE
RPITIT support (#1965): desugar return-position `impl Trait` in traits

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident_view.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view.ml
@@ -25,6 +25,16 @@ module Assert = struct
         DisambiguatedString.{ data; disambiguator }
     | _ -> broken_invariant "last path chunk to exist and be of type TypeNs" did
 
+  (* Associated types synthesized for return-position `impl Trait` in traits
+     carry an `AnonAssocTy` chunk rather than a `TypeNs` one. *)
+  let assoc_type_ns (did : Explicit_def_id.t) =
+    match List.last (Explicit_def_id.to_def_id did).path with
+    | Some { data = TypeNs data | AnonAssocTy data; disambiguator } ->
+        DisambiguatedString.{ data; disambiguator }
+    | _ ->
+        broken_invariant
+          "last path chunk to exist and be of type TypeNs or AnonAssocTy" did
+
   let macro_ns (did : Explicit_def_id.t) =
     match List.last (Explicit_def_id.to_def_id did).path with
     | Some { data = MacroNs data; disambiguator } ->
@@ -56,6 +66,7 @@ let rec poly :
         | _ -> broken_invariant "Impl or Trait" (Assert.parent did) )
   in
   let assert_type_ns did = Assert.type_ns did |> into_n did in
+  let assert_assoc_type_ns did = Assert.assoc_type_ns did |> into_n did in
   let assert_value_ns did = Assert.value_ns did |> into_n did in
   let assert_macro_ns did = Assert.macro_ns did |> into_n did in
   let result =
@@ -75,7 +86,7 @@ let rec poly :
     | Const -> `Const (assert_value_ns did)
     | AssocFn -> `Fn (assert_value_ns did) |> mk_associated_item
     | AssocConst -> `Const (assert_value_ns did) |> mk_associated_item
-    | AssocTy -> `Type (assert_type_ns did) |> mk_associated_item
+    | AssocTy -> `Type (assert_assoc_type_ns did) |> mk_associated_item
     | TyAlias -> `TyAlias (assert_type_ns did)
     | Field ->
         let constructor =

--- a/engine/lib/concrete_ident/concrete_ident_view.ml
+++ b/engine/lib/concrete_ident/concrete_ident_view.ml
@@ -26,11 +26,14 @@ module Assert = struct
     | _ -> broken_invariant "last path chunk to exist and be of type TypeNs" did
 
   (* Associated types synthesized for return-position `impl Trait` in traits
-     carry an `AnonAssocTy` chunk rather than a `TypeNs` one. *)
+     carry an `AnonAssocTy` chunk rather than a `TypeNs` one, and are named after
+     their method; suffix them to avoid clashing with it. *)
   let assoc_type_ns (did : Explicit_def_id.t) =
     match List.last (Explicit_def_id.to_def_id did).path with
-    | Some { data = TypeNs data | AnonAssocTy data; disambiguator } ->
+    | Some { data = TypeNs data; disambiguator } ->
         DisambiguatedString.{ data; disambiguator }
+    | Some { data = AnonAssocTy data; disambiguator } ->
+        DisambiguatedString.{ data = data ^ "_impl_trait"; disambiguator }
     | _ ->
         broken_invariant
           "last path chunk to exist and be of type TypeNs or AnonAssocTy" did

--- a/engine/lib/phases/phase_reject_impl_type_method.ml
+++ b/engine/lib/phases/phase_reject_impl_type_method.ml
@@ -14,14 +14,22 @@ module Make (F : Features.T) =
         let ctx = Diagnostics.Context.Phase phase_id
       end)
 
-      let reject_anon_assoc_ty =
+      (* `impl` return types are lowered to anonymous associated types. Those
+         surfaced as trait/impl members (the non-GAT case) translate like named
+         associated types; a reference to one that has no such member (a GAT)
+         cannot be stated and rejects its item. *)
+      let reject_anon_assoc_ty declared =
+        let is_declared item =
+          List.mem declared item ~equal:Concrete_ident.equal
+        in
         object
           inherit [_] Visitors.map as super
 
           method! visit_ty span t =
             match t with
             | TAssociatedType { item; _ }
-              when Concrete_ident.is_anon_assoc_ty item ->
+              when Concrete_ident.is_anon_assoc_ty item && not (is_declared item)
+              ->
                 Error.unimplemented ~issue_id:1965
                   ~details:
                     "`impl` types are not supported in type signatures of \
@@ -41,5 +49,20 @@ module Make (F : Features.T) =
               make_hax_error_item i.span i.ident msg
         end
 
-      let ditems = List.map ~f:(reject_anon_assoc_ty#visit_item None)
+      let ditems items =
+        let declared =
+          List.concat_map items ~f:(fun i ->
+              let idents get l =
+                List.filter_map l ~f:(fun x ->
+                    let ident = get x in
+                    Option.some_if
+                      (Concrete_ident.is_anon_assoc_ty ident)
+                      ident)
+              in
+              match i.v with
+              | Trait { items; _ } -> idents (fun ti -> ti.ti_ident) items
+              | Impl { items; _ } -> idents (fun ii -> ii.ii_ident) items
+              | _ -> [])
+        in
+        List.map ~f:((reject_anon_assoc_ty declared)#visit_item None) items
     end)

--- a/frontend/exporter/src/types/hir.rs
+++ b/frontend/exporter/src/types/hir.rs
@@ -429,6 +429,12 @@ pub struct Impl<Body: IsBody> {
     })]
     pub of_trait: Option<TraitRef>,
     pub self_ty: Ty,
+    #[map({
+        let mut items = rpitit_impl_items(s);
+        let hir_items: Vec<ImplItem<Body>> = x.sinto(s);
+        items.extend(hir_items);
+        items
+    })]
     pub items: Vec<ImplItem<Body>>,
     #[value({
         let (tcx, owner_id) = (s.base().tcx, s.owner_id());
@@ -622,6 +628,119 @@ pub struct PathSegment {
 }
 
 /// Reflects [`hir::ItemKind`]
+/// Return-position `impl Trait` in a trait method is lowered by rustc to an
+/// anonymous associated type that lives in `associated_items` but not in the
+/// HIR item list. These helpers surface it as a regular associated type so the
+/// method's projection resolves. The GAT case (the anon type has generics of
+/// its own) is left out and handled by rejection.
+#[cfg(feature = "rustc")]
+fn rpitit_assoc_defs<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+) -> Vec<rustc_span::def_id::DefId> {
+    use rustc_middle::ty;
+    let tcx = s.base().tcx;
+    tcx.associated_items(s.owner_id())
+        .in_definition_order()
+        .filter(|assoc| {
+            matches!(
+                assoc.kind,
+                ty::AssocKind::Type {
+                    data: ty::AssocTypeData::Rpitit(_)
+                }
+            )
+            // Only the non-GAT case: lifetimes of its own are fine (erased), but
+            // type or const generics make it a GAT, left to rejection.
+            && tcx
+                .generics_of(assoc.def_id)
+                .own_params
+                .iter()
+                .all(|p| matches!(p.kind, ty::GenericParamDefKind::Lifetime))
+        })
+        .map(|assoc| assoc.def_id)
+        .collect()
+}
+
+#[cfg(feature = "rustc")]
+fn anon_assoc_name(
+    tcx: rustc_middle::ty::TyCtxt<'_>,
+    did: rustc_span::def_id::DefId,
+) -> rustc_span::Symbol {
+    match tcx.def_key(did).disambiguated_data.data {
+        rustc_hir::definitions::DefPathData::AnonAssocTy(name) => name,
+        _ => rustc_span::Symbol::intern("assoc"),
+    }
+}
+
+#[cfg(feature = "rustc")]
+fn empty_generics<Body: IsBody>(span: Span) -> Generics<Body> {
+    Generics {
+        params: vec![],
+        bounds: vec![],
+        has_where_clause_predicates: false,
+        where_clause_span: span.clone(),
+        span,
+    }
+}
+
+#[cfg(feature = "rustc")]
+fn rpitit_trait_items<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody>(
+    s: &S,
+) -> Vec<TraitItem<Body>> {
+    let tcx = s.base().tcx;
+    rpitit_assoc_defs(s)
+        .into_iter()
+        .map(|assoc_did| {
+            let s = &s.with_owner_id(assoc_did);
+            let span: Span = tcx.def_span(assoc_did).sinto(s);
+            TraitItem {
+                ident: (anon_assoc_name(tcx, assoc_did).sinto(s), span.clone()),
+                owner_id: assoc_did.sinto(s),
+                generics: empty_generics(span.clone()),
+                kind: TraitItemKind::Type(vec![], None),
+                span,
+                defaultness: tcx.defaultness(assoc_did).sinto(s),
+                attributes: ItemAttributes::from_owner_id(
+                    s,
+                    rustc_hir::OwnerId {
+                        def_id: assoc_did.expect_local(),
+                    },
+                ),
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "rustc")]
+fn rpitit_impl_items<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody>(
+    s: &S,
+) -> Vec<ImplItem<Body>> {
+    let tcx = s.base().tcx;
+    rpitit_assoc_defs(s)
+        .into_iter()
+        .map(|assoc_did| {
+            let s = &s.with_owner_id(assoc_did);
+            let span: Span = tcx.def_span(assoc_did).sinto(s);
+            let ty: Ty = tcx.type_of(assoc_did).instantiate_identity().sinto(s);
+            ImplItem {
+                ident: (anon_assoc_name(tcx, assoc_did).sinto(s), span.clone()),
+                owner_id: assoc_did.sinto(s),
+                generics: empty_generics(span.clone()),
+                kind: ImplItemKind::Type {
+                    ty,
+                    parent_bounds: vec![],
+                },
+                span,
+                attributes: ItemAttributes::from_owner_id(
+                    s,
+                    rustc_hir::OwnerId {
+                        def_id: assoc_did.expect_local(),
+                    },
+                ),
+            }
+        })
+        .collect()
+}
+
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: hir::ItemKind<'tcx>, state: S as s)]
 #[derive_group(Serializers)]
@@ -704,6 +823,12 @@ pub enum ItemKind<Body: IsBody> {
         Ident,
         Generics<Body>,
         GenericBounds,
+        #[map({
+            let mut items = rpitit_trait_items(s);
+            let hir_items: Vec<TraitItem<Body>> = x.sinto(s);
+            items.extend(hir_items);
+            items
+        })]
         Vec<TraitItem<Body>>,
     ),
     TraitAlias(Constness, Ident, Generics<Body>, GenericBounds),

--- a/rust-engine/src/ast/identifiers/global_id/view.rs
+++ b/rust-engine/src/ast/identifiers/global_id/view.rs
@@ -380,6 +380,10 @@ impl PathSegmentPayload {
                 | DefPathItem::ValueNs(s)
                 | DefPathItem::MacroNs(s)
                 | DefPathItem::LifetimeNs(s) => Symbol::new(s),
+                // Associated types synthesized for return-position `impl Trait`
+                // in traits are named after their method; suffix them to avoid
+                // clashing with it.
+                DefPathItem::AnonAssocTy(s) => Symbol::new(format!("{s}_impl_trait")),
                 _ => return error_dummy_value("PathSegmentPayload::from_named", def_id),
             },
             None => Symbol::new(&def_id.def_id.krate),

--- a/tests/snapshots/legacy/impl-trait-in-trait/lib/fstar/New_tests.Legacy__impl_trait_in_trait__lib.fst
+++ b/tests/snapshots/legacy/impl-trait-in-trait/lib/fstar/New_tests.Legacy__impl_trait_in_trait__lib.fst
@@ -1,0 +1,107 @@
+module New_tests.Legacy__impl_trait_in_trait__lib
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+type t_Foo = | Foo : u8 -> t_Foo
+
+(* item error backend: something is not implemented yet.
+`impl` types are not supported in type signatures of associated items.
+
+This is discussed in issue https://github.com/hacspec/hax/issues/1965.
+Please upvote or comment this issue if you see this error message.
+Note: the error was labeled with context `RejectImplTypeMethod`.
+
+Last available AST for this item:
+
+/// @fail(extraction): fstar(HAX0001), legacy-lean(HAX0001)
+#[allow(dead_code)]
+#[allow(dead_code, unused, unconditional_recursion)]
+#[feature(register_tool, if_let_guard)]
+#[feature(
+    coverage_attribute,
+    stmt_expr_attributes,
+    custom_inner_attributes,
+    test,
+    yield_expr,
+    coroutines,
+    coroutine_trait,
+    no_core,
+    core_intrinsics
+)]
+#[register_tool(_hax)]
+trait t_GenStreamer<Self_> {
+    #[allow(dead_code)]
+    #[allow(dead_code, unused, unconditional_recursion)]
+    #[feature(register_tool, if_let_guard)]
+    #[feature(
+        coverage_attribute,
+        stmt_expr_attributes,
+        custom_inner_attributes,
+        test,
+        yield_expr,
+        coroutines,
+        coroutine_trait,
+        no_core,
+        core_intrinsics
+    )]
+    #[register_tool(_hax)]
+    fn f_gstream<const N: int, Anonymous: 'unk>(_: &Self) -> proj_asso_type!();
+}
+
+
+Last AST:
+/** print_rust: pitem: not implemented  (item: { Concrete_ident.T.def_id =
+  { Explicit_def_id.T.is_constructor = false;
+    def_id =
+    { Types.index = (0, 0, None); is_local = true; kind = Types.Trait;
+      krate = "new_tests";
+      parent =
+      (Some { Types.contents =
+              { Types.id = 0;
+                value =
+                { Types.index = (0, 0, None); is_local = true;
+                  kind = Types.Mod; krate = "new_tests";
+                  parent =
+                  (Some { Types.contents =
+                          { Types.id = 0;
+                            value =
+                            { Types.index = (0, 0, None); is_local = true;
+                              kind = Types.Mod; krate = "new_tests";
+                              parent = None; path = [] }
+                            }
+                          });
+                  path =
+                  [{ Types.data =
+                     (Types.TypeNs "legacy__impl_trait_in_trait__lib");
+                     disambiguator = 0 }
+                    ]
+                  }
+                }
+              });
+      path =
+      [{ Types.data = (Types.TypeNs "legacy__impl_trait_in_trait__lib");
+         disambiguator = 0 };
+        { Types.data = (Types.TypeNs "GenStreamer"); disambiguator = 0 }]
+      }
+    };
+  moved = None; suffix = None }) */
+const _: () = ();
+ *)
+
+class t_Streamer (v_Self: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_stream_impl_trait:Type0;
+  f_stream_pre:v_Self -> Type0;
+  f_stream_post:v_Self -> f_stream_impl_trait -> Type0;
+  f_stream:x0: v_Self
+    -> Prims.Pure f_stream_impl_trait (f_stream_pre x0) (fun result -> f_stream_post x0 result)
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: t_Streamer t_Foo =
+  {
+    f_stream_impl_trait = u8;
+    f_stream_pre = (fun (self: t_Foo) -> true);
+    f_stream_post = (fun (self: t_Foo) (out: u8) -> true);
+    f_stream = fun (self: t_Foo) -> self._0
+  }

--- a/tests/snapshots/legacy/impl-trait-in-trait/lib/legacy-lean/new_tests.lean
+++ b/tests/snapshots/legacy/impl-trait-in-trait/lib/legacy-lean/new_tests.lean
@@ -1,0 +1,43 @@
+
+-- Legacy lean backend for Hax
+-- The Hax prelude library can be found in hax/proof-libs/legacy-lean
+import Hax
+import Std.Tactic.Do
+import Std.Do.Triple
+import Std.Tactic.Do.Syntax
+open Std.Do
+open Std.Tactic
+
+set_option mvcgen.warning false
+set_option linter.unusedVariables false
+
+
+namespace new_tests.legacy__impl_trait_in_trait__lib
+
+structure Foo where
+  _0 : u8
+
+@[spec]
+def Impl.stream_hoisted (self : Foo) : RustM u8 := do (pure (Foo._0 self))
+
+class Streamer.AssociatedTypes (Self : Type) where
+  stream_impl_trait : Type
+
+attribute [reducible] Streamer.AssociatedTypes.stream_impl_trait
+
+abbrev Streamer.stream_impl_trait :=
+  Streamer.AssociatedTypes.stream_impl_trait
+
+class Streamer (Self : Type)
+  [associatedTypes : outParam (Streamer.AssociatedTypes (Self : Type))]
+  where
+  stream (Self) : (Self -> RustM associatedTypes.stream_impl_trait)
+
+@[reducible] instance Impl.AssociatedTypes : Streamer.AssociatedTypes Foo where
+  stream_impl_trait := u8
+
+instance Impl : Streamer Foo where
+  stream := (Impl.stream_hoisted)
+
+end new_tests.legacy__impl_trait_in_trait__lib
+

--- a/tests/src/legacy/impl-trait-in-trait/lib.rs
+++ b/tests/src/legacy/impl-trait-in-trait/lib.rs
@@ -1,0 +1,21 @@
+//! @off: coq, ssprove, proverif
+//! Return-position `impl Trait` in trait methods (#1965).
+
+#![allow(dead_code)]
+
+pub struct Foo(u8);
+
+pub trait Streamer {
+    fn stream(&self) -> impl Clone;
+}
+
+impl Streamer for Foo {
+    fn stream(&self) -> impl Clone {
+        self.0
+    }
+}
+
+/// @fail(extraction): fstar(HAX0001), legacy-lean(HAX0001)
+pub trait GenStreamer {
+    fn gstream<const N: usize>(&self) -> impl Clone;
+}


### PR DESCRIPTION
Desugars return-position `impl Trait` in trait methods (#1965) to a named
associated type: the plain (non-generic) case extracts and verifies, the
generic (GAT) case is rejected gracefully.

Changes:
- engine (`concrete_ident_view.ml`): accept an `AnonAssocTy` last path chunk
  for `AssocTy` items (whole-crate `broken_invariant` abort → per-item
  degradation); suffix it `_impl_trait` so it does not clash with the method.
- frontend (`types/hir.rs`): surface the anonymous associated type synthesized
  for RPITIT as a trait/impl associated-type member (non-GAT case), so the
  method's projection resolves.
- engine (`phase_reject_impl_type_method.ml`): reject only references to
  anonymous associated types with no declared member (the GAT case).
- engine (rust-engine `global_id/view.rs`): name the same `AnonAssocTy` in the
  rust-engine view, so legacy-lean renders RPITIT like F*.
- test (`tests/src/legacy/impl-trait-in-trait`): a plain `-> impl Trait`
  method that verifies (F* + legacy-lean) and a generic variant that is
  rejected.

Limitations:
- The associated-type bound is dropped, so a caller that iterates an RPITIT
  result still fails to resolve the (absent) `Iterator` instance.
- GAT-flavored RPITIT (methods with type/const generics) is not desugared and
  is rejected gracefully.
