### PR TITLE
fix: fix CI job that checks for dead links

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,11 +1,12 @@
 name: Deploy to GH Pages
 
+# Runs on every push to `main` and, for a release that becomes the latest,
+# called from the `release` workflow.
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches: [main]
-  release:
-    types: [published]
 
 jobs:
   # Build job
@@ -13,7 +14,12 @@ jobs:
     if: github.repository == 'cryspen/hax'
     runs-on: ubuntu-latest
     steps:
+      # A call from the `release` workflow runs on the release tag; the site
+      # is built from `main` regardless, only the manual comes from the
+      # release.
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v15
         with:

--- a/.github/workflows/markdown_links.yml
+++ b/.github/workflows/markdown_links.yml
@@ -22,10 +22,13 @@ jobs:
           # links and get rate-limited quickly when anonymous.
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          # eprint.iacr.org rejects lychee's default user agent with 403
+          # Forbidden; so we use a custom user agent string.
           args: >-
             --no-progress
             --max-retries 5
             --exclude-path docs
+            --user-agent 'hax link check (https://github.com/cryspen/hax)'
             './**/*.md'
           fail: true
       - name: Open an issue on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,13 +168,49 @@ jobs:
     with:
       version: ${{ needs.tag.outputs.version }}
 
+  # Whether the release created above is the "latest" according to GitHub.
+  # This excludes pre-releases or patch versions of older releases.
+  # Only if the current release is "latest", we need to redeploy the manual.
+  latest-release:
+    needs: [tag, release-cargo-hax]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      deploy: ${{ steps.latest.outputs.deploy }}
+    steps:
+      - id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          latest="$(gh release view --json tagName --jq .tagName)"
+          if [ "$latest" = "$TAG" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::$TAG is not the latest release ($latest); the website keeps serving that"
+          fi
+
+  # Redeploys the website with the manual of the release created above. We
+  # need to call it here because that release raises no `release` event that
+  # would start it on its own.
+  deploy-website:
+    needs: [latest-release]
+    if: needs.latest-release.outputs.deploy == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/gh_pages.yml
+
   # Files an issue when any part of the release failed, so a failed run
   # surfaces without anyone checking back on it. A repeated
   # failure for the same tag lands as a comment on the open issue instead of
   # a duplicate. A dispatch on a ref that is not a release tag skips every
   # job and files nothing.
   notify-failure:
-    needs: [tag, release-cargo-hax, binstall]
+    needs: [tag, release-cargo-hax, binstall, latest-release, deploy-website]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
@@ -189,6 +225,6 @@ jobs:
           title: Release run for ${{ github.ref_name }} failed
           on-existing: comment
           body: |
-            The `release` workflow failed, so the release may be missing assets: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            The `release` workflow failed, so the release may be missing assets, or the website's manual: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            Once the cause is fixed, restart it with `gh workflow run release.yml --ref ${{ github.ref_name }}`; it publishes only the assets that are still missing.
+            Once the cause is fixed, restart it with `gh workflow run release.yml --ref ${{ github.ref_name }}`; it publishes only the assets that are still missing and redeploys the website.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -64,6 +64,8 @@ The merge starts the `publish` workflow on `main`, pinned to the PR's merge comm
 
 The `release` workflow attaches a `cargo-hax` archive per platform to the GitHub release it creates at the `cargo-hax-v*` tag. `cargo binstall cargo-hax` downloads those, at the names `package.metadata.binstall` in `cli/cargo-hax/Cargo.toml` declares, so both the archives and the published manifest have to be in place for a version to be binstallable. The `binstall` workflow verifies that pairing at the end of every `release` run; a manual dispatch re-checks a released version at any time. A failed run files an issue; it, or a run that never started, can be restarted with `gh workflow run release.yml --ref cargo-hax-vX.Y.Z`. The tag must be the ref: a dispatch on any other ref is recognized as not being a release and skipped.
 
+The website serves the manual of the latest stable GitHub release rather than of `main`, so a stable release also runs the `Deploy to GH Pages` workflow.
+
 ### Trusted publishing
 
 The `publish` workflow authenticates with [trusted publishing](https://crates.io/docs/trusted-publishing): every published crate lists repository `cryspen/hax`, workflow `publish.yml` and environment `crates-io` as a trusted publisher in its crates.io settings. A crate's first version cannot be published that way: publish it with a token once, then add the trusted publisher.


### PR DESCRIPTION
This PR fixes the broken CI job that checks for dead links: https://github.com/cryspen/hax/actions/runs/34075674148

There are two separate issues here:
- eprint.iacr.org rejects the user agent used by the link checker. I set it to use a different user agent.
- A new release does not redeploy the manual because it does not trigger the `release` trigger of GitHub workflows. I added an explicit trigger in the release workflow.

**Assisted by AI, reviewed and edited manually**

[skip changelog]