### PR TITLE
fix(ci): authenticate cargo-binstall against the GitHub API

### DIFF
--- a/.github/workflows/binstall.yml
+++ b/.github/workflows/binstall.yml
@@ -89,9 +89,13 @@ jobs:
 
       - uses: cargo-bins/cargo-binstall@v1.21.1
 
+      # The token authenticates the release lookups against the GitHub API,
+      # whose quota for anonymous requests is shared by every runner on the
+      # same IP and is often spent before this step runs.
       - name: Install the release, from its archive alone
         env:
           VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: >
           cargo binstall --no-confirm --strategies crate-meta-data
           --targets ${{ matrix.target }} --root "$RUNNER_TEMP/hax"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,11 @@ jobs:
           git checkout -B main "$SHA"
 
       - uses: cargo-bins/cargo-binstall@v1.21.1
+      # Authenticates the release lookups against the GitHub API, whose quota
+      # for anonymous requests is shared by every runner on the same IP.
       - run: cargo binstall --no-confirm cargo-release@1.1.4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       # `cargo release` tags the release, which needs a committer identity.
       - run: |

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -63,7 +63,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: cargo-bins/cargo-binstall@v1.21.1
+      # Authenticates the release lookups against the GitHub API, whose quota
+      # for anonymous requests is shared by every runner on the same IP.
       - run: cargo binstall --no-confirm cargo-release@1.1.4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       # `cargo release` commits the bump, which needs a committer identity.
       - run: |


### PR DESCRIPTION
`cargo binstall` checks release assets through the GitHub REST API. Without a token those requests count against the anonymous quota of 60 per hour, shared by every runner behind the same IP. The v0.4.0 binstall check failed on macOS with a 403 for this reason, and the `cargo-release` installs in the publish and release-PR workflows fall back to a source build when the same limit hits.

Passes `github.token` to all three `cargo binstall` steps, raising the quota to 5000 requests per hour per run.

*AI-assisted. Human-reviewed.*

Closes #2225

[skip changelog]