### PR TITLE
fix(core-models): Add pre and post conditions on the `RngCore` trait

### DIFF
--- a/hax-lib/core-models/rand_core/src/lib.rs
+++ b/hax-lib/core-models/rand_core/src/lib.rs
@@ -3,10 +3,15 @@
 // `cargo llvm-cov`, so normal builds and extraction never see this.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+#[hax_lib::attributes]
 pub trait RngCore {
     // Required methods
+    #[hax_lib::requires(true)]
     fn next_u32(&mut self) -> u32;
+    #[hax_lib::requires(true)]
     fn next_u64(&mut self) -> u64;
+    #[hax_lib::requires(true)]
+    #[hax_lib::ensures(|_| future(dst).len() == dst.len())]
     fn fill_bytes(&mut self, dst: &mut [u8]);
 }
 

--- a/hax-lib/proof-libs/fstar/core/Rand_core.fsti
+++ b/hax-lib/proof-libs/fstar/core/Rand_core.fsti
@@ -4,16 +4,22 @@ open FStar.Mul
 open Rust_primitives
 
 class t_RngCore (v_Self: Type0) = {
-  f_next_u32_pre:v_Self -> Type0;
+  f_next_u32_pre:self_: v_Self -> pred: Type0{true ==> pred};
   f_next_u32_post:v_Self -> (v_Self & u32) -> Type0;
   f_next_u32:x0: v_Self
     -> Prims.Pure (v_Self & u32) (f_next_u32_pre x0) (fun result -> f_next_u32_post x0 result);
-  f_next_u64_pre:v_Self -> Type0;
+  f_next_u64_pre:self_: v_Self -> pred: Type0{true ==> pred};
   f_next_u64_post:v_Self -> (v_Self & u64) -> Type0;
   f_next_u64:x0: v_Self
     -> Prims.Pure (v_Self & u64) (f_next_u64_pre x0) (fun result -> f_next_u64_post x0 result);
-  f_fill_bytes_pre:v_Self -> t_Slice u8 -> Type0;
-  f_fill_bytes_post:v_Self -> t_Slice u8 -> (v_Self & t_Slice u8) -> Type0;
+  f_fill_bytes_pre:self_: v_Self -> dst: t_Slice u8 -> pred: Type0{true ==> pred};
+  f_fill_bytes_post:self_: v_Self -> dst: t_Slice u8 -> x: (v_Self & t_Slice u8)
+    -> pred:
+      Type0
+        { pred ==>
+          (let (self_e_future: v_Self), (dst_future: t_Slice u8) = x in
+            (Core_models.Slice.impl__len #u8 dst_future <: usize) =.
+            (Core_models.Slice.impl__len #u8 dst <: usize)) };
   f_fill_bytes:x0: v_Self -> x1: t_Slice u8
     -> Prims.Pure (v_Self & t_Slice u8)
         (f_fill_bytes_pre x0 x1)


### PR DESCRIPTION
This fixes regressions in the model for `RngCore` in our model of `rand` (compared to the hand-written F* before core-models was introduced).

[skip changelog]