### PR TITLE
feat(core-models): model `Option::cloned`

### DIFF
--- a/cli/cargo-hax/defaults.toml
+++ b/cli/cargo-hax/defaults.toml
@@ -19,7 +19,7 @@ lean = "leanprover/lean4:v4.31.0"
 # The Lean library that extracted code builds against. This is a tag in
 # `cryspen/hax-lean`, pushed by `.github/workflows/deploy_hax_lean.yml`; it
 # must match `version` in `hax-lib/proof-libs/lean/lakefile.toml`.
-hax-lean-lib = "v0.3.18"
+hax-lean-lib = "v0.3.19"
 
 # The default opaque set for proof scenarios: trait impls that are
 # routinely derived but rarely worth translating. Applied to every Lean

--- a/hax-lib/core-models/core-models/src/core/option.rs
+++ b/hax-lib/core-models/core-models/src/core/option.rs
@@ -260,6 +260,17 @@ impl<T> Option<Option<T>> {
 }
 
 #[hax_lib::attributes]
+impl<T: super::clone::Clone> Option<T> {
+    /// See [`std::option::Option::cloned`]
+    pub fn cloned(self) -> Option<T> {
+        match self {
+            Some(t) => Some(t.clone()),
+            None => None,
+        }
+    }
+}
+
+#[hax_lib::attributes]
 impl<T> Default for Option<T> {
     /// See [`std::default::Default`]
     fn default() -> Option<T> {
@@ -504,6 +515,11 @@ mod tests {
         #[test]
         fn test_flatten(x in any::<Option<Option<u8>>>()) {
             prop_assert!(x.inject().flatten() == x.flatten().inject());
+        }
+
+        #[test]
+        fn test_cloned(x in any::<Option<u8>>()) {
+            prop_assert!(x.clone().inject().cloned() == x.as_ref().cloned().inject());
         }
 
         #[test]

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -3244,8 +3244,19 @@ let impl_1__flatten (#v_T: Type0) (self: t_Option (t_Option v_T)) : t_Option v_T
   | Option_Some inner -> inner
   | Option_None  -> Option_None <: t_Option v_T
 
+/// See [`std::option::Option::cloned`]
+let impl_2__cloned
+      (#v_T: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core_models.Clone.t_Clone v_T)
+      (self: t_Option v_T)
+    : t_Option v_T =
+  match self <: t_Option v_T with
+  | Option_Some t ->
+    Option_Some (Core_models.Clone.f_clone #v_T #FStar.Tactics.Typeclasses.solve t) <: t_Option v_T
+  | Option_None  -> Option_None <: t_Option v_T
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_2__from__option (#v_T: Type0) : Core_models.Default.t_Default (t_Option v_T) =
+let impl_3__from__option (#v_T: Type0) : Core_models.Default.t_Default (t_Option v_T) =
   {
     f_default_pre = (fun (_: Prims.unit) -> true);
     f_default_post = (fun (_: Prims.unit) (out: t_Option v_T) -> true);
@@ -3253,7 +3264,7 @@ let impl_2__from__option (#v_T: Type0) : Core_models.Default.t_Default (t_Option
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_4__from__option (#v_T: Type0) : Core_models.Ops.Try_trait.t_Try (t_Option v_T) =
+let impl_5 (#v_T: Type0) : Core_models.Ops.Try_trait.t_Try (t_Option v_T) =
   {
     f_Output = v_T;
     f_Residual = t_Option t_Infallible;
@@ -3286,11 +3297,11 @@ let impl_4__from__option (#v_T: Type0) : Core_models.Ops.Try_trait.t_Try (t_Opti
 /// residual carries `Infallible`, so the `Some` arm is unreachable.
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_5': #v_T: Type0
+val impl_6__from__option': #v_T: Type0
   -> Core_models.Ops.Try_trait.t_FromResidual (t_Option v_T) (t_Option t_Infallible)
 
 unfold
-let impl_5 (#v_T: Type0) = impl_5' #v_T
+let impl_6__from__option (#v_T: Type0) = impl_6__from__option' #v_T
 
 /// See [`std::result::Result`]
 type t_Result (v_T: Type0) (v_E: Type0) =
@@ -4385,7 +4396,7 @@ let impl_144: t_From isize bool =
   }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_3__from__option
+let impl_4__from__option
       (#v_T: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: t_PartialEq v_T v_T)
     : t_PartialEq (t_Option v_T) (t_Option v_T) =

--- a/hax-lib/proof-libs/fstar/core/Core_models.Option.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Option.fst
@@ -59,10 +59,12 @@ include Core_models.Bundle {impl__inspect as impl__inspect}
 
 include Core_models.Bundle {impl_1__flatten as impl_1__flatten}
 
-include Core_models.Bundle {impl_2__from__option as impl_2}
+include Core_models.Bundle {impl_2__cloned as impl_2__cloned}
 
 include Core_models.Bundle {impl_3__from__option as impl_3}
 
 include Core_models.Bundle {impl_4__from__option as impl_4}
 
 include Core_models.Bundle {impl_5 as impl_5}
+
+include Core_models.Bundle {impl_6__from__option as impl_6}

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -12477,15 +12477,28 @@ def option.OptionOption.flatten
   | option.Option.Some inner => ok inner
   | option.Option.None => ok option.Option.None
 
+/-- [core_models::option::{core_models::option::Option<T>}::cloned]:
+    Source: 'core-models/src/core/option.rs', lines 265:4-270:5
+    Visibility: public -/
+def option.Option.cloned
+  {T : Type} (cloneCloneInst : clone.Clone T) (self : option.Option T) :
+  RustM (option.Option T)
+  := do
+  match self with
+  | option.Option.Some t =>
+    let t1 ← cloneCloneInst.clone t
+    ok (option.Option.Some t1)
+  | option.Option.None => ok option.Option.None
+
 /-- [core_models::option::{impl core_models::default::Default for core_models::option::Option<T>}::default]:
-    Source: 'core-models/src/core/option.rs', lines 265:4-267:5
+    Source: 'core-models/src/core/option.rs', lines 276:4-278:5
     Visibility: public -/
 def option.Option.Insts.CoreDefaultDefault.default
   (T : Type) : RustM (option.Option T) := do
   ok option.Option.None
 
 /-- Trait implementation: [core_models::option::{impl core_models::default::Default for core_models::option::Option<T>}]
-    Source: 'core-models/src/core/option.rs', lines 263:0-268:1 -/
+    Source: 'core-models/src/core/option.rs', lines 274:0-279:1 -/
 @[reducible]
 def option.Option.Insts.CoreDefaultDefault (T : Type) : default.Default
   (option.Option T) := {
@@ -12493,7 +12506,7 @@ def option.Option.Insts.CoreDefaultDefault (T : Type) : default.Default
 }
 
 /-- [core_models::option::{impl core_models::clone::Clone for core_models::option::Option<T>}::clone]:
-    Source: 'core-models/src/core/option.rs', lines 273:4-278:5
+    Source: 'core-models/src/core/option.rs', lines 284:4-289:5
     Visibility: public -/
 def option.Option.Insts.CoreCloneClone.clone
   {T : Type} (cloneCloneInst : clone.Clone T) (self : option.Option T) :
@@ -12506,7 +12519,7 @@ def option.Option.Insts.CoreCloneClone.clone
   | option.Option.None => ok option.Option.None
 
 /-- Trait implementation: [core_models::option::{impl core_models::clone::Clone for core_models::option::Option<T>}]
-    Source: 'core-models/src/core/option.rs', lines 272:0-279:1 -/
+    Source: 'core-models/src/core/option.rs', lines 283:0-290:1 -/
 @[reducible]
 impl_def option.Option.Insts.CoreCloneClone {T : Type} (cloneCloneInst :
   clone.Clone T) : clone.Clone (option.Option T) := {
@@ -12516,7 +12529,7 @@ impl_def option.Option.Insts.CoreCloneClone {T : Type} (cloneCloneInst :
 }
 
 /-- [core_models::option::{impl core_models::cmp::PartialEq<core_models::option::Option<T>> for core_models::option::Option<T>}::eq]:
-    Source: 'core-models/src/core/option.rs', lines 287:4-293:5
+    Source: 'core-models/src/core/option.rs', lines 298:4-304:5
     Visibility: public -/
 def option.Option.Insts.CoreCmpPartialEqOption.eq
   {T : Type} (cmpPartialEqInst : cmp.PartialEq T T) (self : option.Option T)
@@ -12534,7 +12547,7 @@ def option.Option.Insts.CoreCmpPartialEqOption.eq
     | option.Option.None => ok true
 
 /-- [core_models::option::{impl core_models::cmp::PartialEq<core_models::option::Option<T>> for core_models::option::Option<T>}::ne]:
-    Source: 'core-models/src/core/option.rs', lines 284:4-286:5
+    Source: 'core-models/src/core/option.rs', lines 295:4-297:5
     Visibility: public -/
 def option.Option.Insts.CoreCmpPartialEqOption.ne
   {T : Type} (cmpPartialEqInst : cmp.PartialEq T T) (self : option.Option T)
@@ -12547,7 +12560,7 @@ def option.Option.Insts.CoreCmpPartialEqOption.ne
   ok (b = false)
 
 /-- Trait implementation: [core_models::option::{impl core_models::cmp::PartialEq<core_models::option::Option<T>> for core_models::option::Option<T>}]
-    Source: 'core-models/src/core/option.rs', lines 282:0-294:1 -/
+    Source: 'core-models/src/core/option.rs', lines 293:0-305:1 -/
 @[reducible]
 def option.Option.Insts.CoreCmpPartialEqOption {T : Type}
   (cmpPartialEqInst : cmp.PartialEq T T) : cmp.PartialEq (option.Option T)
@@ -12557,7 +12570,7 @@ def option.Option.Insts.CoreCmpPartialEqOption {T : Type}
 }
 
 /-- [core_models::option::{impl core_models::ops::try_trait::Try<T, core_models::option::Option<core_models::convert::Infallible>> for core_models::option::Option<T>}::branch]:
-    Source: 'core-models/src/core/option.rs', lines 308:4-313:5
+    Source: 'core-models/src/core/option.rs', lines 319:4-324:5
     Visibility: public -/
 def option.Option.Insts.CoreOpsTry_traitTryTOptionInfallible.branch
   {T : Type} (self : option.Option T) :
@@ -12569,14 +12582,14 @@ def option.Option.Insts.CoreOpsTry_traitTryTOptionInfallible.branch
     ok (ops.control_flow.ControlFlow.Break option.Option.None)
 
 /-- [core_models::option::{impl core_models::ops::try_trait::Try<T, core_models::option::Option<core_models::convert::Infallible>> for core_models::option::Option<T>}::from_output]:
-    Source: 'core-models/src/core/option.rs', lines 304:4-306:5
+    Source: 'core-models/src/core/option.rs', lines 315:4-317:5
     Visibility: public -/
 def option.Option.Insts.CoreOpsTry_traitTryTOptionInfallible.from_output
   {T : Type} (output : T) : RustM (option.Option T) := do
   ok (option.Option.Some output)
 
 /-- Trait implementation: [core_models::option::{impl core_models::ops::try_trait::Try<T, core_models::option::Option<core_models::convert::Infallible>> for core_models::option::Option<T>}]
-    Source: 'core-models/src/core/option.rs', lines 300:0-314:1 -/
+    Source: 'core-models/src/core/option.rs', lines 311:0-325:1 -/
 @[reducible]
 def option.Option.Insts.CoreOpsTry_traitTryTOptionInfallible (T : Type)
   : ops.try_trait.Try (option.Option T) T (option.Option convert.Infallible)
@@ -12588,7 +12601,7 @@ def option.Option.Insts.CoreOpsTry_traitTryTOptionInfallible (T : Type)
 }
 
 /-- [core_models::option::{impl core_models::ops::try_trait::FromResidual<core_models::option::Option<core_models::convert::Infallible>> for core_models::option::Option<T>}::from_residual]:
-    Source: 'core-models/src/core/option.rs', lines 324:4-329:5
+    Source: 'core-models/src/core/option.rs', lines 335:4-340:5
     Visibility: public -/
 def
   option.Option.Insts.CoreOpsTry_traitFromResidualOptionInfallible.from_residual
@@ -12600,7 +12613,7 @@ def
   | option.Option.None => ok option.Option.None
 
 /-- Trait implementation: [core_models::option::{impl core_models::ops::try_trait::FromResidual<core_models::option::Option<core_models::convert::Infallible>> for core_models::option::Option<T>}]
-    Source: 'core-models/src/core/option.rs', lines 320:0-330:1 -/
+    Source: 'core-models/src/core/option.rs', lines 331:0-341:1 -/
 @[reducible]
 def option.Option.Insts.CoreOpsTry_traitFromResidualOptionInfallible (T
   : Type) : ops.try_trait.FromResidual (option.Option T) (option.Option

--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "hax"
-version = "0.3.18"
+version = "0.3.19"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
Adds one new core model for `Option::cloned` (needed for Bertie)

[skip changelog]