### PR TITLE
core-models: transparent unsigned rotate_left/right via shifts+xor (F*)

### DIFF
--- a/cli/cargo-hax/defaults.toml
+++ b/cli/cargo-hax/defaults.toml
@@ -19,7 +19,7 @@ lean = "leanprover/lean4:v4.31.0"
 # The Lean library that extracted code builds against. This is a tag in
 # `cryspen/hax-lean`, pushed by `.github/workflows/deploy_hax_lean.yml`; it
 # must match `version` in `hax-lib/proof-libs/lean/lakefile.toml`.
-hax-lean-lib = "v0.3.19"
+hax-lean-lib = "v0.3.20"
 
 # The default opaque set for proof scenarios: trait impls that are
 # routinely derived but rarely worth translating. Applied to every Lean

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -17,6 +17,10 @@ macro_rules! uint_impl {
         $Name: ty,
         $Max: expr,
         $Bits: expr,
+        // Width used for the rotate shift amounts.  Same as `$Bits` for fixed-width
+        // types, but `rust_primitives::SIZE_BITS` for `usize` so the F* `shiftval`
+        // refinement (bounded by the abstract `bits usize == size_bits`) discharges.
+        $ShiftBits: expr,
         $Bytes: expr,
     ) => {
         #[hax_lib::attributes]
@@ -133,14 +137,25 @@ macro_rules! uint_impl {
                 paste! { [<count_ones_ $Name>](x) }
             }
             /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::opaque)]
+            /// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+            /// (which is `x.rotate_right(n)` and would extract back into this model,
+            /// forming a cycle — hence the previous F* `opaque`).  The two shifted
+            /// halves occupy disjoint bit positions, so `^` coincides with `|`.
+            /// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+            /// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+            /// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+            /// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+            /// by the abstract `bits usize == size_bits`, which a literal `64`
+            /// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
             pub fn rotate_right(x: $Self, n: core::primitive::u32) -> $Self {
-                paste! { [<rotate_right_ $Name>](x, n) }
+                let m = n % $ShiftBits;
+                if m == 0 { x } else { (x >> m) ^ (x << ($ShiftBits - m)) }
             }
             /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-            #[cfg_attr(hax_backend_fstar, hax_lib::opaque)]
+            /// Modeled via shifts + xor; see `rotate_right` above for the rationale.
             pub fn rotate_left(x: $Self, n: core::primitive::u32) -> $Self {
-                paste! { [<rotate_left_ $Name>](x, n) }
+                let m = n % $ShiftBits;
+                if m == 0 { x } else { (x << m) ^ (x >> ($ShiftBits - m)) }
             }
             /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
             #[cfg_attr(hax_backend_fstar, hax_lib::opaque)]
@@ -590,6 +605,7 @@ uint_impl! {
     u8,
     255,
     8,
+    8,
     1,
 }
 
@@ -597,6 +613,7 @@ uint_impl! {
     core::primitive::u16,
     u16,
     65535,
+    16,
     16,
     2,
 }
@@ -606,6 +623,7 @@ uint_impl! {
     u32,
     4294967295,
     32,
+    32,
     4,
 }
 
@@ -614,6 +632,7 @@ uint_impl! {
     u64,
     18446744073709551615,
     64,
+    64,
     8,
 }
 
@@ -621,6 +640,7 @@ uint_impl! {
     core::primitive::u128,
     u128,
     340282366920938463463374607431768211455,
+    128,
     128,
     16,
 }
@@ -634,6 +654,10 @@ uint_impl! {
     // `Result U32`, but aeneas inlines associated consts as plain values at use sites
     // (`usize::BITS - x`), matching the fixed-width `u32::BITS : U32`. Value-identical.
     64,
+    // Rotate shift width: `SIZE_BITS` (not the literal `64`) so the F* `shiftval`
+    // refinement, bounded by the abstract `bits usize == size_bits`, discharges.
+    // At a use site aeneas inlines the const, so Lean still sees a plain value.
+    SIZE_BITS,
     SIZE_BYTES,
 }
 

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -17,9 +17,6 @@ macro_rules! uint_impl {
         $Name: ty,
         $Max: expr,
         $Bits: expr,
-        // Width used for the rotate shift amounts.  Same as `$Bits` for fixed-width
-        // types, but `rust_primitives::SIZE_BITS` for `usize` so the F* `shiftval`
-        // refinement (bounded by the abstract `bits usize == size_bits`) discharges.
         $ShiftBits: expr,
         $Bytes: expr,
     ) => {
@@ -137,34 +134,24 @@ macro_rules! uint_impl {
                 paste! { [<count_ones_ $Name>](x) }
             }
             /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-            /// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-            /// (which is `x.rotate_right(n)` and would extract back into this model,
-            /// forming a cycle — hence the previous F* `opaque`).  The two shifted
-            /// halves occupy disjoint bit positions, so `^` coincides with `|`.
-            /// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-            /// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-            /// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-            /// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-            /// by the abstract `bits usize == size_bits`, which a literal `64`
-            /// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-            ///
-            /// `opaque_to_smt`: the shift+xor body is transparent (so the
-            /// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-            /// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-            /// two sides are the SAME rotate application) loses reflexivity and Z3
-            /// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
             #[cfg_attr(hax_backend_fstar, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
             pub fn rotate_right(x: $Self, n: core::primitive::u32) -> $Self {
                 let m = n % $ShiftBits;
-                if m == 0 { x } else { (x >> m) ^ (x << ($ShiftBits - m)) }
+                if m == 0 {
+                    x
+                } else {
+                    (x >> m) ^ (x << ($ShiftBits - m))
+                }
             }
             /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-            /// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-            /// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
             #[cfg_attr(hax_backend_fstar, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
             pub fn rotate_left(x: $Self, n: core::primitive::u32) -> $Self {
                 let m = n % $ShiftBits;
-                if m == 0 { x } else { (x << m) ^ (x >> ($ShiftBits - m)) }
+                if m == 0 {
+                    x
+                } else {
+                    (x << m) ^ (x >> ($ShiftBits - m))
+                }
             }
             /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
             #[cfg_attr(hax_backend_fstar, hax_lib::opaque)]
@@ -663,9 +650,6 @@ uint_impl! {
     // `Result U32`, but aeneas inlines associated consts as plain values at use sites
     // (`usize::BITS - x`), matching the fixed-width `u32::BITS : U32`. Value-identical.
     64,
-    // Rotate shift width: `SIZE_BITS` (not the literal `64`) so the F* `shiftval`
-    // refinement, bounded by the abstract `bits usize == size_bits`, discharges.
-    // At a use site aeneas inlines the const, so Lean still sees a plain value.
     SIZE_BITS,
     SIZE_BYTES,
 }
@@ -880,12 +864,18 @@ mod tests {
                         }
 
                         #[test]
-                        fn [<test_ $t _rotate_right>](x in any::<$t>(), n in 0u32..$t::BITS) {
+                        fn [<test_ $t _rotate_right>](
+                            x in any::<$t>(),
+                            n in prop_oneof![Just(0u32), Just($t::BITS), 0u32..$t::BITS, any::<u32>()],
+                        ) {
                             prop_assert_eq!(super::$t::rotate_right(x.inject(), n), x.rotate_right(n));
                         }
 
                         #[test]
-                        fn [<test_ $t _rotate_left>](x in any::<$t>(), n in 0u32..$t::BITS) {
+                        fn [<test_ $t _rotate_left>](
+                            x in any::<$t>(),
+                            n in prop_oneof![Just(0u32), Just($t::BITS), 0u32..$t::BITS, any::<u32>()],
+                        ) {
                             prop_assert_eq!(super::$t::rotate_left(x.inject(), n), x.rotate_left(n));
                         }
 

--- a/hax-lib/core-models/core-models/src/core/num/mod.rs
+++ b/hax-lib/core-models/core-models/src/core/num/mod.rs
@@ -147,12 +147,21 @@ macro_rules! uint_impl {
             /// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
             /// by the abstract `bits usize == size_bits`, which a literal `64`
             /// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+            ///
+            /// `opaque_to_smt`: the shift+xor body is transparent (so the
+            /// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+            /// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+            /// two sides are the SAME rotate application) loses reflexivity and Z3
+            /// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+            #[cfg_attr(hax_backend_fstar, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
             pub fn rotate_right(x: $Self, n: core::primitive::u32) -> $Self {
                 let m = n % $ShiftBits;
                 if m == 0 { x } else { (x >> m) ^ (x << ($ShiftBits - m)) }
             }
             /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
             /// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+            /// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+            #[cfg_attr(hax_backend_fstar, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
             pub fn rotate_left(x: $Self, n: core::primitive::u32) -> $Self {
                 let m = n % $ShiftBits;
                 if m == 0 { x } else { (x << m) ^ (x >> ($ShiftBits - m)) }

--- a/hax-lib/core-models/rust_primitives/src/lib.rs
+++ b/hax-lib/core-models/rust_primitives/src/lib.rs
@@ -276,12 +276,6 @@ pub mod arithmetic {
                 pub fn [<count_ones_ $Self>](x: $Self) -> u32 {
                     x.count_ones()
                 }
-                pub fn [<rotate_right_ $Self>](x: $Self, n: u32) -> $Self {
-                    x.rotate_right(n)
-                }
-                pub fn [<rotate_left_ $Self>](x: $Self, n: u32) -> $Self {
-                    x.rotate_left(n)
-                }
                 pub fn [<leading_zeros_ $Self>](x: $Self) -> u32 {
                     x.leading_zeros()
                 }
@@ -316,8 +310,14 @@ pub mod arithmetic {
             paste! {
                 $(
                     pub fn [<abs_ $Self>](x: $Self) -> $Self {
-                    x.abs()
-                }
+                        x.abs()
+                    }
+                    pub fn [<rotate_right_ $Self>](x: $Self, n: u32) -> $Self {
+                        x.rotate_right(n)
+                    }
+                    pub fn [<rotate_left_ $Self>](x: $Self, n: u32) -> $Self {
+                        x.rotate_left(n)
+                    }
                 )*
             }
         }

--- a/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
+++ b/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
@@ -608,6 +608,16 @@ pub fn test_usize_rotate_right_one() -> bool {
     2usize.rotate_right(1u32) == 1usize
 }
 
+#[rust_lean_test]
+pub fn test_usize_rotate_left_wrapping() -> bool {
+    1usize.rotate_left(65u32) == 2usize
+}
+
+#[rust_lean_test]
+pub fn test_usize_rotate_right_wrapping() -> bool {
+    2usize.rotate_right(65u32) == 1usize
+}
+
 // =============================================================================
 // leading_zeros
 // =============================================================================

--- a/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
+++ b/hax-lib/core-models/tests/rust_lean_equiv_test/source/src/core/num.rs
@@ -583,6 +583,31 @@ pub fn test_u8_rotate_right_full() -> bool {
     0b10000001u8.rotate_right(8u32) == 0b10000001u8
 }
 
+#[rust_lean_test]
+pub fn test_u8_rotate_left_wrapping() -> bool {
+    0b10000001u8.rotate_left(9u32) == 0b00000011u8
+}
+
+#[rust_lean_test]
+pub fn test_u8_rotate_right_wrapping() -> bool {
+    0b10000001u8.rotate_right(9u32) == 0b11000000u8
+}
+
+#[rust_lean_test]
+pub fn test_usize_rotate_left_zero() -> bool {
+    1usize.rotate_left(0u32) == 1usize
+}
+
+#[rust_lean_test]
+pub fn test_usize_rotate_left_one() -> bool {
+    1usize.rotate_left(1u32) == 2usize
+}
+
+#[rust_lean_test]
+pub fn test_usize_rotate_right_one() -> bool {
+    2usize.rotate_right(1u32) == 1usize
+}
+
 // =============================================================================
 // leading_zeros
 // =============================================================================

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -330,18 +330,25 @@ let impl_6__overflowing_pow (x: u8) (exp: u32) : (u8 & bool) =
 let impl_6__count_ones (x: u8) : u32 = Rust_primitives.Arithmetic.count_ones_u8 x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_6__rotate_right': x: u8 -> n: u32 -> u8
-
-unfold
-let impl_6__rotate_right = impl_6__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_6__rotate_right (x: u8) (n: u32) : u8 =
+  let m:u32 = n %! mk_u32 8 in
+  if m =. mk_u32 0 then x else (x >>! m <: u8) ^. (x <<! (mk_u32 8 -! m <: u32) <: u8)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_6__rotate_left': x: u8 -> n: u32 -> u8
-
-unfold
-let impl_6__rotate_left = impl_6__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_6__rotate_left (x: u8) (n: u32) : u8 =
+  let m:u32 = n %! mk_u32 8 in
+  if m =. mk_u32 0 then x else (x <<! m <: u8) ^. (x >>! (mk_u32 8 -! m <: u32) <: u8)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -490,18 +497,25 @@ let impl_7__overflowing_pow (x: u16) (exp: u32) : (u16 & bool) =
 let impl_7__count_ones (x: u16) : u32 = Rust_primitives.Arithmetic.count_ones_u16 x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_7__rotate_right': x: u16 -> n: u32 -> u16
-
-unfold
-let impl_7__rotate_right = impl_7__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_7__rotate_right (x: u16) (n: u32) : u16 =
+  let m:u32 = n %! mk_u32 16 in
+  if m =. mk_u32 0 then x else (x >>! m <: u16) ^. (x <<! (mk_u32 16 -! m <: u32) <: u16)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_7__rotate_left': x: u16 -> n: u32 -> u16
-
-unfold
-let impl_7__rotate_left = impl_7__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_7__rotate_left (x: u16) (n: u32) : u16 =
+  let m:u32 = n %! mk_u32 16 in
+  if m =. mk_u32 0 then x else (x <<! m <: u16) ^. (x >>! (mk_u32 16 -! m <: u32) <: u16)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -650,18 +664,25 @@ let impl_8__overflowing_pow (x exp: u32) : (u32 & bool) =
 let impl_8__count_ones (x: u32) : u32 = Rust_primitives.Arithmetic.count_ones_u32 x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_8__rotate_right': x: u32 -> n: u32 -> u32
-
-unfold
-let impl_8__rotate_right = impl_8__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_8__rotate_right (x n: u32) : u32 =
+  let m:u32 = n %! mk_u32 32 in
+  if m =. mk_u32 0 then x else (x >>! m <: u32) ^. (x <<! (mk_u32 32 -! m <: u32) <: u32)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_8__rotate_left': x: u32 -> n: u32 -> u32
-
-unfold
-let impl_8__rotate_left = impl_8__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_8__rotate_left (x n: u32) : u32 =
+  let m:u32 = n %! mk_u32 32 in
+  if m =. mk_u32 0 then x else (x <<! m <: u32) ^. (x >>! (mk_u32 32 -! m <: u32) <: u32)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -810,18 +831,25 @@ let impl_9__overflowing_pow (x: u64) (exp: u32) : (u64 & bool) =
 let impl_9__count_ones (x: u64) : u32 = Rust_primitives.Arithmetic.count_ones_u64 x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_9__rotate_right': x: u64 -> n: u32 -> u64
-
-unfold
-let impl_9__rotate_right = impl_9__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_9__rotate_right (x: u64) (n: u32) : u64 =
+  let m:u32 = n %! mk_u32 64 in
+  if m =. mk_u32 0 then x else (x >>! m <: u64) ^. (x <<! (mk_u32 64 -! m <: u32) <: u64)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_9__rotate_left': x: u64 -> n: u32 -> u64
-
-unfold
-let impl_9__rotate_left = impl_9__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_9__rotate_left (x: u64) (n: u32) : u64 =
+  let m:u32 = n %! mk_u32 64 in
+  if m =. mk_u32 0 then x else (x <<! m <: u64) ^. (x >>! (mk_u32 64 -! m <: u32) <: u64)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -970,18 +998,25 @@ let impl_10__overflowing_pow (x: u128) (exp: u32) : (u128 & bool) =
 let impl_10__count_ones (x: u128) : u32 = Rust_primitives.Arithmetic.count_ones_u128 x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_10__rotate_right': x: u128 -> n: u32 -> u128
-
-unfold
-let impl_10__rotate_right = impl_10__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_10__rotate_right (x: u128) (n: u32) : u128 =
+  let m:u32 = n %! mk_u32 128 in
+  if m =. mk_u32 0 then x else (x >>! m <: u128) ^. (x <<! (mk_u32 128 -! m <: u32) <: u128)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_10__rotate_left': x: u128 -> n: u32 -> u128
-
-unfold
-let impl_10__rotate_left = impl_10__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_10__rotate_left (x: u128) (n: u32) : u128 =
+  let m:u32 = n %! mk_u32 128 in
+  if m =. mk_u32 0 then x else (x <<! m <: u128) ^. (x >>! (mk_u32 128 -! m <: u32) <: u128)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -1136,18 +1171,29 @@ let impl_11__overflowing_pow (x: usize) (exp: u32) : (usize & bool) =
 let impl_11__count_ones (x: usize) : u32 = Rust_primitives.Arithmetic.count_ones_usize x
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-assume
-val impl_11__rotate_right': x: usize -> n: u32 -> usize
-
-unfold
-let impl_11__rotate_right = impl_11__rotate_right'
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+let impl_11__rotate_right (x: usize) (n: u32) : usize =
+  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
+  if m =. mk_u32 0
+  then x
+  else (x >>! m <: usize) ^. (x <<! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-assume
-val impl_11__rotate_left': x: usize -> n: u32 -> usize
-
-unfold
-let impl_11__rotate_left = impl_11__rotate_left'
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+let impl_11__rotate_left (x: usize) (n: u32) : usize =
+  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
+  if m =. mk_u32 0
+  then x
+  else (x <<! m <: usize) ^. (x >>! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -415,21 +415,6 @@ let impl_6__rem_euclid (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_6__rotate_right (x: u8) (n: u32) : u8 =
   let m:u32 = n %! mk_u32 8 in
   if m =. mk_u32 0 then x else (x >>! m <: u8) ^. (x <<! (mk_u32 8 -! m <: u32) <: u8)
@@ -437,8 +422,6 @@ let impl_6__rotate_right (x: u8) (n: u32) : u8 =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_6__rotate_left (x: u8) (n: u32) : u8 =
   let m:u32 = n %! mk_u32 8 in
   if m =. mk_u32 0 then x else (x <<! m <: u8) ^. (x >>! (mk_u32 8 -! m <: u32) <: u8)
@@ -592,21 +575,6 @@ let impl_7__rem_euclid (x y: u16) : Prims.Pure u16 (requires y <>. mk_u16 0) (fu
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_7__rotate_right (x: u16) (n: u32) : u16 =
   let m:u32 = n %! mk_u32 16 in
   if m =. mk_u32 0 then x else (x >>! m <: u16) ^. (x <<! (mk_u32 16 -! m <: u32) <: u16)
@@ -614,8 +582,6 @@ let impl_7__rotate_right (x: u16) (n: u32) : u16 =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_7__rotate_left (x: u16) (n: u32) : u16 =
   let m:u32 = n %! mk_u32 16 in
   if m =. mk_u32 0 then x else (x <<! m <: u16) ^. (x >>! (mk_u32 16 -! m <: u32) <: u16)
@@ -769,21 +735,6 @@ let impl_8__rem_euclid (x y: u32) : Prims.Pure u32 (requires y <>. mk_u32 0) (fu
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_8__rotate_right (x n: u32) : u32 =
   let m:u32 = n %! mk_u32 32 in
   if m =. mk_u32 0 then x else (x >>! m <: u32) ^. (x <<! (mk_u32 32 -! m <: u32) <: u32)
@@ -791,8 +742,6 @@ let impl_8__rotate_right (x n: u32) : u32 =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_8__rotate_left (x n: u32) : u32 =
   let m:u32 = n %! mk_u32 32 in
   if m =. mk_u32 0 then x else (x <<! m <: u32) ^. (x >>! (mk_u32 32 -! m <: u32) <: u32)
@@ -946,21 +895,6 @@ let impl_9__rem_euclid (x y: u64) : Prims.Pure u64 (requires y <>. mk_u64 0) (fu
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_9__rotate_right (x: u64) (n: u32) : u64 =
   let m:u32 = n %! mk_u32 64 in
   if m =. mk_u32 0 then x else (x >>! m <: u64) ^. (x <<! (mk_u32 64 -! m <: u32) <: u64)
@@ -968,8 +902,6 @@ let impl_9__rotate_right (x: u64) (n: u32) : u64 =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_9__rotate_left (x: u64) (n: u32) : u64 =
   let m:u32 = n %! mk_u32 64 in
   if m =. mk_u32 0 then x else (x <<! m <: u64) ^. (x >>! (mk_u32 64 -! m <: u32) <: u64)
@@ -1125,21 +1057,6 @@ let impl_10__rem_euclid (x y: u128)
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_10__rotate_right (x: u128) (n: u32) : u128 =
   let m:u32 = n %! mk_u32 128 in
   if m =. mk_u32 0 then x else (x >>! m <: u128) ^. (x <<! (mk_u32 128 -! m <: u32) <: u128)
@@ -1147,8 +1064,6 @@ let impl_10__rotate_right (x: u128) (n: u32) : u128 =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_10__rotate_left (x: u128) (n: u32) : u128 =
   let m:u32 = n %! mk_u32 128 in
   if m =. mk_u32 0 then x else (x <<! m <: u128) ^. (x >>! (mk_u32 128 -! m <: u32) <: u128)
@@ -1308,21 +1223,6 @@ let impl_11__rem_euclid (x y: usize)
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-/// `opaque_to_smt`: the shift+xor body is transparent (so the
-/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
-/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
-/// two sides are the SAME rotate application) loses reflexivity and Z3
-/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
 let impl_11__rotate_right (x: usize) (n: u32) : usize =
   let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
   if m =. mk_u32 0
@@ -1332,8 +1232,6 @@ let impl_11__rotate_right (x: usize) (n: u32) : usize =
 [@@ "opaque_to_smt"]
 
 /// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
 let impl_11__rotate_left (x: usize) (n: u32) : usize =
   let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
   if m =. mk_u32 0

--- a/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
+++ b/hax-lib/proof-libs/fstar/core/Core_models.Bundle.fst
@@ -329,27 +329,6 @@ let impl_6__overflowing_pow (x: u8) (exp: u32) : (u8 & bool) =
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_6__count_ones (x: u8) : u32 = Rust_primitives.Arithmetic.count_ones_u8 x
 
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_6__rotate_right (x: u8) (n: u32) : u8 =
-  let m:u32 = n %! mk_u32 8 in
-  if m =. mk_u32 0 then x else (x >>! m <: u8) ^. (x <<! (mk_u32 8 -! m <: u32) <: u8)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_6__rotate_left (x: u8) (n: u32) : u8 =
-  let m:u32 = n %! mk_u32 8 in
-  if m =. mk_u32 0 then x else (x <<! m <: u8) ^. (x >>! (mk_u32 8 -! m <: u32) <: u8)
-
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
 val impl_6__leading_zeros': x: u8 -> u32
@@ -433,6 +412,37 @@ let impl_6__unchecked_mul (x y: u8)
 let impl_6__rem_euclid (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_u8 x y
 
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_6__rotate_right (x: u8) (n: u32) : u8 =
+  let m:u32 = n %! mk_u32 8 in
+  if m =. mk_u32 0 then x else (x >>! m <: u8) ^. (x <<! (mk_u32 8 -! m <: u32) <: u8)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_6__rotate_left (x: u8) (n: u32) : u8 =
+  let m:u32 = n %! mk_u32 8 in
+  if m =. mk_u32 0 then x else (x <<! m <: u8) ^. (x >>! (mk_u32 8 -! m <: u32) <: u8)
+
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_6__unchecked_div (x y: u8) : Prims.Pure u8 (requires y <>. mk_u8 0) (fun _ -> Prims.l_True) =
   x /! y
@@ -495,27 +505,6 @@ let impl_7__overflowing_pow (x: u16) (exp: u32) : (u16 & bool) =
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_7__count_ones (x: u16) : u32 = Rust_primitives.Arithmetic.count_ones_u16 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_7__rotate_right (x: u16) (n: u32) : u16 =
-  let m:u32 = n %! mk_u32 16 in
-  if m =. mk_u32 0 then x else (x >>! m <: u16) ^. (x <<! (mk_u32 16 -! m <: u32) <: u16)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_7__rotate_left (x: u16) (n: u32) : u16 =
-  let m:u32 = n %! mk_u32 16 in
-  if m =. mk_u32 0 then x else (x <<! m <: u16) ^. (x >>! (mk_u32 16 -! m <: u32) <: u16)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -600,6 +589,37 @@ let impl_7__unchecked_mul (x y: u16)
 let impl_7__rem_euclid (x y: u16) : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_u16 x y
 
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_7__rotate_right (x: u16) (n: u32) : u16 =
+  let m:u32 = n %! mk_u32 16 in
+  if m =. mk_u32 0 then x else (x >>! m <: u16) ^. (x <<! (mk_u32 16 -! m <: u32) <: u16)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_7__rotate_left (x: u16) (n: u32) : u16 =
+  let m:u32 = n %! mk_u32 16 in
+  if m =. mk_u32 0 then x else (x <<! m <: u16) ^. (x >>! (mk_u32 16 -! m <: u32) <: u16)
+
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_7__unchecked_div (x y: u16)
     : Prims.Pure u16 (requires y <>. mk_u16 0) (fun _ -> Prims.l_True) = x /! y
@@ -662,27 +682,6 @@ let impl_8__overflowing_pow (x exp: u32) : (u32 & bool) =
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_8__count_ones (x: u32) : u32 = Rust_primitives.Arithmetic.count_ones_u32 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_8__rotate_right (x n: u32) : u32 =
-  let m:u32 = n %! mk_u32 32 in
-  if m =. mk_u32 0 then x else (x >>! m <: u32) ^. (x <<! (mk_u32 32 -! m <: u32) <: u32)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_8__rotate_left (x n: u32) : u32 =
-  let m:u32 = n %! mk_u32 32 in
-  if m =. mk_u32 0 then x else (x <<! m <: u32) ^. (x >>! (mk_u32 32 -! m <: u32) <: u32)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -767,6 +766,37 @@ let impl_8__unchecked_mul (x y: u32)
 let impl_8__rem_euclid (x y: u32) : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_u32 x y
 
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_8__rotate_right (x n: u32) : u32 =
+  let m:u32 = n %! mk_u32 32 in
+  if m =. mk_u32 0 then x else (x >>! m <: u32) ^. (x <<! (mk_u32 32 -! m <: u32) <: u32)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_8__rotate_left (x n: u32) : u32 =
+  let m:u32 = n %! mk_u32 32 in
+  if m =. mk_u32 0 then x else (x <<! m <: u32) ^. (x >>! (mk_u32 32 -! m <: u32) <: u32)
+
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_8__unchecked_div (x y: u32)
     : Prims.Pure u32 (requires y <>. mk_u32 0) (fun _ -> Prims.l_True) = x /! y
@@ -829,27 +859,6 @@ let impl_9__overflowing_pow (x: u64) (exp: u32) : (u64 & bool) =
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_9__count_ones (x: u64) : u32 = Rust_primitives.Arithmetic.count_ones_u64 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_9__rotate_right (x: u64) (n: u32) : u64 =
-  let m:u32 = n %! mk_u32 64 in
-  if m =. mk_u32 0 then x else (x >>! m <: u64) ^. (x <<! (mk_u32 64 -! m <: u32) <: u64)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_9__rotate_left (x: u64) (n: u32) : u64 =
-  let m:u32 = n %! mk_u32 64 in
-  if m =. mk_u32 0 then x else (x <<! m <: u64) ^. (x >>! (mk_u32 64 -! m <: u32) <: u64)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -934,6 +943,37 @@ let impl_9__unchecked_mul (x y: u64)
 let impl_9__rem_euclid (x y: u64) : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_u64 x y
 
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_9__rotate_right (x: u64) (n: u32) : u64 =
+  let m:u32 = n %! mk_u32 64 in
+  if m =. mk_u32 0 then x else (x >>! m <: u64) ^. (x <<! (mk_u32 64 -! m <: u32) <: u64)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_9__rotate_left (x: u64) (n: u32) : u64 =
+  let m:u32 = n %! mk_u32 64 in
+  if m =. mk_u32 0 then x else (x <<! m <: u64) ^. (x >>! (mk_u32 64 -! m <: u32) <: u64)
+
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_9__unchecked_div (x y: u64)
     : Prims.Pure u64 (requires y <>. mk_u64 0) (fun _ -> Prims.l_True) = x /! y
@@ -996,27 +1036,6 @@ let impl_10__overflowing_pow (x: u128) (exp: u32) : (u128 & bool) =
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_10__count_ones (x: u128) : u32 = Rust_primitives.Arithmetic.count_ones_u128 x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_10__rotate_right (x: u128) (n: u32) : u128 =
-  let m:u32 = n %! mk_u32 128 in
-  if m =. mk_u32 0 then x else (x >>! m <: u128) ^. (x <<! (mk_u32 128 -! m <: u32) <: u128)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_10__rotate_left (x: u128) (n: u32) : u128 =
-  let m:u32 = n %! mk_u32 128 in
-  if m =. mk_u32 0 then x else (x <<! m <: u128) ^. (x >>! (mk_u32 128 -! m <: u32) <: u128)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -1103,6 +1122,37 @@ let impl_10__rem_euclid (x y: u128)
     : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_u128 x y
 
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_10__rotate_right (x: u128) (n: u32) : u128 =
+  let m:u32 = n %! mk_u32 128 in
+  if m =. mk_u32 0 then x else (x >>! m <: u128) ^. (x <<! (mk_u32 128 -! m <: u32) <: u128)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_10__rotate_left (x: u128) (n: u32) : u128 =
+  let m:u32 = n %! mk_u32 128 in
+  if m =. mk_u32 0 then x else (x <<! m <: u128) ^. (x >>! (mk_u32 128 -! m <: u32) <: u128)
+
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_10__unchecked_div (x y: u128)
     : Prims.Pure u128 (requires y <>. mk_u128 0) (fun _ -> Prims.l_True) = x /! y
@@ -1169,31 +1219,6 @@ let impl_11__overflowing_pow (x: usize) (exp: u32) : (usize & bool) =
 
 /// See [`std::primitive::u8::count_ones`] (and similar for other integer types)
 let impl_11__count_ones (x: usize) : u32 = Rust_primitives.Arithmetic.count_ones_usize x
-
-/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
-/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
-/// (which is `x.rotate_right(n)` and would extract back into this model,
-/// forming a cycle — hence the previous F* `opaque`).  The two shifted
-/// halves occupy disjoint bit positions, so `^` coincides with `|`.
-/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
-/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
-/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
-/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
-/// by the abstract `bits usize == size_bits`, which a literal `64`
-/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
-let impl_11__rotate_right (x: usize) (n: u32) : usize =
-  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
-  if m =. mk_u32 0
-  then x
-  else (x >>! m <: usize) ^. (x <<! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
-
-/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
-/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
-let impl_11__rotate_left (x: usize) (n: u32) : usize =
-  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
-  if m =. mk_u32 0
-  then x
-  else (x <<! m <: usize) ^. (x >>! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
 
 /// See [`std::primitive::u8::leading_zeros`] (and similar for other integer types)
 assume
@@ -1279,6 +1304,41 @@ let impl_11__unchecked_mul (x y: usize)
 let impl_11__rem_euclid (x y: usize)
     : Prims.Pure usize (requires y <>. mk_usize 0) (fun _ -> Prims.l_True) =
   Rust_primitives.Arithmetic.rem_euclid_usize x y
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_right`] (and similar for other integer types)
+/// Modeled via shifts + xor rather than the `rotate_right_*` primitive
+/// (which is `x.rotate_right(n)` and would extract back into this model,
+/// forming a cycle — hence the previous F* `opaque`).  The two shifted
+/// halves occupy disjoint bit positions, so `^` coincides with `|`.
+/// `m = n % BITS`; the `m == 0` guard avoids the full-width shift
+/// `x >> BITS` / `x << BITS`, which is undefined.  The width is
+/// `$ShiftBits` (the literal for fixed-width types, `SIZE_BITS` for
+/// `usize`): for `usize` the F* shift refinement `shiftval` is bounded
+/// by the abstract `bits usize == size_bits`, which a literal `64`
+/// cannot discharge but `SIZE_BITS` (`== mk_u32 size_bits`) can.
+/// `opaque_to_smt`: the shift+xor body is transparent (so the
+/// `Proof_Utils.Lemmas` bridge lemma can `reveal` it), but rotate is an
+/// atom by default — otherwise every consumer (e.g. Keccak `rho`, whose
+/// two sides are the SAME rotate application) loses reflexivity and Z3
+/// re-proves 25 nonlinear shift+xor equalities per lemma (saturation).
+let impl_11__rotate_right (x: usize) (n: u32) : usize =
+  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
+  if m =. mk_u32 0
+  then x
+  else (x >>! m <: usize) ^. (x <<! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
+
+[@@ "opaque_to_smt"]
+
+/// See [`std::primitive::u8::rotate_left`] (and similar for other integer types)
+/// Modeled via shifts + xor; see `rotate_right` above for the rationale.
+/// `opaque_to_smt` (see `rotate_right`): atom by default, revealable body.
+let impl_11__rotate_left (x: usize) (n: u32) : usize =
+  let m:u32 = n %! Rust_primitives.Arithmetic.v_SIZE_BITS in
+  if m =. mk_u32 0
+  then x
+  else (x <<! m <: usize) ^. (x >>! (Rust_primitives.Arithmetic.v_SIZE_BITS -! m <: u32) <: usize)
 
 /// See [`std::primitive::u8::unchecked_div`] (and similar for other integer types)
 let impl_11__unchecked_div (x y: usize)

--- a/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
+++ b/hax-lib/proof-libs/fstar/rust_primitives/Rust_primitives.Arithmetic.fsti
@@ -20,8 +20,6 @@ let rem_euclid_u8 (x: u8) (y: u8 {v y <> 0}): u8 = x %! y
 val pow_u8 : u8 -> u32 -> u8
 val overflowing_pow_u8 : u8 -> u32 -> u8 & bool
 val count_ones_u8 : u8 -> r:u32{v r <= 8}
-unfold 
-let rotate_left_u8 = rotate_left_u #U8
 
 let wrapping_add_u16 : u16 -> u16 -> u16 = add_mod
 let saturating_add_u16 : u16 -> u16 -> u16 = add_sat
@@ -40,8 +38,6 @@ let rem_euclid_u16 (x: u16) (y: u16 {v y <> 0}): u16 = x %! y
 val pow_u16 : x:u16 -> y:u32 -> result : u16 {v x == 2 /\ v y < 16 ==> result == mk_u16 (pow2 (v y))}
 val overflowing_pow_u16 : u16 -> u32 -> u16 & bool
 val count_ones_u16 : u16 -> r:u32{v r <= 16}
-unfold 
-let rotate_left_u16 = rotate_left_u #U16
 
 let wrapping_add_u32 : u32 -> u32 -> u32 = add_mod
 let saturating_add_u32 : u32 -> u32 -> u32 = add_sat
@@ -60,8 +56,6 @@ let rem_euclid_u32 (x: u32) (y: u32 {v y <> 0}): u32 = x %! y
 val pow_u32 : x:u32 -> y:u32 -> result : u32 {v x == 2 /\ v y <= 16 ==> result == mk_u32 (pow2 (v y))}
 val overflowing_pow_u32 : u32 -> u32 -> u32 & bool
 val count_ones_u32 : u32 -> r:u32{v r <= 32}
-unfold 
-let rotate_left_u32 = rotate_left_u #U32
 
 let wrapping_add_u64 : u64 -> u64 -> u64 = add_mod
 let saturating_add_u64 : u64 -> u64 -> u64 = add_sat
@@ -80,8 +74,6 @@ let rem_euclid_u64 (x: u64) (y: u64 {v y <> 0}): u64 = x %! y
 val pow_u64 : u64 -> u32 -> u64
 val overflowing_pow_u64 : u64 -> u32 -> u64 & bool
 val count_ones_u64 : u64 -> r:u32{v r <= 64}
-unfold 
-let rotate_left_u64 = rotate_left_u #U64
 
 let wrapping_add_u128 : u128 -> u128 -> u128 = add_mod
 let saturating_add_u128 : u128 -> u128 -> u128 = add_sat
@@ -100,8 +92,6 @@ let rem_euclid_u128 (x: u128) (y: u128 {v y <> 0}): u128 = x %! y
 val pow_u128 : u128 -> u32 -> u128
 val overflowing_pow_u128 : u128 -> u32 -> u128 & bool
 val count_ones_u128 : u128 -> r:u32{v r <= 128}
-unfold 
-let rotate_left_u128 = rotate_left_u #U128
 
 let wrapping_add_usize : usize -> usize -> usize = add_mod
 let saturating_add_usize : usize -> usize -> usize = add_sat
@@ -120,8 +110,6 @@ let rem_euclid_usize (x: usize) (y: usize {v y <> 0}): usize = x %! y
 val pow_usize : usize -> u32 -> usize
 val overflowing_pow_usize : usize -> u32 -> usize & bool
 val count_ones_usize : usize -> r:u32{v r <= size_bits}
-unfold 
-let rotate_left_usize = rotate_left_u #USIZE
 
 let wrapping_add_i8 : i8 -> i8 -> i8 = add_mod
 let saturating_add_i8 : i8 -> i8 -> i8 = add_sat

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Funs.lean
@@ -1731,14 +1731,14 @@ def I128.Insts.CoreConvertFromU64 : convert.From Std.I128 Std.U64 := {
 
 /-
 /-- [core_models::num::{core_models::num::u8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible] def num.U8.MAX : Std.U8 := 255#u8
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::u8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U8.MIN : Std.U8 := 0#u8
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1791,14 +1791,14 @@ def U8.Insts.CoreConvertTryFromU32TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::u16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible] def num.U16.MAX : Std.U16 := 65535#u16
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::u16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U16.MIN : Std.U16 := 0#u16
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1874,14 +1874,14 @@ def U16.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::u32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible] def num.U32.MAX : Std.U32 := 4294967295#u32
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::u32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U32.MIN : Std.U32 := 0#u32
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -1911,7 +1911,7 @@ def U32.Insts.CoreConvertTryFromU64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::usize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Usize.MAX : RustM Std.Usize := rust_primitives.arithmetic.USIZE_MAX
@@ -1919,7 +1919,7 @@ def num.Usize.MAX : RustM Std.Usize := rust_primitives.arithmetic.USIZE_MAX
 
 /-
 /-- [core_models::num::{core_models::num::usize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.Usize.MIN : Std.Usize := 0#usize
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2025,7 +2025,7 @@ def U32.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::u64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.U64.MAX : Std.U64 := 18446744073709551615#u64
@@ -2033,7 +2033,7 @@ def num.U64.MAX : Std.U64 := 18446744073709551615#u64
 
 /-
 /-- [core_models::num::{core_models::num::u64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U64.MIN : Std.U64 := 0#u64
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2191,14 +2191,14 @@ def U64.Insts.CoreConvertTryFromUsizeTryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MAX : Std.I8 := 127#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i8}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.MIN : Std.I8 := (-128)#i8
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2251,14 +2251,14 @@ def I8.Insts.CoreConvertTryFromI32TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MAX : Std.I16 := 32767#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i16}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.MIN : Std.I16 := (-32768)#i16
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2334,14 +2334,14 @@ def I16.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MAX : Std.I32 := 2147483647#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-
 /-- [core_models::num::{core_models::num::i32}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.MIN : Std.I32 := (-2147483648)#i32
 -/  -- provided by CoreModels.Core.FunsPrologue
@@ -2371,7 +2371,7 @@ def I32.Insts.CoreConvertTryFromI64TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MAX : RustM Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
@@ -2379,7 +2379,7 @@ def num.Isize.MAX : RustM Std.Isize := rust_primitives.arithmetic.ISIZE_MAX
 
 /-
 /-- [core_models::num::{core_models::num::isize}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.Isize.MIN : RustM Std.Isize := rust_primitives.arithmetic.ISIZE_MIN
@@ -2487,7 +2487,7 @@ def I32.Insts.CoreConvertTryFromI128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MAX : Std.I64 := 9223372036854775807#i64
@@ -2495,7 +2495,7 @@ def num.I64.MAX : Std.I64 := 9223372036854775807#i64
 
 /-
 /-- [core_models::num::{core_models::num::i64}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I64.MIN : Std.I64 := (-9223372036854775808)#i64
@@ -2999,7 +2999,7 @@ def I64.Insts.CoreConvertTryFromU128TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 274:12-274:40
+    Source: 'core-models/src/core/num/mod.rs', lines 285:12-285:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MAX : Std.I128 := 170141183460469231731687303715884105727#i128
@@ -3227,7 +3227,7 @@ def U64.Insts.CoreConvertTryFromI8TryFromIntError : convert.TryFrom
 
 /-
 /-- [core_models::num::{core_models::num::u128}::MAX]
-    Source: 'core-models/src/core/num/mod.rs', lines 27:12-27:40
+    Source: 'core-models/src/core/num/mod.rs', lines 28:12-28:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.U128.MAX : Std.U128 := 340282366920938463463374607431768211455#u128
@@ -6650,14 +6650,14 @@ def option.Option.unwrap {T : Type} (self : option.Option T) : RustM T := do
   | option.Option.None => panicking.internal.panic T
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.I8.overflowing_add
   (x : Std.I8) (y : Std.I8) : RustM (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.I8.checked_add_unsigned
   (x : Std.I8) (y : Std.U8) : RustM (option.Option Std.I8) := do
@@ -6678,14 +6678,14 @@ def I8.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.I16.overflowing_add
   (x : Std.I16) (y : Std.I16) : RustM (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.I16.checked_add_unsigned
   (x : Std.I16) (y : Std.U16) : RustM (option.Option Std.I16) := do
@@ -6706,14 +6706,14 @@ def I16.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.I32.overflowing_add
   (x : Std.I32) (y : Std.I32) : RustM (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.I32.checked_add_unsigned
   (x : Std.I32) (y : Std.U32) : RustM (option.Option Std.I32) := do
@@ -6734,14 +6734,14 @@ def I32.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.I64.overflowing_add
   (x : Std.I64) (y : Std.I64) : RustM (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.I64.checked_add_unsigned
   (x : Std.I64) (y : Std.U64) : RustM (option.Option Std.I64) := do
@@ -6762,14 +6762,14 @@ def I64.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.Isize.overflowing_add
   (x : Std.Isize) (y : Std.Isize) : RustM (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.Isize.checked_add_unsigned
   (x : Std.Isize) (y : Std.Usize) : RustM (option.Option Std.Isize) := do
@@ -6790,14 +6790,14 @@ def Isize.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 285:12-287:13
+    Source: 'core-models/src/core/num/mod.rs', lines 296:12-298:13
     Visibility: public -/
 def num.I128.overflowing_add
   (x : Std.I128) (y : Std.I128) : RustM (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_add_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 329:12-338:13
+    Source: 'core-models/src/core/num/mod.rs', lines 340:12-349:13
     Visibility: public -/
 def num.I128.checked_add_unsigned
   (x : Std.I128) (y : Std.U128) : RustM (option.Option Std.I128) := do
@@ -6818,14 +6818,14 @@ def I128.Insts.CoreIterRangeStep.forward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.I8.overflowing_sub
   (x : Std.I8) (y : Std.I8) : RustM (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I8.checked_sub_unsigned
   (x : Std.I8) (y : Std.U8) : RustM (option.Option Std.I8) := do
@@ -6846,14 +6846,14 @@ def I8.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.I16.overflowing_sub
   (x : Std.I16) (y : Std.I16) : RustM (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I16.checked_sub_unsigned
   (x : Std.I16) (y : Std.U16) : RustM (option.Option Std.I16) := do
@@ -6874,14 +6874,14 @@ def I16.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.I32.overflowing_sub
   (x : Std.I32) (y : Std.I32) : RustM (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I32.checked_sub_unsigned
   (x : Std.I32) (y : Std.U32) : RustM (option.Option Std.I32) := do
@@ -6902,14 +6902,14 @@ def I32.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.I64.overflowing_sub
   (x : Std.I64) (y : Std.I64) : RustM (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I64.checked_sub_unsigned
   (x : Std.I64) (y : Std.U64) : RustM (option.Option Std.I64) := do
@@ -6930,14 +6930,14 @@ def I64.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.Isize.overflowing_sub
   (x : Std.Isize) (y : Std.Isize) : RustM (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_isize x y
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.Isize.checked_sub_unsigned
   (x : Std.Isize) (y : Std.Usize) : RustM (option.Option Std.Isize) := do
@@ -6958,14 +6958,14 @@ def Isize.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 311:12-313:13
+    Source: 'core-models/src/core/num/mod.rs', lines 322:12-324:13
     Visibility: public -/
 def num.I128.overflowing_sub
   (x : Std.I128) (y : Std.I128) : RustM (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub_unsigned]:
-    Source: 'core-models/src/core/num/mod.rs', lines 340:12-347:13
+    Source: 'core-models/src/core/num/mod.rs', lines 351:12-358:13
     Visibility: public -/
 def num.I128.checked_sub_unsigned
   (x : Std.I128) (y : Std.U128) : RustM (option.Option Std.I128) := do
@@ -6986,7 +6986,7 @@ def I128.Insts.CoreIterRangeStep.backward_unchecked
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U8.unchecked_add (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   x + y
@@ -7000,7 +7000,7 @@ def U8.Insts.CoreIterRangeStep.forward_unchecked
   num.U8.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U16.unchecked_add (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   x + y
@@ -7014,7 +7014,7 @@ def U16.Insts.CoreIterRangeStep.forward_unchecked
   num.U16.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U32.unchecked_add (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   x + y
@@ -7028,7 +7028,7 @@ def U32.Insts.CoreIterRangeStep.forward_unchecked
   num.U32.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U64.unchecked_add (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   x + y
@@ -7042,7 +7042,7 @@ def U64.Insts.CoreIterRangeStep.forward_unchecked
   num.U64.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.Usize.unchecked_add
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
@@ -7056,7 +7056,7 @@ def Usize.Insts.CoreIterRangeStep.forward_unchecked
   num.Usize.unchecked_add start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 53:12-55:13
+    Source: 'core-models/src/core/num/mod.rs', lines 54:12-56:13
     Visibility: public -/
 def num.U128.unchecked_add (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   x + y
@@ -7070,7 +7070,7 @@ def U128.Insts.CoreIterRangeStep.forward_unchecked
   num.U128.unchecked_add start i
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.U8.unchecked_sub (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   x - y
@@ -7084,7 +7084,7 @@ def U8.Insts.CoreIterRangeStep.backward_unchecked
   num.U8.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.U16.unchecked_sub (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   x - y
@@ -7098,7 +7098,7 @@ def U16.Insts.CoreIterRangeStep.backward_unchecked
   num.U16.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.U32.unchecked_sub (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   x - y
@@ -7112,7 +7112,7 @@ def U32.Insts.CoreIterRangeStep.backward_unchecked
   num.U32.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.U64.unchecked_sub (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   x - y
@@ -7126,7 +7126,7 @@ def U64.Insts.CoreIterRangeStep.backward_unchecked
   num.U64.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.Usize.unchecked_sub
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
@@ -7140,7 +7140,7 @@ def Usize.Insts.CoreIterRangeStep.backward_unchecked
   num.Usize.unchecked_sub start n
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 79:12-81:13
+    Source: 'core-models/src/core/num/mod.rs', lines 80:12-82:13
     Visibility: public -/
 def num.U128.unchecked_sub (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   x - y
@@ -7154,14 +7154,14 @@ def U128.Insts.CoreIterRangeStep.backward_unchecked
   num.U128.unchecked_sub start i
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.U8.overflowing_add
   (x : Std.U8) (y : Std.U8) : RustM (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U8.checked_add
   (x : Std.U8) (y : Std.U8) : RustM (option.Option Std.U8) := do
@@ -7189,7 +7189,7 @@ def U8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.I8.wrapping_add (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.wrapping_add_i8 x y
@@ -7218,14 +7218,14 @@ def I8.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.U16.overflowing_add
   (x : Std.U16) (y : Std.U16) : RustM (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U16.checked_add
   (x : Std.U16) (y : Std.U16) : RustM (option.Option Std.U16) := do
@@ -7253,7 +7253,7 @@ def U16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.I16.wrapping_add (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.wrapping_add_i16 x y
@@ -7282,14 +7282,14 @@ def I16.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.U32.overflowing_add
   (x : Std.U32) (y : Std.U32) : RustM (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U32.checked_add
   (x : Std.U32) (y : Std.U32) : RustM (option.Option Std.U32) := do
@@ -7317,7 +7317,7 @@ def U32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.I32.wrapping_add (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.wrapping_add_i32 x y
@@ -7346,14 +7346,14 @@ def I32.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.U64.overflowing_add
   (x : Std.U64) (y : Std.U64) : RustM (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U64.checked_add
   (x : Std.U64) (y : Std.U64) : RustM (option.Option Std.U64) := do
@@ -7381,7 +7381,7 @@ def U64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.I64.wrapping_add (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.wrapping_add_i64 x y
@@ -7410,14 +7410,14 @@ def I64.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.Usize.overflowing_add
   (x : Std.Usize) (y : Std.Usize) : RustM (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_add_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.Usize.checked_add
   (x : Std.Usize) (y : Std.Usize) : RustM (option.Option Std.Usize) := do
@@ -7447,7 +7447,7 @@ def Usize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.Isize.wrapping_add
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
@@ -7479,14 +7479,14 @@ def Isize.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 39:12-41:13
+    Source: 'core-models/src/core/num/mod.rs', lines 40:12-42:13
     Visibility: public -/
 def num.U128.overflowing_add
   (x : Std.U128) (y : Std.U128) : RustM (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_add_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 43:12-50:13
+    Source: 'core-models/src/core/num/mod.rs', lines 44:12-51:13
     Visibility: public -/
 def num.U128.checked_add
   (x : Std.U128) (y : Std.U128) : RustM (option.Option Std.U128) := do
@@ -7512,7 +7512,7 @@ def U128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.I128.checked_add
   (x : Std.I128) (y : Std.I128) : RustM (option.Option Std.I128) := do
@@ -7538,14 +7538,14 @@ def I128.Insts.CoreIterRangeStep.forward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U8.overflowing_sub
   (x : Std.U8) (y : Std.U8) : RustM (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.U8.checked_sub
   (x : Std.U8) (y : Std.U8) : RustM (option.Option Std.U8) := do
@@ -7573,7 +7573,7 @@ def U8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.I8.wrapping_sub (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.wrapping_sub_i8 x y
@@ -7602,14 +7602,14 @@ def I8.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U16.overflowing_sub
   (x : Std.U16) (y : Std.U16) : RustM (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.U16.checked_sub
   (x : Std.U16) (y : Std.U16) : RustM (option.Option Std.U16) := do
@@ -7637,7 +7637,7 @@ def U16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.I16.wrapping_sub (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.wrapping_sub_i16 x y
@@ -7666,14 +7666,14 @@ def I16.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U32.overflowing_sub
   (x : Std.U32) (y : Std.U32) : RustM (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.U32.checked_sub
   (x : Std.U32) (y : Std.U32) : RustM (option.Option Std.U32) := do
@@ -7701,7 +7701,7 @@ def U32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.I32.wrapping_sub (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.wrapping_sub_i32 x y
@@ -7730,14 +7730,14 @@ def I32.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U64.overflowing_sub
   (x : Std.U64) (y : Std.U64) : RustM (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.U64.checked_sub
   (x : Std.U64) (y : Std.U64) : RustM (option.Option Std.U64) := do
@@ -7765,7 +7765,7 @@ def U64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.I64.wrapping_sub (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.wrapping_sub_i64 x y
@@ -7794,14 +7794,14 @@ def I64.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.Usize.overflowing_sub
   (x : Std.Usize) (y : Std.Usize) : RustM (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_usize x y
 
 /-- [core_models::num::{core_models::num::usize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.Usize.checked_sub
   (x : Std.Usize) (y : Std.Usize) : RustM (option.Option Std.Usize) := do
@@ -7831,7 +7831,7 @@ def Usize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.Isize.wrapping_sub
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
@@ -7863,14 +7863,14 @@ def Isize.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 65:12-67:13
+    Source: 'core-models/src/core/num/mod.rs', lines 66:12-68:13
     Visibility: public -/
 def num.U128.overflowing_sub
   (x : Std.U128) (y : Std.U128) : RustM (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::u128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 69:12-76:13
+    Source: 'core-models/src/core/num/mod.rs', lines 70:12-77:13
     Visibility: public -/
 def num.U128.checked_sub
   (x : Std.U128) (y : Std.U128) : RustM (option.Option Std.U128) := do
@@ -7896,7 +7896,7 @@ def U128.Insts.CoreIterRangeStep.backward
   option.Option.unwrap o
 
 /-- [core_models::num::{core_models::num::i128}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I128.checked_sub
   (x : Std.I128) (y : Std.I128) : RustM (option.Option Std.I128) := do
@@ -8415,310 +8415,310 @@ impl_def num.error.TryFromIntError.Insts.CoreCmpPartialEqTryFromIntError
 
 /-
 /-- [core_models::num::{core_models::num::u128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 25:12-25:37
+    Source: 'core-models/src/core/num/mod.rs', lines 26:12-26:37
     Visibility: public -/
 @[global_simps, irreducible] def num.U128.MIN : Std.U128 := 0#u128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-- [core_models::num::{core_models::num::u8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::u16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::u32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::u64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::u128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.U128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::usize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 29:12-29:57
+    Source: 'core-models/src/core/num/mod.rs', lines 30:12-30:57
     Visibility: public -/
 @[global_simps, irreducible] def num.Usize.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.U8.wrapping_add (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.wrapping_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.U16.wrapping_add (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.wrapping_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.U32.wrapping_add (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.wrapping_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.U64.wrapping_add (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.wrapping_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.U128.wrapping_add (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.wrapping_add_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 31:12-33:13
+    Source: 'core-models/src/core/num/mod.rs', lines 32:12-34:13
     Visibility: public -/
 def num.Usize.wrapping_add
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.wrapping_add_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.U8.saturating_add (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.saturating_add_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.U16.saturating_add (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.saturating_add_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.U32.saturating_add (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.saturating_add_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.U64.saturating_add (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.saturating_add_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.U128.saturating_add
   (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.saturating_add_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 35:12-37:13
+    Source: 'core-models/src/core/num/mod.rs', lines 36:12-38:13
     Visibility: public -/
 def num.Usize.saturating_add
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.saturating_add_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U8.wrapping_sub (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.wrapping_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U16.wrapping_sub (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.wrapping_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U32.wrapping_sub (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.wrapping_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U64.wrapping_sub (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.wrapping_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.U128.wrapping_sub (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.wrapping_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 57:12-59:13
+    Source: 'core-models/src/core/num/mod.rs', lines 58:12-60:13
     Visibility: public -/
 def num.Usize.wrapping_sub
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.wrapping_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U8.saturating_sub (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.saturating_sub_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U16.saturating_sub (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.saturating_sub_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U32.saturating_sub (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.saturating_sub_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U64.saturating_sub (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.saturating_sub_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.U128.saturating_sub
   (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.saturating_sub_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 61:12-63:13
+    Source: 'core-models/src/core/num/mod.rs', lines 62:12-64:13
     Visibility: public -/
 def num.Usize.saturating_sub
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.saturating_sub_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.U8.wrapping_mul (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.wrapping_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.U16.wrapping_mul (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.wrapping_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.U32.wrapping_mul (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.wrapping_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.U64.wrapping_mul (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.wrapping_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.U128.wrapping_mul (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.wrapping_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 83:12-85:13
+    Source: 'core-models/src/core/num/mod.rs', lines 84:12-86:13
     Visibility: public -/
 def num.Usize.wrapping_mul
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.wrapping_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.U8.saturating_mul (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.saturating_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.U16.saturating_mul (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.saturating_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.U32.saturating_mul (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.saturating_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.U64.saturating_mul (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.saturating_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.U128.saturating_mul
   (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.saturating_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 87:12-89:13
+    Source: 'core-models/src/core/num/mod.rs', lines 88:12-90:13
     Visibility: public -/
 def num.Usize.saturating_mul
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.saturating_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.U8.overflowing_mul
   (x : Std.U8) (y : Std.U8) : RustM (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.U16.overflowing_mul
   (x : Std.U16) (y : Std.U16) : RustM (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.U32.overflowing_mul
   (x : Std.U32) (y : Std.U32) : RustM (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.U64.overflowing_mul
   (x : Std.U64) (y : Std.U64) : RustM (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.U128.overflowing_mul
   (x : Std.U128) (y : Std.U128) : RustM (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 91:12-93:13
+    Source: 'core-models/src/core/num/mod.rs', lines 92:12-94:13
     Visibility: public -/
 def num.Usize.overflowing_mul
   (x : Std.Usize) (y : Std.Usize) : RustM (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.U8.checked_mul
   (x : Std.U8) (y : Std.U8) : RustM (option.Option Std.U8) := do
@@ -8728,7 +8728,7 @@ def num.U8.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.U16.checked_mul
   (x : Std.U16) (y : Std.U16) : RustM (option.Option Std.U16) := do
@@ -8738,7 +8738,7 @@ def num.U16.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.U32.checked_mul
   (x : Std.U32) (y : Std.U32) : RustM (option.Option Std.U32) := do
@@ -8748,7 +8748,7 @@ def num.U32.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.U64.checked_mul
   (x : Std.U64) (y : Std.U64) : RustM (option.Option Std.U64) := do
@@ -8758,7 +8758,7 @@ def num.U64.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.U128.checked_mul
   (x : Std.U128) (y : Std.U128) : RustM (option.Option Std.U128) := do
@@ -8768,7 +8768,7 @@ def num.U128.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::usize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 95:12-102:13
+    Source: 'core-models/src/core/num/mod.rs', lines 96:12-103:13
     Visibility: public -/
 def num.Usize.checked_mul
   (x : Std.Usize) (y : Std.Usize) : RustM (option.Option Std.Usize) := do
@@ -8778,159 +8778,159 @@ def num.Usize.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.U8.unchecked_mul (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.U16.unchecked_mul (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.U32.unchecked_mul (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.U64.unchecked_mul (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.U128.unchecked_mul (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 105:12-107:13
+    Source: 'core-models/src/core/num/mod.rs', lines 106:12-108:13
     Visibility: public -/
 def num.Usize.unchecked_mul
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   x * y
 
 /-- [core_models::num::{core_models::num::u8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.U8.rem_euclid (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.rem_euclid_u8 x y
 
 /-- [core_models::num::{core_models::num::u16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.U16.rem_euclid (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.rem_euclid_u16 x y
 
 /-- [core_models::num::{core_models::num::u32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.U32.rem_euclid (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.rem_euclid_u32 x y
 
 /-- [core_models::num::{core_models::num::u64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.U64.rem_euclid (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.rem_euclid_u64 x y
 
 /-- [core_models::num::{core_models::num::u128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.U128.rem_euclid (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.rem_euclid_u128 x y
 
 /-- [core_models::num::{core_models::num::usize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 110:12-112:13
+    Source: 'core-models/src/core/num/mod.rs', lines 111:12-113:13
     Visibility: public -/
 def num.Usize.rem_euclid
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.rem_euclid_usize x y
 
 /-- [core_models::num::{core_models::num::u8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.U8.pow (x : Std.U8) (exp : Std.U32) : RustM Std.U8 := do
   rust_primitives.arithmetic.pow_u8 x exp
 
 /-- [core_models::num::{core_models::num::u16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.U16.pow (x : Std.U16) (exp : Std.U32) : RustM Std.U16 := do
   rust_primitives.arithmetic.pow_u16 x exp
 
 /-- [core_models::num::{core_models::num::u32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.U32.pow (x : Std.U32) (exp : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.pow_u32 x exp
 
 /-- [core_models::num::{core_models::num::u64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.U64.pow (x : Std.U64) (exp : Std.U32) : RustM Std.U64 := do
   rust_primitives.arithmetic.pow_u64 x exp
 
 /-- [core_models::num::{core_models::num::u128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.U128.pow (x : Std.U128) (exp : Std.U32) : RustM Std.U128 := do
   rust_primitives.arithmetic.pow_u128 x exp
 
 /-- [core_models::num::{core_models::num::usize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 114:12-116:13
+    Source: 'core-models/src/core/num/mod.rs', lines 115:12-117:13
     Visibility: public -/
 def num.Usize.pow (x : Std.Usize) (exp : Std.U32) : RustM Std.Usize := do
   rust_primitives.arithmetic.pow_usize x exp
 
 /-- [core_models::num::{core_models::num::u8}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.U8.overflowing_pow
   (x : Std.U8) (exp : Std.U32) : RustM (Std.U8 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_u8 x exp
 
 /-- [core_models::num::{core_models::num::u16}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.U16.overflowing_pow
   (x : Std.U16) (exp : Std.U32) : RustM (Std.U16 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_u16 x exp
 
 /-- [core_models::num::{core_models::num::u32}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.U32.overflowing_pow
   (x : Std.U32) (exp : Std.U32) : RustM (Std.U32 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_u32 x exp
 
 /-- [core_models::num::{core_models::num::u64}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.U64.overflowing_pow
   (x : Std.U64) (exp : Std.U32) : RustM (Std.U64 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_u64 x exp
 
 /-- [core_models::num::{core_models::num::u128}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.U128.overflowing_pow
   (x : Std.U128) (exp : Std.U32) : RustM (Std.U128 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_u128 x exp
 
 /-- [core_models::num::{core_models::num::usize}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 118:12-120:13
+    Source: 'core-models/src/core/num/mod.rs', lines 119:12-121:13
     Visibility: public -/
 def num.Usize.overflowing_pow
   (x : Std.Usize) (exp : Std.U32) : RustM (Std.Usize × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_usize x exp
 
 /-- [core_models::num::{core_models::num::u8}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.U8.checked_pow
   (x : Std.U8) (exp : Std.U32) : RustM (option.Option Std.U8) := do
@@ -8940,7 +8940,7 @@ def num.U8.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u16}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.U16.checked_pow
   (x : Std.U16) (exp : Std.U32) : RustM (option.Option Std.U16) := do
@@ -8950,7 +8950,7 @@ def num.U16.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u32}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.U32.checked_pow
   (x : Std.U32) (exp : Std.U32) : RustM (option.Option Std.U32) := do
@@ -8960,7 +8960,7 @@ def num.U32.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u64}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.U64.checked_pow
   (x : Std.U64) (exp : Std.U32) : RustM (option.Option Std.U64) := do
@@ -8970,7 +8970,7 @@ def num.U64.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u128}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.U128.checked_pow
   (x : Std.U128) (exp : Std.U32) : RustM (option.Option Std.U128) := do
@@ -8980,7 +8980,7 @@ def num.U128.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::usize}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 123:12-130:13
+    Source: 'core-models/src/core/num/mod.rs', lines 124:12-131:13
     Visibility: public -/
 def num.Usize.checked_pow
   (x : Std.Usize) (exp : Std.U32) : RustM (option.Option Std.Usize) := do
@@ -8990,340 +8990,422 @@ def num.Usize.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::u8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U8.count_ones (x : Std.U8) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U16.count_ones (x : Std.U16) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U32.count_ones (x : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U64.count_ones (x : Std.U64) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.U128.count_ones (x : Std.U128) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 132:12-134:13
+    Source: 'core-models/src/core/num/mod.rs', lines 133:12-135:13
     Visibility: public -/
 def num.Usize.count_ones (x : Std.Usize) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_usize x
 
 /-- [core_models::num::{core_models::num::u8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.U8.rotate_right (x : Std.U8) (n : Std.U32) : RustM Std.U8 := do
-  rust_primitives.arithmetic.rotate_right_u8 x n
+  let m ← n % 8#u32
+  if m = 0#u32
+  then ok x
+  else let i ← x >>> m
+       let i1 ← 8#u32 - m
+       let i2 ← x <<< i1
+       ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.U16.rotate_right (x : Std.U16) (n : Std.U32) : RustM Std.U16 := do
-  rust_primitives.arithmetic.rotate_right_u16 x n
+  let m ← n % 16#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x >>> m
+    let i1 ← 16#u32 - m
+    let i2 ← x <<< i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.U32.rotate_right (x : Std.U32) (n : Std.U32) : RustM Std.U32 := do
-  rust_primitives.arithmetic.rotate_right_u32 x n
+  let m ← n % 32#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x >>> m
+    let i1 ← 32#u32 - m
+    let i2 ← x <<< i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.U64.rotate_right (x : Std.U64) (n : Std.U32) : RustM Std.U64 := do
-  rust_primitives.arithmetic.rotate_right_u64 x n
+  let m ← n % 64#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x >>> m
+    let i1 ← 64#u32 - m
+    let i2 ← x <<< i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.U128.rotate_right (x : Std.U128) (n : Std.U32) : RustM Std.U128 := do
-  rust_primitives.arithmetic.rotate_right_u128 x n
+  let m ← n % 128#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x >>> m
+    let i1 ← 128#u32 - m
+    let i2 ← x <<< i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::usize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 137:12-139:13
+    Source: 'core-models/src/core/num/mod.rs', lines 138:12-145:13
     Visibility: public -/
 def num.Usize.rotate_right
   (x : Std.Usize) (n : Std.U32) : RustM Std.Usize := do
-  rust_primitives.arithmetic.rotate_right_usize x n
+  let i ← rust_primitives.arithmetic.SIZE_BITS
+  let m ← n % i
+  if m = 0#u32
+  then ok x
+  else let i1 ← x >>> m
+       let i2 ← i - m
+       let i3 ← x <<< i2
+       ok (i1 ^^^ i3)
 
 /-- [core_models::num::{core_models::num::u8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.U8.rotate_left (x : Std.U8) (n : Std.U32) : RustM Std.U8 := do
-  rust_primitives.arithmetic.rotate_left_u8 x n
+  let m ← n % 8#u32
+  if m = 0#u32
+  then ok x
+  else let i ← x <<< m
+       let i1 ← 8#u32 - m
+       let i2 ← x >>> i1
+       ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.U16.rotate_left (x : Std.U16) (n : Std.U32) : RustM Std.U16 := do
-  rust_primitives.arithmetic.rotate_left_u16 x n
+  let m ← n % 16#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x <<< m
+    let i1 ← 16#u32 - m
+    let i2 ← x >>> i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.U32.rotate_left (x : Std.U32) (n : Std.U32) : RustM Std.U32 := do
-  rust_primitives.arithmetic.rotate_left_u32 x n
+  let m ← n % 32#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x <<< m
+    let i1 ← 32#u32 - m
+    let i2 ← x >>> i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.U64.rotate_left (x : Std.U64) (n : Std.U32) : RustM Std.U64 := do
-  rust_primitives.arithmetic.rotate_left_u64 x n
+  let m ← n % 64#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x <<< m
+    let i1 ← 64#u32 - m
+    let i2 ← x >>> i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::u128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.U128.rotate_left (x : Std.U128) (n : Std.U32) : RustM Std.U128 := do
-  rust_primitives.arithmetic.rotate_left_u128 x n
+  let m ← n % 128#u32
+  if m = 0#u32
+  then ok x
+  else
+    let i ← x <<< m
+    let i1 ← 128#u32 - m
+    let i2 ← x >>> i1
+    ok (i ^^^ i2)
 
 /-- [core_models::num::{core_models::num::usize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 142:12-144:13
+    Source: 'core-models/src/core/num/mod.rs', lines 148:12-155:13
     Visibility: public -/
 def num.Usize.rotate_left (x : Std.Usize) (n : Std.U32) : RustM Std.Usize := do
-  rust_primitives.arithmetic.rotate_left_usize x n
+  let i ← rust_primitives.arithmetic.SIZE_BITS
+  let m ← n % i
+  if m = 0#u32
+  then ok x
+  else let i1 ← x <<< m
+       let i2 ← i - m
+       let i3 ← x >>> i2
+       ok (i1 ^^^ i3)
 
 /-- [core_models::num::{core_models::num::u8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.U8.leading_zeros (x : Std.U8) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.U16.leading_zeros (x : Std.U16) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.U32.leading_zeros (x : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.U64.leading_zeros (x : Std.U64) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.U128.leading_zeros (x : Std.U128) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 147:12-149:13
+    Source: 'core-models/src/core/num/mod.rs', lines 158:12-160:13
     Visibility: public -/
 def num.Usize.leading_zeros (x : Std.Usize) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_usize x
 
 /-- [core_models::num::{core_models::num::u8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.U8.ilog2 (x : Std.U8) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_u8 x
 
 /-- [core_models::num::{core_models::num::u16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.U16.ilog2 (x : Std.U16) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_u16 x
 
 /-- [core_models::num::{core_models::num::u32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.U32.ilog2 (x : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_u32 x
 
 /-- [core_models::num::{core_models::num::u64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.U64.ilog2 (x : Std.U64) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_u64 x
 
 /-- [core_models::num::{core_models::num::u128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.U128.ilog2 (x : Std.U128) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_u128 x
 
 /-- [core_models::num::{core_models::num::usize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 152:12-154:13
+    Source: 'core-models/src/core/num/mod.rs', lines 163:12-165:13
     Visibility: public -/
 def num.Usize.ilog2 (x : Std.Usize) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_usize x
 
 /-- [core_models::num::{core_models::num::u8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U8.from_be_bytes (bytes : Array Std.U8 1#usize) : RustM Std.U8 := do
   rust_primitives.arithmetic.from_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U16.from_be_bytes (bytes : Array Std.U8 2#usize) : RustM Std.U16 := do
   rust_primitives.arithmetic.from_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U32.from_be_bytes (bytes : Array Std.U8 4#usize) : RustM Std.U32 := do
   rust_primitives.arithmetic.from_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U64.from_be_bytes (bytes : Array Std.U8 8#usize) : RustM Std.U64 := do
   rust_primitives.arithmetic.from_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.U128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : RustM Std.U128 := do
   rust_primitives.arithmetic.from_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 173:12-175:13
+    Source: 'core-models/src/core/num/mod.rs', lines 184:12-186:13
     Visibility: public -/
 def num.Usize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.from_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.U8.from_le_bytes (bytes : Array Std.U8 1#usize) : RustM Std.U8 := do
   rust_primitives.arithmetic.from_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.U16.from_le_bytes (bytes : Array Std.U8 2#usize) : RustM Std.U16 := do
   rust_primitives.arithmetic.from_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.U32.from_le_bytes (bytes : Array Std.U8 4#usize) : RustM Std.U32 := do
   rust_primitives.arithmetic.from_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.U64.from_le_bytes (bytes : Array Std.U8 8#usize) : RustM Std.U64 := do
   rust_primitives.arithmetic.from_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.U128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : RustM Std.U128 := do
   rust_primitives.arithmetic.from_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 178:12-180:13
+    Source: 'core-models/src/core/num/mod.rs', lines 189:12-191:13
     Visibility: public -/
 def num.Usize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.from_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.U8.to_be_bytes (bytes : Std.U8) : RustM (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.U16.to_be_bytes (bytes : Std.U16) : RustM (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.U32.to_be_bytes (bytes : Std.U32) : RustM (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.U64.to_be_bytes (bytes : Std.U64) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.U128.to_be_bytes
   (bytes : Std.U128) : RustM (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 183:12-185:13
+    Source: 'core-models/src/core/num/mod.rs', lines 194:12-196:13
     Visibility: public -/
 def num.Usize.to_be_bytes
   (bytes : Std.Usize) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.U8.to_le_bytes (bytes : Std.U8) : RustM (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u8 bytes
 
 /-- [core_models::num::{core_models::num::u16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.U16.to_le_bytes (bytes : Std.U16) : RustM (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u16 bytes
 
 /-- [core_models::num::{core_models::num::u32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.U32.to_le_bytes (bytes : Std.U32) : RustM (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u32 bytes
 
 /-- [core_models::num::{core_models::num::u64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.U64.to_le_bytes (bytes : Std.U64) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u64 bytes
 
 /-- [core_models::num::{core_models::num::u128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.U128.to_le_bytes
   (bytes : Std.U128) : RustM (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_u128 bytes
 
 /-- [core_models::num::{core_models::num::usize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 188:12-190:13
+    Source: 'core-models/src/core/num/mod.rs', lines 199:12-201:13
     Visibility: public -/
 def num.Usize.to_le_bytes
   (bytes : Std.Usize) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_usize bytes
 
 /-- [core_models::num::{core_models::num::u8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.U8.checked_div
   (x : Std.U8) (y : Std.U8) : RustM (option.Option Std.U8) := do
@@ -9333,7 +9415,7 @@ def num.U8.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.U16.checked_div
   (x : Std.U16) (y : Std.U16) : RustM (option.Option Std.U16) := do
@@ -9343,7 +9425,7 @@ def num.U16.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.U32.checked_div
   (x : Std.U32) (y : Std.U32) : RustM (option.Option Std.U32) := do
@@ -9353,7 +9435,7 @@ def num.U32.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.U64.checked_div
   (x : Std.U64) (y : Std.U64) : RustM (option.Option Std.U64) := do
@@ -9363,7 +9445,7 @@ def num.U64.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.U128.checked_div
   (x : Std.U128) (y : Std.U128) : RustM (option.Option Std.U128) := do
@@ -9373,7 +9455,7 @@ def num.U128.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 192:12-198:13
+    Source: 'core-models/src/core/num/mod.rs', lines 203:12-209:13
     Visibility: public -/
 def num.Usize.checked_div
   (x : Std.Usize) (y : Std.Usize) : RustM (option.Option Std.Usize) := do
@@ -9383,44 +9465,44 @@ def num.Usize.checked_div
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.U8.unchecked_div (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.U16.unchecked_div (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.U32.unchecked_div (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.U64.unchecked_div (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.U128.unchecked_div (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 201:12-203:13
+    Source: 'core-models/src/core/num/mod.rs', lines 212:12-214:13
     Visibility: public -/
 def num.Usize.unchecked_div
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   x / y
 
 /-- [core_models::num::{core_models::num::u8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.U8.checked_rem
   (x : Std.U8) (y : Std.U8) : RustM (option.Option Std.U8) := do
@@ -9430,7 +9512,7 @@ def num.U8.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.U16.checked_rem
   (x : Std.U16) (y : Std.U16) : RustM (option.Option Std.U16) := do
@@ -9440,7 +9522,7 @@ def num.U16.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.U32.checked_rem
   (x : Std.U32) (y : Std.U32) : RustM (option.Option Std.U32) := do
@@ -9450,7 +9532,7 @@ def num.U32.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.U64.checked_rem
   (x : Std.U64) (y : Std.U64) : RustM (option.Option Std.U64) := do
@@ -9460,7 +9542,7 @@ def num.U64.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.U128.checked_rem
   (x : Std.U128) (y : Std.U128) : RustM (option.Option Std.U128) := do
@@ -9470,7 +9552,7 @@ def num.U128.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::usize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 205:12-211:13
+    Source: 'core-models/src/core/num/mod.rs', lines 216:12-222:13
     Visibility: public -/
 def num.Usize.checked_rem
   (x : Std.Usize) (y : Std.Usize) : RustM (option.Option Std.Usize) := do
@@ -9480,44 +9562,44 @@ def num.Usize.checked_rem
        ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::u8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.U8.unchecked_rem (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.U16.unchecked_rem (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.U32.unchecked_rem (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.U64.unchecked_rem (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::u128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.U128.unchecked_rem (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::usize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 214:12-216:13
+    Source: 'core-models/src/core/num/mod.rs', lines 225:12-227:13
     Visibility: public -/
 def num.Usize.unchecked_rem
   (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   x % y
 
 /-- [core_models::num::{core_models::num::u8}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.U8.is_power_of_two (x : Std.U8) : RustM Bool := do
   if x != 0#u8
@@ -9527,7 +9609,7 @@ def num.U8.is_power_of_two (x : Std.U8) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u16}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.U16.is_power_of_two (x : Std.U16) : RustM Bool := do
   if x != 0#u16
@@ -9537,7 +9619,7 @@ def num.U16.is_power_of_two (x : Std.U16) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u32}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.U32.is_power_of_two (x : Std.U32) : RustM Bool := do
   if x != 0#u32
@@ -9547,7 +9629,7 @@ def num.U32.is_power_of_two (x : Std.U32) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u64}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.U64.is_power_of_two (x : Std.U64) : RustM Bool := do
   if x != 0#u64
@@ -9557,7 +9639,7 @@ def num.U64.is_power_of_two (x : Std.U64) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u128}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.U128.is_power_of_two (x : Std.U128) : RustM Bool := do
   if x != 0#u128
@@ -9567,7 +9649,7 @@ def num.U128.is_power_of_two (x : Std.U128) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::usize}::is_power_of_two]:
-    Source: 'core-models/src/core/num/mod.rs', lines 218:12-220:13
+    Source: 'core-models/src/core/num/mod.rs', lines 229:12-231:13
     Visibility: public -/
 def num.Usize.is_power_of_two (x : Std.Usize) : RustM Bool := do
   if x != 0#usize
@@ -9577,7 +9659,7 @@ def num.Usize.is_power_of_two (x : Std.Usize) : RustM Bool := do
   else ok false
 
 /-- [core_models::num::{core_models::num::u8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   let d ← x / y
@@ -9587,7 +9669,7 @@ def num.U8.div_ceil (x : Std.U8) (y : Std.U8) : RustM Std.U8 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   let d ← x / y
@@ -9597,7 +9679,7 @@ def num.U16.div_ceil (x : Std.U16) (y : Std.U16) : RustM Std.U16 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   let d ← x / y
@@ -9607,7 +9689,7 @@ def num.U32.div_ceil (x : Std.U32) (y : Std.U32) : RustM Std.U32 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   let d ← x / y
@@ -9617,7 +9699,7 @@ def num.U64.div_ceil (x : Std.U64) (y : Std.U64) : RustM Std.U64 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   let d ← x / y
@@ -9627,7 +9709,7 @@ def num.U128.div_ceil (x : Std.U128) (y : Std.U128) : RustM Std.U128 := do
   else ok d
 
 /-- [core_models::num::{core_models::num::usize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 223:12-227:13
+    Source: 'core-models/src/core/num/mod.rs', lines 234:12-238:13
     Visibility: public -/
 def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   let d ← x / y
@@ -9637,7 +9719,7 @@ def num.Usize.div_ceil (x : Std.Usize) (y : Std.Usize) : RustM Std.Usize := do
   else ok d
 
 /-- [core_models::num::{core_models::num::u8}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : RustM Bool := do
   if y = 0#u8
@@ -9646,7 +9728,7 @@ def num.U8.is_multiple_of (x : Std.U8) (y : Std.U8) : RustM Bool := do
        ok (i = 0#u8)
 
 /-- [core_models::num::{core_models::num::u16}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : RustM Bool := do
   if y = 0#u16
@@ -9655,7 +9737,7 @@ def num.U16.is_multiple_of (x : Std.U16) (y : Std.U16) : RustM Bool := do
        ok (i = 0#u16)
 
 /-- [core_models::num::{core_models::num::u32}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : RustM Bool := do
   if y = 0#u32
@@ -9664,7 +9746,7 @@ def num.U32.is_multiple_of (x : Std.U32) (y : Std.U32) : RustM Bool := do
        ok (i = 0#u32)
 
 /-- [core_models::num::{core_models::num::u64}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : RustM Bool := do
   if y = 0#u64
@@ -9673,7 +9755,7 @@ def num.U64.is_multiple_of (x : Std.U64) (y : Std.U64) : RustM Bool := do
        ok (i = 0#u64)
 
 /-- [core_models::num::{core_models::num::u128}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : RustM Bool := do
   if y = 0#u128
@@ -9682,7 +9764,7 @@ def num.U128.is_multiple_of (x : Std.U128) (y : Std.U128) : RustM Bool := do
        ok (i = 0#u128)
 
 /-- [core_models::num::{core_models::num::usize}::is_multiple_of]:
-    Source: 'core-models/src/core/num/mod.rs', lines 229:12-235:13
+    Source: 'core-models/src/core/num/mod.rs', lines 240:12-246:13
     Visibility: public -/
 def num.Usize.is_multiple_of (x : Std.Usize) (y : Std.Usize) : RustM Bool := do
   if y = 0#usize
@@ -9691,125 +9773,125 @@ def num.Usize.is_multiple_of (x : Std.Usize) (y : Std.Usize) : RustM Bool := do
        ok (i = 0#usize)
 
 /-- [core_models::num::{core_models::num::u8}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.U8.wrapping_neg (x : Std.U8) : RustM Std.U8 := do
   rust_primitives.arithmetic.wrapping_sub_u8 0#u8 x
 
 /-- [core_models::num::{core_models::num::u16}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.U16.wrapping_neg (x : Std.U16) : RustM Std.U16 := do
   rust_primitives.arithmetic.wrapping_sub_u16 0#u16 x
 
 /-- [core_models::num::{core_models::num::u32}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.U32.wrapping_neg (x : Std.U32) : RustM Std.U32 := do
   rust_primitives.arithmetic.wrapping_sub_u32 0#u32 x
 
 /-- [core_models::num::{core_models::num::u64}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.U64.wrapping_neg (x : Std.U64) : RustM Std.U64 := do
   rust_primitives.arithmetic.wrapping_sub_u64 0#u64 x
 
 /-- [core_models::num::{core_models::num::u128}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.U128.wrapping_neg (x : Std.U128) : RustM Std.U128 := do
   rust_primitives.arithmetic.wrapping_sub_u128 0#u128 x
 
 /-- [core_models::num::{core_models::num::usize}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 250:12-252:13
+    Source: 'core-models/src/core/num/mod.rs', lines 261:12-263:13
     Visibility: public -/
 def num.Usize.wrapping_neg (x : Std.Usize) : RustM Std.Usize := do
   rust_primitives.arithmetic.wrapping_sub_usize 0#usize x
 
 /-
 /-- [core_models::num::{core_models::num::i128}::MIN]
-    Source: 'core-models/src/core/num/mod.rs', lines 272:12-272:40
+    Source: 'core-models/src/core/num/mod.rs', lines 283:12-283:40
     Visibility: public -/
 @[global_simps, irreducible]
 def num.I128.MIN : Std.I128 := (-170141183460469231731687303715884105728)#i128
 -/  -- provided by CoreModels.Core.FunsPrologue
 
 /-- [core_models::num::{core_models::num::i8}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I8.BITS : Std.U32 := 8#u32
 
 /-- [core_models::num::{core_models::num::i16}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I16.BITS : Std.U32 := 16#u32
 
 /-- [core_models::num::{core_models::num::i32}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I32.BITS : Std.U32 := 32#u32
 
 /-- [core_models::num::{core_models::num::i64}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I64.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::i128}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.I128.BITS : Std.U32 := 128#u32
 
 /-- [core_models::num::{core_models::num::isize}::BITS]
-    Source: 'core-models/src/core/num/mod.rs', lines 276:12-276:57
+    Source: 'core-models/src/core/num/mod.rs', lines 287:12-287:57
     Visibility: public -/
 @[global_simps, irreducible] def num.Isize.BITS : Std.U32 := 64#u32
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 277:12-279:13
+    Source: 'core-models/src/core/num/mod.rs', lines 288:12-290:13
     Visibility: public -/
 def num.I128.wrapping_add (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.wrapping_add_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.I8.saturating_add (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.saturating_add_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.I16.saturating_add (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.saturating_add_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.I32.saturating_add (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.saturating_add_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.I64.saturating_add (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.saturating_add_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.I128.saturating_add
   (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.saturating_add_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 281:12-283:13
+    Source: 'core-models/src/core/num/mod.rs', lines 292:12-294:13
     Visibility: public -/
 def num.Isize.saturating_add
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.saturating_add_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.I8.checked_add
   (x : Std.I8) (y : Std.I8) : RustM (option.Option Std.I8) := do
@@ -9819,7 +9901,7 @@ def num.I8.checked_add
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i16}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.I16.checked_add
   (x : Std.I16) (y : Std.I16) : RustM (option.Option Std.I16) := do
@@ -9829,7 +9911,7 @@ def num.I16.checked_add
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i32}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.I32.checked_add
   (x : Std.I32) (y : Std.I32) : RustM (option.Option Std.I32) := do
@@ -9839,7 +9921,7 @@ def num.I32.checked_add
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i64}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.I64.checked_add
   (x : Std.I64) (y : Std.I64) : RustM (option.Option Std.I64) := do
@@ -9849,7 +9931,7 @@ def num.I64.checked_add
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::isize}::checked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 289:12-296:13
+    Source: 'core-models/src/core/num/mod.rs', lines 300:12-307:13
     Visibility: public -/
 def num.Isize.checked_add
   (x : Std.Isize) (y : Std.Isize) : RustM (option.Option Std.Isize) := do
@@ -9859,88 +9941,88 @@ def num.Isize.checked_add
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.I8.unchecked_add (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.I16.unchecked_add (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.I32.unchecked_add (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.I64.unchecked_add (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.I128.unchecked_add (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   x + y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_add]:
-    Source: 'core-models/src/core/num/mod.rs', lines 299:12-301:13
+    Source: 'core-models/src/core/num/mod.rs', lines 310:12-312:13
     Visibility: public -/
 def num.Isize.unchecked_add
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   x + y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 303:12-305:13
+    Source: 'core-models/src/core/num/mod.rs', lines 314:12-316:13
     Visibility: public -/
 def num.I128.wrapping_sub (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.wrapping_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.I8.saturating_sub (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.saturating_sub_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.I16.saturating_sub (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.saturating_sub_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.I32.saturating_sub (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.saturating_sub_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.I64.saturating_sub (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.saturating_sub_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.I128.saturating_sub
   (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.saturating_sub_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 307:12-309:13
+    Source: 'core-models/src/core/num/mod.rs', lines 318:12-320:13
     Visibility: public -/
 def num.Isize.saturating_sub
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.saturating_sub_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I8.checked_sub
   (x : Std.I8) (y : Std.I8) : RustM (option.Option Std.I8) := do
@@ -9950,7 +10032,7 @@ def num.I8.checked_sub
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i16}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I16.checked_sub
   (x : Std.I16) (y : Std.I16) : RustM (option.Option Std.I16) := do
@@ -9960,7 +10042,7 @@ def num.I16.checked_sub
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i32}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I32.checked_sub
   (x : Std.I32) (y : Std.I32) : RustM (option.Option Std.I32) := do
@@ -9970,7 +10052,7 @@ def num.I32.checked_sub
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i64}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.I64.checked_sub
   (x : Std.I64) (y : Std.I64) : RustM (option.Option Std.I64) := do
@@ -9980,7 +10062,7 @@ def num.I64.checked_sub
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::isize}::checked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 315:12-322:13
+    Source: 'core-models/src/core/num/mod.rs', lines 326:12-333:13
     Visibility: public -/
 def num.Isize.checked_sub
   (x : Std.Isize) (y : Std.Isize) : RustM (option.Option Std.Isize) := do
@@ -9990,161 +10072,161 @@ def num.Isize.checked_sub
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.I8.unchecked_sub (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.I16.unchecked_sub (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.I32.unchecked_sub (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.I64.unchecked_sub (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   x - y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.I128.unchecked_sub (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   x - y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_sub]:
-    Source: 'core-models/src/core/num/mod.rs', lines 325:12-327:13
+    Source: 'core-models/src/core/num/mod.rs', lines 336:12-338:13
     Visibility: public -/
 def num.Isize.unchecked_sub
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   x - y
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I8.wrapping_mul (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.wrapping_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I16.wrapping_mul (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.wrapping_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I32.wrapping_mul (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.wrapping_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I64.wrapping_mul (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.wrapping_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.I128.wrapping_mul (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.wrapping_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 349:12-351:13
+    Source: 'core-models/src/core/num/mod.rs', lines 360:12-362:13
     Visibility: public -/
 def num.Isize.wrapping_mul
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.wrapping_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.I8.saturating_mul (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.saturating_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.I16.saturating_mul (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.saturating_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.I32.saturating_mul (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.saturating_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.I64.saturating_mul (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.saturating_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.I128.saturating_mul
   (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.saturating_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::saturating_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 353:12-355:13
+    Source: 'core-models/src/core/num/mod.rs', lines 364:12-366:13
     Visibility: public -/
 def num.Isize.saturating_mul
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.saturating_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.I8.overflowing_mul
   (x : Std.I8) (y : Std.I8) : RustM (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.I16.overflowing_mul
   (x : Std.I16) (y : Std.I16) : RustM (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.I32.overflowing_mul
   (x : Std.I32) (y : Std.I32) : RustM (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.I64.overflowing_mul
   (x : Std.I64) (y : Std.I64) : RustM (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.I128.overflowing_mul
   (x : Std.I128) (y : Std.I128) : RustM (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 357:12-359:13
+    Source: 'core-models/src/core/num/mod.rs', lines 368:12-370:13
     Visibility: public -/
 def num.Isize.overflowing_mul
   (x : Std.Isize) (y : Std.Isize) : RustM (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_mul_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.I8.checked_mul
   (x : Std.I8) (y : Std.I8) : RustM (option.Option Std.I8) := do
@@ -10154,7 +10236,7 @@ def num.I8.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i16}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.I16.checked_mul
   (x : Std.I16) (y : Std.I16) : RustM (option.Option Std.I16) := do
@@ -10164,7 +10246,7 @@ def num.I16.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i32}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.I32.checked_mul
   (x : Std.I32) (y : Std.I32) : RustM (option.Option Std.I32) := do
@@ -10174,7 +10256,7 @@ def num.I32.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i64}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.I64.checked_mul
   (x : Std.I64) (y : Std.I64) : RustM (option.Option Std.I64) := do
@@ -10184,7 +10266,7 @@ def num.I64.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i128}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.I128.checked_mul
   (x : Std.I128) (y : Std.I128) : RustM (option.Option Std.I128) := do
@@ -10194,7 +10276,7 @@ def num.I128.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::isize}::checked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 361:12-368:13
+    Source: 'core-models/src/core/num/mod.rs', lines 372:12-379:13
     Visibility: public -/
 def num.Isize.checked_mul
   (x : Std.Isize) (y : Std.Isize) : RustM (option.Option Std.Isize) := do
@@ -10204,159 +10286,159 @@ def num.Isize.checked_mul
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.I8.unchecked_mul (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.I16.unchecked_mul (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.I32.unchecked_mul (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.I64.unchecked_mul (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   x * y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.I128.unchecked_mul (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   x * y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_mul]:
-    Source: 'core-models/src/core/num/mod.rs', lines 371:12-373:13
+    Source: 'core-models/src/core/num/mod.rs', lines 382:12-384:13
     Visibility: public -/
 def num.Isize.unchecked_mul
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   x * y
 
 /-- [core_models::num::{core_models::num::i8}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I8.rem_euclid (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.rem_euclid_i8 x y
 
 /-- [core_models::num::{core_models::num::i16}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I16.rem_euclid (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.rem_euclid_i16 x y
 
 /-- [core_models::num::{core_models::num::i32}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I32.rem_euclid (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.rem_euclid_i32 x y
 
 /-- [core_models::num::{core_models::num::i64}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I64.rem_euclid (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.rem_euclid_i64 x y
 
 /-- [core_models::num::{core_models::num::i128}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.I128.rem_euclid (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.rem_euclid_i128 x y
 
 /-- [core_models::num::{core_models::num::isize}::rem_euclid]:
-    Source: 'core-models/src/core/num/mod.rs', lines 377:12-379:13
+    Source: 'core-models/src/core/num/mod.rs', lines 388:12-390:13
     Visibility: public -/
 def num.Isize.rem_euclid
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.rem_euclid_isize x y
 
 /-- [core_models::num::{core_models::num::i8}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.I8.pow (x : Std.I8) (exp : Std.U32) : RustM Std.I8 := do
   rust_primitives.arithmetic.pow_i8 x exp
 
 /-- [core_models::num::{core_models::num::i16}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.I16.pow (x : Std.I16) (exp : Std.U32) : RustM Std.I16 := do
   rust_primitives.arithmetic.pow_i16 x exp
 
 /-- [core_models::num::{core_models::num::i32}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.I32.pow (x : Std.I32) (exp : Std.U32) : RustM Std.I32 := do
   rust_primitives.arithmetic.pow_i32 x exp
 
 /-- [core_models::num::{core_models::num::i64}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.I64.pow (x : Std.I64) (exp : Std.U32) : RustM Std.I64 := do
   rust_primitives.arithmetic.pow_i64 x exp
 
 /-- [core_models::num::{core_models::num::i128}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.I128.pow (x : Std.I128) (exp : Std.U32) : RustM Std.I128 := do
   rust_primitives.arithmetic.pow_i128 x exp
 
 /-- [core_models::num::{core_models::num::isize}::pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 381:12-383:13
+    Source: 'core-models/src/core/num/mod.rs', lines 392:12-394:13
     Visibility: public -/
 def num.Isize.pow (x : Std.Isize) (exp : Std.U32) : RustM Std.Isize := do
   rust_primitives.arithmetic.pow_isize x exp
 
 /-- [core_models::num::{core_models::num::i8}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I8.overflowing_pow
   (x : Std.I8) (exp : Std.U32) : RustM (Std.I8 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_i8 x exp
 
 /-- [core_models::num::{core_models::num::i16}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I16.overflowing_pow
   (x : Std.I16) (exp : Std.U32) : RustM (Std.I16 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_i16 x exp
 
 /-- [core_models::num::{core_models::num::i32}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I32.overflowing_pow
   (x : Std.I32) (exp : Std.U32) : RustM (Std.I32 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_i32 x exp
 
 /-- [core_models::num::{core_models::num::i64}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I64.overflowing_pow
   (x : Std.I64) (exp : Std.U32) : RustM (Std.I64 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_i64 x exp
 
 /-- [core_models::num::{core_models::num::i128}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.I128.overflowing_pow
   (x : Std.I128) (exp : Std.U32) : RustM (Std.I128 × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_i128 x exp
 
 /-- [core_models::num::{core_models::num::isize}::overflowing_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 385:12-387:13
+    Source: 'core-models/src/core/num/mod.rs', lines 396:12-398:13
     Visibility: public -/
 def num.Isize.overflowing_pow
   (x : Std.Isize) (exp : Std.U32) : RustM (Std.Isize × Bool) := do
   rust_primitives.arithmetic.overflowing_pow_isize x exp
 
 /-- [core_models::num::{core_models::num::i8}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.I8.checked_pow
   (x : Std.I8) (exp : Std.U32) : RustM (option.Option Std.I8) := do
@@ -10366,7 +10448,7 @@ def num.I8.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i16}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.I16.checked_pow
   (x : Std.I16) (exp : Std.U32) : RustM (option.Option Std.I16) := do
@@ -10376,7 +10458,7 @@ def num.I16.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i32}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.I32.checked_pow
   (x : Std.I32) (exp : Std.U32) : RustM (option.Option Std.I32) := do
@@ -10386,7 +10468,7 @@ def num.I32.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i64}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.I64.checked_pow
   (x : Std.I64) (exp : Std.U32) : RustM (option.Option Std.I64) := do
@@ -10396,7 +10478,7 @@ def num.I64.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i128}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.I128.checked_pow
   (x : Std.I128) (exp : Std.U32) : RustM (option.Option Std.I128) := do
@@ -10406,7 +10488,7 @@ def num.I128.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::isize}::checked_pow]:
-    Source: 'core-models/src/core/num/mod.rs', lines 390:12-397:13
+    Source: 'core-models/src/core/num/mod.rs', lines 401:12-408:13
     Visibility: public -/
 def num.Isize.checked_pow
   (x : Std.Isize) (exp : Std.U32) : RustM (option.Option Std.Isize) := do
@@ -10416,376 +10498,376 @@ def num.Isize.checked_pow
   else ok (option.Option.Some result1)
 
 /-- [core_models::num::{core_models::num::i8}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I8.count_ones (x : Std.I8) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I16.count_ones (x : Std.I16) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I32.count_ones (x : Std.I32) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I64.count_ones (x : Std.I64) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.I128.count_ones (x : Std.I128) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::count_ones]:
-    Source: 'core-models/src/core/num/mod.rs', lines 399:12-401:13
+    Source: 'core-models/src/core/num/mod.rs', lines 410:12-412:13
     Visibility: public -/
 def num.Isize.count_ones (x : Std.Isize) : RustM Std.U32 := do
   rust_primitives.arithmetic.count_ones_isize x
 
 /-- [core_models::num::{core_models::num::i8}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I8.abs (x : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.abs_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I16.abs (x : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.abs_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I32.abs (x : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.abs_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I64.abs (x : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.abs_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.I128.abs (x : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.abs_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::abs]:
-    Source: 'core-models/src/core/num/mod.rs', lines 404:12-406:13
+    Source: 'core-models/src/core/num/mod.rs', lines 415:12-417:13
     Visibility: public -/
 def num.Isize.abs (x : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.abs_isize x
 
 /-- [core_models::num::{core_models::num::i8}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I8.rotate_right (x : Std.I8) (n : Std.U32) : RustM Std.I8 := do
   rust_primitives.arithmetic.rotate_right_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I16.rotate_right (x : Std.I16) (n : Std.U32) : RustM Std.I16 := do
   rust_primitives.arithmetic.rotate_right_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I32.rotate_right (x : Std.I32) (n : Std.U32) : RustM Std.I32 := do
   rust_primitives.arithmetic.rotate_right_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I64.rotate_right (x : Std.I64) (n : Std.U32) : RustM Std.I64 := do
   rust_primitives.arithmetic.rotate_right_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.I128.rotate_right (x : Std.I128) (n : Std.U32) : RustM Std.I128 := do
   rust_primitives.arithmetic.rotate_right_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_right]:
-    Source: 'core-models/src/core/num/mod.rs', lines 409:12-411:13
+    Source: 'core-models/src/core/num/mod.rs', lines 420:12-422:13
     Visibility: public -/
 def num.Isize.rotate_right
   (x : Std.Isize) (n : Std.U32) : RustM Std.Isize := do
   rust_primitives.arithmetic.rotate_right_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I8.rotate_left (x : Std.I8) (n : Std.U32) : RustM Std.I8 := do
   rust_primitives.arithmetic.rotate_left_i8 x n
 
 /-- [core_models::num::{core_models::num::i16}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I16.rotate_left (x : Std.I16) (n : Std.U32) : RustM Std.I16 := do
   rust_primitives.arithmetic.rotate_left_i16 x n
 
 /-- [core_models::num::{core_models::num::i32}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I32.rotate_left (x : Std.I32) (n : Std.U32) : RustM Std.I32 := do
   rust_primitives.arithmetic.rotate_left_i32 x n
 
 /-- [core_models::num::{core_models::num::i64}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I64.rotate_left (x : Std.I64) (n : Std.U32) : RustM Std.I64 := do
   rust_primitives.arithmetic.rotate_left_i64 x n
 
 /-- [core_models::num::{core_models::num::i128}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.I128.rotate_left (x : Std.I128) (n : Std.U32) : RustM Std.I128 := do
   rust_primitives.arithmetic.rotate_left_i128 x n
 
 /-- [core_models::num::{core_models::num::isize}::rotate_left]:
-    Source: 'core-models/src/core/num/mod.rs', lines 414:12-416:13
+    Source: 'core-models/src/core/num/mod.rs', lines 425:12-427:13
     Visibility: public -/
 def num.Isize.rotate_left (x : Std.Isize) (n : Std.U32) : RustM Std.Isize := do
   rust_primitives.arithmetic.rotate_left_isize x n
 
 /-- [core_models::num::{core_models::num::i8}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.I8.leading_zeros (x : Std.I8) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.I16.leading_zeros (x : Std.I16) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.I32.leading_zeros (x : Std.I32) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.I64.leading_zeros (x : Std.I64) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.I128.leading_zeros (x : Std.I128) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::leading_zeros]:
-    Source: 'core-models/src/core/num/mod.rs', lines 419:12-421:13
+    Source: 'core-models/src/core/num/mod.rs', lines 430:12-432:13
     Visibility: public -/
 def num.Isize.leading_zeros (x : Std.Isize) : RustM Std.U32 := do
   rust_primitives.arithmetic.leading_zeros_isize x
 
 /-- [core_models::num::{core_models::num::i8}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.I8.ilog2 (x : Std.I8) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_i8 x
 
 /-- [core_models::num::{core_models::num::i16}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.I16.ilog2 (x : Std.I16) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_i16 x
 
 /-- [core_models::num::{core_models::num::i32}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.I32.ilog2 (x : Std.I32) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_i32 x
 
 /-- [core_models::num::{core_models::num::i64}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.I64.ilog2 (x : Std.I64) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_i64 x
 
 /-- [core_models::num::{core_models::num::i128}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.I128.ilog2 (x : Std.I128) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_i128 x
 
 /-- [core_models::num::{core_models::num::isize}::ilog2]:
-    Source: 'core-models/src/core/num/mod.rs', lines 424:12-426:13
+    Source: 'core-models/src/core/num/mod.rs', lines 435:12-437:13
     Visibility: public -/
 def num.Isize.ilog2 (x : Std.Isize) : RustM Std.U32 := do
   rust_primitives.arithmetic.ilog2_isize x
 
 /-- [core_models::num::{core_models::num::i8}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.I8.from_be_bytes (bytes : Array Std.U8 1#usize) : RustM Std.I8 := do
   rust_primitives.arithmetic.from_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.I16.from_be_bytes (bytes : Array Std.U8 2#usize) : RustM Std.I16 := do
   rust_primitives.arithmetic.from_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.I32.from_be_bytes (bytes : Array Std.U8 4#usize) : RustM Std.I32 := do
   rust_primitives.arithmetic.from_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.I64.from_be_bytes (bytes : Array Std.U8 8#usize) : RustM Std.I64 := do
   rust_primitives.arithmetic.from_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.I128.from_be_bytes
   (bytes : Array Std.U8 16#usize) : RustM Std.I128 := do
   rust_primitives.arithmetic.from_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 445:12-447:13
+    Source: 'core-models/src/core/num/mod.rs', lines 456:12-458:13
     Visibility: public -/
 def num.Isize.from_be_bytes
   (bytes : Array Std.U8 8#usize) : RustM Std.Isize := do
   rust_primitives.arithmetic.from_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.I8.from_le_bytes (bytes : Array Std.U8 1#usize) : RustM Std.I8 := do
   rust_primitives.arithmetic.from_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.I16.from_le_bytes (bytes : Array Std.U8 2#usize) : RustM Std.I16 := do
   rust_primitives.arithmetic.from_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.I32.from_le_bytes (bytes : Array Std.U8 4#usize) : RustM Std.I32 := do
   rust_primitives.arithmetic.from_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.I64.from_le_bytes (bytes : Array Std.U8 8#usize) : RustM Std.I64 := do
   rust_primitives.arithmetic.from_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.I128.from_le_bytes
   (bytes : Array Std.U8 16#usize) : RustM Std.I128 := do
   rust_primitives.arithmetic.from_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::from_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 450:12-452:13
+    Source: 'core-models/src/core/num/mod.rs', lines 461:12-463:13
     Visibility: public -/
 def num.Isize.from_le_bytes
   (bytes : Array Std.U8 8#usize) : RustM Std.Isize := do
   rust_primitives.arithmetic.from_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.I8.to_be_bytes (bytes : Std.I8) : RustM (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.I16.to_be_bytes (bytes : Std.I16) : RustM (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.I32.to_be_bytes (bytes : Std.I32) : RustM (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.I64.to_be_bytes (bytes : Std.I64) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.I128.to_be_bytes
   (bytes : Std.I128) : RustM (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_be_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_be_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 455:12-457:13
+    Source: 'core-models/src/core/num/mod.rs', lines 466:12-468:13
     Visibility: public -/
 def num.Isize.to_be_bytes
   (bytes : Std.Isize) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_be_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.I8.to_le_bytes (bytes : Std.I8) : RustM (Array Std.U8 1#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i8 bytes
 
 /-- [core_models::num::{core_models::num::i16}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.I16.to_le_bytes (bytes : Std.I16) : RustM (Array Std.U8 2#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i16 bytes
 
 /-- [core_models::num::{core_models::num::i32}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.I32.to_le_bytes (bytes : Std.I32) : RustM (Array Std.U8 4#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i32 bytes
 
 /-- [core_models::num::{core_models::num::i64}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.I64.to_le_bytes (bytes : Std.I64) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i64 bytes
 
 /-- [core_models::num::{core_models::num::i128}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.I128.to_le_bytes
   (bytes : Std.I128) : RustM (Array Std.U8 16#usize) := do
   rust_primitives.arithmetic.to_le_bytes_i128 bytes
 
 /-- [core_models::num::{core_models::num::isize}::to_le_bytes]:
-    Source: 'core-models/src/core/num/mod.rs', lines 460:12-462:13
+    Source: 'core-models/src/core/num/mod.rs', lines 471:12-473:13
     Visibility: public -/
 def num.Isize.to_le_bytes
   (bytes : Std.Isize) : RustM (Array Std.U8 8#usize) := do
   rust_primitives.arithmetic.to_le_bytes_isize bytes
 
 /-- [core_models::num::{core_models::num::i8}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.I8.checked_div
   (x : Std.I8) (y : Std.I8) : RustM (option.Option Std.I8) := do
@@ -10802,7 +10884,7 @@ def num.I8.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.I16.checked_div
   (x : Std.I16) (y : Std.I16) : RustM (option.Option Std.I16) := do
@@ -10819,7 +10901,7 @@ def num.I16.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.I32.checked_div
   (x : Std.I32) (y : Std.I32) : RustM (option.Option Std.I32) := do
@@ -10836,7 +10918,7 @@ def num.I32.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.I64.checked_div
   (x : Std.I64) (y : Std.I64) : RustM (option.Option Std.I64) := do
@@ -10853,7 +10935,7 @@ def num.I64.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.I128.checked_div
   (x : Std.I128) (y : Std.I128) : RustM (option.Option Std.I128) := do
@@ -10870,7 +10952,7 @@ def num.I128.checked_div
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 464:12-470:13
+    Source: 'core-models/src/core/num/mod.rs', lines 475:12-481:13
     Visibility: public -/
 def num.Isize.checked_div
   (x : Std.Isize) (y : Std.Isize) : RustM (option.Option Std.Isize) := do
@@ -10888,44 +10970,44 @@ def num.Isize.checked_div
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.I8.unchecked_div (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.I16.unchecked_div (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.I32.unchecked_div (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.I64.unchecked_div (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   x / y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.I128.unchecked_div (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   x / y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_div]:
-    Source: 'core-models/src/core/num/mod.rs', lines 473:12-475:13
+    Source: 'core-models/src/core/num/mod.rs', lines 484:12-486:13
     Visibility: public -/
 def num.Isize.unchecked_div
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   x / y
 
 /-- [core_models::num::{core_models::num::i8}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.I8.checked_rem
   (x : Std.I8) (y : Std.I8) : RustM (option.Option Std.I8) := do
@@ -10942,7 +11024,7 @@ def num.I8.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i16}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.I16.checked_rem
   (x : Std.I16) (y : Std.I16) : RustM (option.Option Std.I16) := do
@@ -10959,7 +11041,7 @@ def num.I16.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i32}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.I32.checked_rem
   (x : Std.I32) (y : Std.I32) : RustM (option.Option Std.I32) := do
@@ -10976,7 +11058,7 @@ def num.I32.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i64}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.I64.checked_rem
   (x : Std.I64) (y : Std.I64) : RustM (option.Option Std.I64) := do
@@ -10993,7 +11075,7 @@ def num.I64.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::i128}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.I128.checked_rem
   (x : Std.I128) (y : Std.I128) : RustM (option.Option Std.I128) := do
@@ -11010,7 +11092,7 @@ def num.I128.checked_rem
          ok (option.Option.Some i)
 
 /-- [core_models::num::{core_models::num::isize}::checked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 477:12-483:13
+    Source: 'core-models/src/core/num/mod.rs', lines 488:12-494:13
     Visibility: public -/
 def num.Isize.checked_rem
   (x : Std.Isize) (y : Std.Isize) : RustM (option.Option Std.Isize) := do
@@ -11028,44 +11110,44 @@ def num.Isize.checked_rem
          ok (option.Option.Some i1)
 
 /-- [core_models::num::{core_models::num::i8}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.I8.unchecked_rem (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i16}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.I16.unchecked_rem (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i32}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.I32.unchecked_rem (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i64}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.I64.unchecked_rem (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   x % y
 
 /-- [core_models::num::{core_models::num::i128}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.I128.unchecked_rem (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   x % y
 
 /-- [core_models::num::{core_models::num::isize}::unchecked_rem]:
-    Source: 'core-models/src/core/num/mod.rs', lines 486:12-488:13
+    Source: 'core-models/src/core/num/mod.rs', lines 497:12-499:13
     Visibility: public -/
 def num.Isize.unchecked_rem
   (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   x % y
 
 /-- [core_models::num::{core_models::num::i8}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.I8.signum (x : Std.I8) : RustM Std.I8 := do
   if x > 0#i8
@@ -11075,7 +11157,7 @@ def num.I8.signum (x : Std.I8) : RustM Std.I8 := do
        else ok (-1)#i8
 
 /-- [core_models::num::{core_models::num::i16}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.I16.signum (x : Std.I16) : RustM Std.I16 := do
   if x > 0#i16
@@ -11085,7 +11167,7 @@ def num.I16.signum (x : Std.I16) : RustM Std.I16 := do
        else ok (-1)#i16
 
 /-- [core_models::num::{core_models::num::i32}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.I32.signum (x : Std.I32) : RustM Std.I32 := do
   if x > 0#i32
@@ -11095,7 +11177,7 @@ def num.I32.signum (x : Std.I32) : RustM Std.I32 := do
        else ok (-1)#i32
 
 /-- [core_models::num::{core_models::num::i64}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.I64.signum (x : Std.I64) : RustM Std.I64 := do
   if x > 0#i64
@@ -11105,7 +11187,7 @@ def num.I64.signum (x : Std.I64) : RustM Std.I64 := do
        else ok (-1)#i64
 
 /-- [core_models::num::{core_models::num::i128}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.I128.signum (x : Std.I128) : RustM Std.I128 := do
   if x > 0#i128
@@ -11115,7 +11197,7 @@ def num.I128.signum (x : Std.I128) : RustM Std.I128 := do
        else ok (-1)#i128
 
 /-- [core_models::num::{core_models::num::isize}::signum]:
-    Source: 'core-models/src/core/num/mod.rs', lines 490:12-498:13
+    Source: 'core-models/src/core/num/mod.rs', lines 501:12-509:13
     Visibility: public -/
 def num.Isize.signum (x : Std.Isize) : RustM Std.Isize := do
   if x > 0#isize
@@ -11125,7 +11207,7 @@ def num.Isize.signum (x : Std.Isize) : RustM Std.Isize := do
        else ok (-1)#isize
 
 /-- [core_models::num::{core_models::num::i8}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
   let d ← x / y
@@ -11146,7 +11228,7 @@ def num.I8.div_ceil (x : Std.I8) (y : Std.I8) : RustM Std.I8 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i16}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
   let d ← x / y
@@ -11167,7 +11249,7 @@ def num.I16.div_ceil (x : Std.I16) (y : Std.I16) : RustM Std.I16 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i32}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
   let d ← x / y
@@ -11188,7 +11270,7 @@ def num.I32.div_ceil (x : Std.I32) (y : Std.I32) : RustM Std.I32 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i64}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
   let d ← x / y
@@ -11209,7 +11291,7 @@ def num.I64.div_ceil (x : Std.I64) (y : Std.I64) : RustM Std.I64 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i128}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
   let d ← x / y
@@ -11230,7 +11312,7 @@ def num.I128.div_ceil (x : Std.I128) (y : Std.I128) : RustM Std.I128 := do
        else ok d
 
 /-- [core_models::num::{core_models::num::isize}::div_ceil]:
-    Source: 'core-models/src/core/num/mod.rs', lines 502:12-511:13
+    Source: 'core-models/src/core/num/mod.rs', lines 513:12-522:13
     Visibility: public -/
 def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
   let d ← x / y
@@ -11252,205 +11334,205 @@ def num.Isize.div_ceil (x : Std.Isize) (y : Std.Isize) : RustM Std.Isize := do
        else ok d
 
 /-- [core_models::num::{core_models::num::i8}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.I8.wrapping_neg (x : Std.I8) : RustM Std.I8 := do
   rust_primitives.arithmetic.wrapping_sub_i8 0#i8 x
 
 /-- [core_models::num::{core_models::num::i16}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.I16.wrapping_neg (x : Std.I16) : RustM Std.I16 := do
   rust_primitives.arithmetic.wrapping_sub_i16 0#i16 x
 
 /-- [core_models::num::{core_models::num::i32}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.I32.wrapping_neg (x : Std.I32) : RustM Std.I32 := do
   rust_primitives.arithmetic.wrapping_sub_i32 0#i32 x
 
 /-- [core_models::num::{core_models::num::i64}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.I64.wrapping_neg (x : Std.I64) : RustM Std.I64 := do
   rust_primitives.arithmetic.wrapping_sub_i64 0#i64 x
 
 /-- [core_models::num::{core_models::num::i128}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.I128.wrapping_neg (x : Std.I128) : RustM Std.I128 := do
   rust_primitives.arithmetic.wrapping_sub_i128 0#i128 x
 
 /-- [core_models::num::{core_models::num::isize}::wrapping_neg]:
-    Source: 'core-models/src/core/num/mod.rs', lines 526:12-528:13
+    Source: 'core-models/src/core/num/mod.rs', lines 537:12-539:13
     Visibility: public -/
 def num.Isize.wrapping_neg (x : Std.Isize) : RustM Std.Isize := do
   rust_primitives.arithmetic.wrapping_sub_isize 0#isize x
 
 /-- [core_models::num::{impl core_models::default::Default for u8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def U8.Insts.CoreDefaultDefault.default : RustM Std.U8 := do
   ok 0#u8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def U8.Insts.CoreDefaultDefault : default.Default Std.U8 := {
   default := U8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def U16.Insts.CoreDefaultDefault.default : RustM Std.U16 := do
   ok 0#u16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def U16.Insts.CoreDefaultDefault : default.Default Std.U16 := {
   default := U16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def U32.Insts.CoreDefaultDefault.default : RustM Std.U32 := do
   ok 0#u32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def U32.Insts.CoreDefaultDefault : default.Default Std.U32 := {
   default := U32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def U64.Insts.CoreDefaultDefault.default : RustM Std.U64 := do
   ok 0#u64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def U64.Insts.CoreDefaultDefault : default.Default Std.U64 := {
   default := U64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for u128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def U128.Insts.CoreDefaultDefault.default : RustM Std.U128 := do
   ok 0#u128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for u128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def U128.Insts.CoreDefaultDefault : default.Default Std.U128 := {
   default := U128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for usize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def Usize.Insts.CoreDefaultDefault.default : RustM Std.Usize := do
   ok 0#usize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for usize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def Usize.Insts.CoreDefaultDefault : default.Default Std.Usize := {
   default := Usize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i8}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def I8.Insts.CoreDefaultDefault.default : RustM Std.I8 := do
   ok 0#i8
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i8}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def I8.Insts.CoreDefaultDefault : default.Default Std.I8 := {
   default := I8.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i16}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def I16.Insts.CoreDefaultDefault.default : RustM Std.I16 := do
   ok 0#i16
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i16}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def I16.Insts.CoreDefaultDefault : default.Default Std.I16 := {
   default := I16.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i32}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def I32.Insts.CoreDefaultDefault.default : RustM Std.I32 := do
   ok 0#i32
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i32}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def I32.Insts.CoreDefaultDefault : default.Default Std.I32 := {
   default := I32.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i64}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def I64.Insts.CoreDefaultDefault.default : RustM Std.I64 := do
   ok 0#i64
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i64}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def I64.Insts.CoreDefaultDefault : default.Default Std.I64 := {
   default := I64.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for i128}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def I128.Insts.CoreDefaultDefault.default : RustM Std.I128 := do
   ok 0#i128
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for i128}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def I128.Insts.CoreDefaultDefault : default.Default Std.I128 := {
   default := I128.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for isize}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 707:16-709:17
+    Source: 'core-models/src/core/num/mod.rs', lines 724:16-726:17
     Visibility: public -/
 def Isize.Insts.CoreDefaultDefault.default : RustM Std.Isize := do
   ok 0#isize
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for isize}]
-    Source: 'core-models/src/core/num/mod.rs', lines 706:12-710:13 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 723:12-727:13 -/
 @[reducible]
 def Isize.Insts.CoreDefaultDefault : default.Default Std.Isize := {
   default := Isize.Insts.CoreDefaultDefault.default
 }
 
 /-- [core_models::num::{impl core_models::default::Default for bool}::default]:
-    Source: 'core-models/src/core/num/mod.rs', lines 733:4-735:5
+    Source: 'core-models/src/core/num/mod.rs', lines 750:4-752:5
     Visibility: public -/
 def Bool.Insts.CoreDefaultDefault.default : RustM Bool := do
   ok false
 
 /-- Trait implementation: [core_models::num::{impl core_models::default::Default for bool}]
-    Source: 'core-models/src/core/num/mod.rs', lines 731:0-736:1 -/
+    Source: 'core-models/src/core/num/mod.rs', lines 748:0-753:1 -/
 @[reducible]
 def Bool.Insts.CoreDefaultDefault : default.Default Bool := {
   default := Bool.Insts.CoreDefaultDefault.default

--- a/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/Core/Types.lean
@@ -698,73 +698,73 @@ structure num.error.ParseIntError where
   kind : num.error.IntErrorKind
 
 /-- [core_models::num::u8]
-    Source: 'core-models/src/core/num/mod.rs', lines 539:0-539:14
+    Source: 'core-models/src/core/num/mod.rs', lines 550:0-550:14
     Visibility: public -/
 @[reducible]
 def num.u8 := Unit
 
 /-- [core_models::num::u16]
-    Source: 'core-models/src/core/num/mod.rs', lines 542:0-542:15
+    Source: 'core-models/src/core/num/mod.rs', lines 553:0-553:15
     Visibility: public -/
 @[reducible]
 def num.u16 := Unit
 
 /-- [core_models::num::u32]
-    Source: 'core-models/src/core/num/mod.rs', lines 545:0-545:15
+    Source: 'core-models/src/core/num/mod.rs', lines 556:0-556:15
     Visibility: public -/
 @[reducible]
 def num.u32 := Unit
 
 /-- [core_models::num::u64]
-    Source: 'core-models/src/core/num/mod.rs', lines 548:0-548:15
+    Source: 'core-models/src/core/num/mod.rs', lines 559:0-559:15
     Visibility: public -/
 @[reducible]
 def num.u64 := Unit
 
 /-- [core_models::num::u128]
-    Source: 'core-models/src/core/num/mod.rs', lines 551:0-551:16
+    Source: 'core-models/src/core/num/mod.rs', lines 562:0-562:16
     Visibility: public -/
 @[reducible]
 def num.u128 := Unit
 
 /-- [core_models::num::usize]
-    Source: 'core-models/src/core/num/mod.rs', lines 554:0-554:17
+    Source: 'core-models/src/core/num/mod.rs', lines 565:0-565:17
     Visibility: public -/
 @[reducible]
 def num.usize := Unit
 
 /-- [core_models::num::i8]
-    Source: 'core-models/src/core/num/mod.rs', lines 557:0-557:14
+    Source: 'core-models/src/core/num/mod.rs', lines 568:0-568:14
     Visibility: public -/
 @[reducible]
 def num.i8 := Unit
 
 /-- [core_models::num::i16]
-    Source: 'core-models/src/core/num/mod.rs', lines 560:0-560:15
+    Source: 'core-models/src/core/num/mod.rs', lines 571:0-571:15
     Visibility: public -/
 @[reducible]
 def num.i16 := Unit
 
 /-- [core_models::num::i32]
-    Source: 'core-models/src/core/num/mod.rs', lines 563:0-563:15
+    Source: 'core-models/src/core/num/mod.rs', lines 574:0-574:15
     Visibility: public -/
 @[reducible]
 def num.i32 := Unit
 
 /-- [core_models::num::i64]
-    Source: 'core-models/src/core/num/mod.rs', lines 566:0-566:15
+    Source: 'core-models/src/core/num/mod.rs', lines 577:0-577:15
     Visibility: public -/
 @[reducible]
 def num.i64 := Unit
 
 /-- [core_models::num::i128]
-    Source: 'core-models/src/core/num/mod.rs', lines 569:0-569:16
+    Source: 'core-models/src/core/num/mod.rs', lines 580:0-580:16
     Visibility: public -/
 @[reducible]
 def num.i128 := Unit
 
 /-- [core_models::num::isize]
-    Source: 'core-models/src/core/num/mod.rs', lines 572:0-572:17
+    Source: 'core-models/src/core/num/mod.rs', lines 583:0-583:17
     Visibility: public -/
 @[reducible]
 def num.isize := Unit

--- a/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
+++ b/hax-lib/proof-libs/lean/CoreModels/RustPrimitives/Funs.lean
@@ -1238,18 +1238,6 @@ def rust_primitives.sequence.seq_index
   .ok (IScalar.rotate_right x n)
 @[spec] def rust_primitives.arithmetic.rotate_right_isize (x : Isize) (n : U32) : RustM Isize :=
   .ok (IScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_u8 (x : U8) (n : U32) : RustM U8 :=
-  .ok (UScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_u16 (x : U16) (n : U32) : RustM U16 :=
-  .ok (UScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_u32 (x : U32) (n : U32) : RustM U32 :=
-  .ok (UScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_u64 (x : U64) (n : U32) : RustM U64 :=
-  .ok (UScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_u128 (x : U128) (n : U32) : RustM U128 :=
-  .ok (UScalar.rotate_right x n)
-@[spec] def rust_primitives.arithmetic.rotate_right_usize (x : Usize) (n : U32) : RustM Usize :=
-  .ok (UScalar.rotate_right x n)
 
 @[spec] def rust_primitives.arithmetic.rotate_left_i8 (x : I8) (n : U32) : RustM I8 :=
   .ok (IScalar.rotate_left x n)
@@ -1263,17 +1251,5 @@ def rust_primitives.sequence.seq_index
   .ok (IScalar.rotate_left x n)
 @[spec] def rust_primitives.arithmetic.rotate_left_isize (x : Isize) (n : U32) : RustM Isize :=
   .ok (IScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_u8 (x : U8) (n : U32) : RustM U8 :=
-  .ok (UScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_u16 (x : U16) (n : U32) : RustM U16 :=
-  .ok (UScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_u32 (x : U32) (n : U32) : RustM U32 :=
-  .ok (UScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_u64 (x : U64) (n : U32) : RustM U64 :=
-  .ok (UScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_u128 (x : U128) (n : U32) : RustM U128 :=
-  .ok (UScalar.rotate_left x n)
-@[spec] def rust_primitives.arithmetic.rotate_left_usize (x : Usize) (n : U32) : RustM Usize :=
-  .ok (UScalar.rotate_left x n)
 
 end CoreModels

--- a/hax-lib/proof-libs/lean/lakefile.toml
+++ b/hax-lib/proof-libs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "hax"
-version = "0.3.19"
+version = "0.3.20"
 defaultTargets = ["Hax", "CoreModels"]
 
 [[lean_lib]]


### PR DESCRIPTION
Fixes the `rotate_left` half of #2230.

## Problem

In the F\* backend, `Core_models`' unsigned `rotate_left`/`rotate_right` carry
`#[cfg_attr(hax_backend_fstar, hax_lib::opaque)]`. They forward to the
`rotate_{left,right}_*` primitives, which are `x.rotate_*(n)` and extract back
into this model — a cycle — so they were opaque. As a result the F\* proof-libs
expose `Core_models.Bundle.impl_*__rotate_{left,right}` as spec-less
`assume val`s. Downstream proofs that relate a rotate to shifts/xor (e.g.
libcrux SHA-3's AVX2 Keccak-f equivalence, `lemma_shl_xor_shr_is_rotate_left`)
can no longer discharge, and in 0.3.7 these were *defined* (not assumed).

## Fix

Model the **unsigned** rotates directly from shifts + xor — cycle-free and
transparent in both F\* and Lean:

```rust
let m = n % BITS;
if m == 0 { x } else { (x << m) ^ (x >> (BITS - m)) }
```

The two shifted halves are bit-disjoint, so `^` coincides with `|`; the
`m == 0` guard avoids the undefined full-width shift. A new `$ShiftBits` macro
argument supplies the width used in the shift amounts — the plain literal for
the fixed-width types, and `rust_primitives::SIZE_BITS` for `usize`. `usize`
must use `SIZE_BITS` (extracts to `mk_u32 size_bits`) rather than the literal
`64`, because the F\* `shiftval` refinement is bounded by the abstract
`bits usize == size_bits`, which a literal cannot discharge.

**Signed rotates are intentionally left opaque:** Rust's `>>` on signed
integers is arithmetic (sign-extending), so the shift/xor identity does not
hold for them; a correct signed version needs a logical shift and nothing
currently depends on a transparent one.

## Validation

- `core-models` differential proptests: 24/24 `rotate_{left,right}` cases pass
  (`u8..u128`, `usize`), i.e. the model matches `core`'s real `rotate_*`.
- The regenerated F\* `Core_models.Bundle.fst` now has transparent bodies and
  typechecks cleanly as a dependency of a downstream libcrux ml-kem build.

## ⚠️ Lean proof-libs NOT yet regenerated

This PR regenerates only the **F\*** proof-libs (`make fstar-core-models`). The
source change also affects the **Lean** extraction, which still needs
`make lean` (charon) to be regenerated and committed before merge. Flagging as
draft for that reason.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip changelog]
