### PR TITLE
perf(nix): shorten the toolchain build's critical path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Test `cargo-hax`
         run: cargo test -p cargo-hax --verbose
 
+      # Also apart, and for the same reason: `hax-rust-engine` takes
+      # `hax-frontend-exporter` with `default-features = false`, so a shared
+      # invocation with `hax-driver` would unify the `rustc` feature onto it.
+      # This is the only place these tests run: the nix build no longer runs
+      # the workspace's test suites (see `cli/default.nix`).
+      - name: Test `hax-rust-engine`
+        run: cargo test -p hax-rust-engine --verbose
+
       - name: Test `hax-frontend-exporter` with feature `rustc` off
         run: cargo check -p hax-frontend-exporter --no-default-features --verbose
 

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -95,6 +95,19 @@ let
     cargoExtraArgs =
       "--locked -p cargo-hax --bin hax-export-json-schemas --features cargo-hax/legacy-engine";
   });
+  # `cargo hax` and the driver it shells out to, and nothing else. This is all
+  # `hax-engine-names-extract`'s build needs; depending on the full `hax` below
+  # would chain it behind `hax_export_json_schemas`, which it does not use, so
+  # the two ~70s derivations would run one after the other instead of at once.
+  hax_frontend_only = stdenv.mkDerivation {
+    name = "hax-frontend-only-${commonArgs.version}";
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${hax_bin}/bin/cargo-hax $out/bin/
+      cp ${hax_driver_and_libs}/bin/driver-hax-frontend-exporter $out/bin/
+    '';
+  };
   # hax without cargo artifacts: only binaries
   hax = stdenv.mkDerivation {
     name = "hax-${commonArgs.version}";
@@ -181,7 +194,7 @@ in stdenv.mkDerivation {
       cargoArtifacts = hax_driver_and_libs;
       # `build.rs` here shells out to `cargo-hax`, which in turn needs
       # `hax-driver` on `PATH`: both are needed, not just `hax_driver_and_libs`.
-      nativeBuildInputs = [ hax ];
+      nativeBuildInputs = [ hax_frontend_only ];
       postUnpack = ''
         cd $sourceRoot/engine/names/extract
         sourceRoot="."

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -1,4 +1,7 @@
 { craneLib, stdenv, makeWrapper, lib, rustc, rustc-docs, gcc, hax-engine
+  # Whether the `tests` derivation (`checks.toolchain`) is meant to be
+  # buildable: it needs the `tests` workspace vendored, which the individual
+  # build derivations do not.
 , doCheck ? true, zlib, just, libiconv }:
 let
   pname = "hax";
@@ -30,7 +33,14 @@ let
           || is-crate-readme path))
         || !(builtins.isNull (builtins.match ".*/renamings" path));
     };
-    inherit buildInputs doCheck;
+    inherit buildInputs;
+    # The build derivations below only build; the unit and doc tests of the
+    # workspace are covered by the `Test Workspace` CI job, and the toolchain
+    # tests by the `tests` derivation (which re-enables `doCheck`). Leaving
+    # crane's default on made every one of them recompile the whole workspace
+    # as test targets — minutes of the critical path for suites that had
+    # already run elsewhere.
+    doCheck = false;
     cargoExtraArgs = "--locked";
     doNotRemoveReferencesToRustToolchain = true;
   } // (if doCheck then {

--- a/cli/default.nix
+++ b/cli/default.nix
@@ -7,6 +7,14 @@ let
   # Crate readmes are compiled in as rustdoc crate docs via
   # `#![doc = include_str!("../README.md")]`.
   is-crate-readme = path: builtins.match ".*/README[.]md" path != null;
+  # Trees that hold cargo sources no workspace member builds against, kept out
+  # so that touching them does not reshuffle the source hash and rebuild the
+  # whole toolchain. `tests` and `hax-lib/core-models` are both `exclude`d from
+  # the workspace (see the root `Cargo.toml`) and nothing path-depends on
+  # either, so neither reaches `cargo build` here.
+  is-excluded-tree = path:
+    builtins.match ".*/(tests|examples|docs|proof-libs)/.*" path != null
+    || builtins.match ".*/hax-lib/core-models/.*" path != null;
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv zlib.dev ];
   binaries = [ hax hax-engine.bin rustc gcc hax_rust_engine ] ++ buildInputs;
   commonArgs = {
@@ -14,8 +22,7 @@ let
     src = lib.cleanSourceWith {
       src = craneLib.path ./..;
       filter = path: type:
-        (builtins.isNull
-        (builtins.match ".*/(tests|examples|docs|proof-libs)/.*" path)
+        (!is-excluded-tree path
         && (builtins.isNull (builtins.match ".*[.](md|svg)" path)
           || is-crate-readme path)
         && (craneLib.filterCargoSources path type


### PR DESCRIPTION
The nix build of the toolchain takes ~15m30s, and every CI job that
installs hax pays it in full. Measured on `nix build .#check-toolchain -L`
in [run 34351018309](https://github.com/cryspen/hax/actions/runs/34351018309):

| stage | wall | of which `checkPhase` |
|---|---|---|
| `hax-deps` | 154 s | — |
| ‖ `cargo-hax` 417 s · `hax` (driver+libs) 431 s · `hax-rust-engine` 494 s | 494 s | 192 s + 107 s |
| `hax-export-json-schemas` | 77 s | — |
| `hax-engine-names-extract` | 65 s | — |
| `hax-engine` (OCaml) | 160 s | — |

Three independent changes, one per commit.

**1. `hax-lib/core-models` was inside the crane source filter.**
It is `exclude`d from the cargo workspace and no member path-depends on
it, so `cargo build` never saw it — but editing any of its 109 files
gave `packages.hax` a fresh derivation hash. Since ~16 jobs install hax
(`verify_extraction`'s `nix-action` + 11 `example-*`, `install_and_test`,
`core_models`' `lean-build`/`fstar-build`/`core-models-tests`), a
core-models-only PR cost ~15m30s × 16 for a change the build cannot
observe. Those PRs now resolve `.#` to the path the last merge-queue run
already pushed to `hax.cachix.org` and download instead. For reference,
`verify_extraction`'s `Install the toolchain` on `main` — where that
cache hit already applies — takes 45-53 s.

**2. crane's `doCheck` defaults to on**, so all five `buildPackage` calls
recompiled the workspace as test targets and ran its suites. Most of it
produced nothing: `hax-export-json-schemas` and `hax_engine_names_extract`
each report `running 0 tests`, as does every library in
`hax_driver_and_libs`' checkPhase. Those suites already run in
`Test Workspace`, and the toolchain tests in the `tests` derivation
(`checks.toolchain`), which keeps `doCheck` on.

`hax-rust-engine` was the exception — `Test Workspace` `--exclude`d it, so
the nix build was the only place its tests ran. It gets its own step
there, apart from the `--workspace` invocation for the same reason
`cargo-hax` is.

**3. names-extract was chained behind `hax-export-json-schemas`.** Its
build only shells out to `cargo hax … json`, so it needs `cargo-hax` and
`driver-hax-frontend-exporter`; it took them from the full unwrapped
`hax`, which also carries `hax-export-json-schemas`. The two ran strictly
serially (77 s + 65 s) where they can overlap.

## Measured effect

Runner speed varies by ±4 min between GitHub runners, more than this
change is worth, so wall-clock step times alone cannot show it. Comparing
`-L` logs instead, normalized by two derivations this PR does not change:
`hax-deps` (154 s → 111 s) and `hax-tests`' checkPhase (512 s → 392 s)
both put this runner at ~0.75× the baseline's wall time.

| derivation | baseline | × 0.75 | this PR | real change |
|---|---|---|---|---|
| `hax-deps` | 154 s | 116 s | 111 s | — (speed probe) |
| `cargo-hax` | 417 s | 313 s | 257 s | −56 s |
| `hax` (driver+libs) | 431 s | 323 s | ~240 s | −80 s |
| `hax-rust-engine` | 498 s | 374 s | 228 s | −146 s |
| `hax-export-json-schemas` + names-extract | 143 s serial | 107 s | **66 s overlapped** | −41 s |
| `hax-engine` | 161 s | 121 s | 130 s | — (noise) |
| `hax-tests` checkPhase | 512 s | 384 s | 392 s | — (speed probe) |

Structurally, and independent of runner speed: `checkPhase completed`
drops from 3 occurrences to 1 (only `hax-tests`, as intended), and the
overlap between `hax-export-json-schemas` and names-extract goes from
−1 s (strictly serial) to +48 s.

**Critical path.** Note that `hax-rust-engine`'s 192 s checkPhase was
never on it: reconstructing the baseline timestamps, it finished at
12:38:32 while the binding chain had already moved past it — `cargo-hax`
(12:37:11) -> `hax-export-json-schemas` (12:38:29) -> names-extract
(12:39:35) -> `hax-engine`. For `nix profile install .` (15 of the 16
jobs) that path was 878 s, speed-adjusts to 659 s, and came in at 565 s:
**-1m34s here, -2m05s at baseline speed**. Roughly 74 s of it is
`cargo-hax` (its own 19 s checkPhase plus less CPU contention now that
two sibling builds no longer compile test targets beside it) and ~54 s is
un-chaining names-extract.

Second, independent measurement: each `example-*` job against its own
11-12 run baseline median, so each of the 11 is a separate runner draw.

| example | this PR | baseline median | n | delta |
|---|---|---|---|---|
| kyber_compress | 13m56s | 18m49s | 11 | -4m53s |
| loop_equivalence | 17m43s | 20m56s | 11 | -3m13s |
| sha3 | 17m18s | 19m44s | 12 | -2m26s |
| sha256 | 16m28s | 18m49s | 12 | -2m21s |
| proverif-psk | 14m02s | 16m12s | 12 | -2m10s |
| chacha20 | 17m57s | 19m19s | 12 | -1m22s |
| lean_tutorial | 18m37s | 19m53s | 12 | -1m16s |
| adc | 18m39s | 19m50s | 12 | -1m11s |
| limited-order-book | 17m41s | 18m52s | 11 | -1m11s |
| anodized | 21m11s | 22m10s | 11 | -0m59s |
| barrett | 20m44s | 21m10s | 11 | -0m26s |

Faster in **11/11**; median -1m22s, mean -1m57s (the mean is pulled by
the two outliers, so the median is the more robust figure here).

Taking the two methods together, the honest estimate is **~1.5-2 min off
every job that builds the toolchain** — call it ~15m30s -> ~13m45s on a
PR that touches Rust. Across the ~16 such jobs that is ~25 runner-minutes
per push. Much larger, though, is the cache hit commit 1 unlocks: ~50 s
instead of ~15m30s for a PR that only touches core-models, tests,
examples, docs or proof-libs.

The removed test phases are also ~5 min of freed CPU per job, which
matters on 4-vCPU runners even where it does not show as wall time.

## Verification

Cold `nix build .#hax --max-jobs 1` passes locally with zero
`checkPhase completed`. `cargo-hax --version` works, unwrapped `hax`
still ships all four binaries, and `cargo hax into fstar` on a throwaway
crate extracts. `cargo test -p hax-rust-engine` passes on all three
`Test Workspace` platforms (38 s / 39 s / 56 s). Editing a core-models
file leaves `.#`'s output path byte-identical.

Merging changes the derivation hashes, so the first merge-queue run after
this rebuilds once and repopulates the cache.

[skip changelog] — build-time only: no change to `cargo-hax`'s behaviour or
output, which the workflow lists under "CI/CD or tooling changes with no
external effect".
