### PR TITLE
 fix(ci): build docs with default python3 so nixpkgs binary cache applies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
       in rec {
         packages = {
           inherit rustc ocamlformat rustfmt fstar hax-env rustc-docs proverif;
-          docs = pkgs.python312Packages.callPackage ./docs {
+          docs = pkgs.python3Packages.callPackage ./docs {
             hax-frontend-docs = packages.hax-rust-frontend.docs;
           };
           hax-engine = pkgs.callPackage ./engine {


### PR DESCRIPTION
This nix built ended in a timeout error:
https://github.com/cryspen/hax/actions/runs/34070464946/job/101586727831

According to Claude, this is because python 3.12 is not the default of our version of nixpkgs. So it is not cached and needs to be rebuilt from scratch. That takes time.

[skip changelog]